### PR TITLE
Use data-field attributes for independent field persistence

### DIFF
--- a/js/actions.js
+++ b/js/actions.js
@@ -3,16 +3,17 @@ import { $, nowHM } from './utils.js';
 export const MEDS = ['TXA','Fentanilis','Paracetamolis','Ketoprofenas','O- kraujas','Fibryga','Ca gliukonatas'];
 export const PROCS = ['Intubacija','Krikotirotomija','Pleuros drenažas','Adatinė dekompresija','Kūno šildymas','Turniketas','Dubens diržas','Gipsavimas','Siuvimas','Repocizija'];
 
-function buildActionCard(name, saveAll){
+function buildActionCard(group, name, saveAll){
   const card=document.createElement('div');
   card.className='card';
   card.style.padding='10px';
   card.style.borderRadius='10px';
-  card.innerHTML=`<label class="pill"><input type="checkbox" class="act_chk"> ${name}</label>
+  const slug=name.toLowerCase().replace(/\s+/g,'_').replace(/[^a-z0-9_]/g,'');
+  card.innerHTML=`<label class="pill"><input type="checkbox" class="act_chk" data-field="${group}_${slug}_chk"> ${name}</label>
     <div class="grid cols-3" style="margin-top:6px">
-      <div><label>Laikas</label><input type="time" class="act_time"></div>
-      <div><label>Dozė/kiekis</label><input type="text" class="act_dose"></div>
-      <div><label>Pastabos</label><input type="text" class="act_note"></div>
+      <div><label>Laikas</label><input type="time" class="act_time" data-field="${group}_${slug}_time"></div>
+      <div><label>Dozė/kiekis</label><input type="text" class="act_dose" data-field="${group}_${slug}_dose"></div>
+      <div><label>Pastabos</label><input type="text" class="act_note" data-field="${group}_${slug}_note"></div>
     </div>`;
   const chk=card.querySelector('.act_chk');
   const time=card.querySelector('.act_time');
@@ -24,6 +25,6 @@ function buildActionCard(name, saveAll){
 export function initActions(saveAll){
   const medsWrap=$('#medications');
   const procsWrap=$('#procedures');
-  MEDS.forEach(n=>medsWrap.appendChild(buildActionCard(n, saveAll)));
-  PROCS.forEach(n=>procsWrap.appendChild(buildActionCard(n, saveAll)));
+  MEDS.forEach(n=>medsWrap.appendChild(buildActionCard('med', n, saveAll)));
+  PROCS.forEach(n=>procsWrap.appendChild(buildActionCard('proc', n, saveAll)));
 }

--- a/js/app.js
+++ b/js/app.js
@@ -13,7 +13,12 @@ const imgWrap=$('#imaging_basic'); IMG.forEach(n=>{const s=document.createElemen
 const labsWrap=$('#labs_basic'); LABS.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; labsWrap.appendChild(s);});
 const fastAreas=['Perikardas','Dešinė pleura','Kairė pleura','RUQ','LUQ','Dubuo']; const fastWrap=$('#fastGrid');
 fastAreas.forEach(a=>{const box=document.createElement('div'); box.innerHTML=`<label>${a}</label><div class="row"><label class="pill"><input type="radio" name="fast_${a}" value="Yra"> Yra</label><label class="pill"><input type="radio" name="fast_${a}" value="Nėra"> Nėra</label></div>`; fastWrap.appendChild(box);});
-const teamWrap=$('#teamGrid'); TEAM_ROLES.forEach(r=>{const box=document.createElement('div'); box.innerHTML=`<label>${r}</label><input type="text" data-team="${r}" placeholder="Vardas Pavardė">`; teamWrap.appendChild(box);});
+const teamWrap=$('#teamGrid'); TEAM_ROLES.forEach(r=>{
+  const slug=r.replace(/\s+/g,'_');
+  const box=document.createElement('div');
+  box.innerHTML=`<label>${r}</label><input type="text" data-team="${r}" data-field="team_${slug}" placeholder="Vardas Pavardė">`;
+  teamWrap.appendChild(box);
+});
 
 /* ===== SVG Body Map (no canvas) ===== */
 const BodySVG=(function(){
@@ -91,7 +96,8 @@ const FIELD_SELECTORS='input[type="text"],input[type="number"],input[type="time"
 function saveAll(){
   const data={};
   $$(FIELD_SELECTORS).forEach(el=>{
-    const key=el.id||el.name||el.dataset.team||el.className;
+    const key=el.dataset.field || el.id || el.name;
+    if(!key) return;
     if(el.type==='radio'){ if(el.checked) data[key+'__'+el.value]=true; }
     else if(el.type==='checkbox'){ data[key]=el.checked?'__checked__':(el.value||''); }
     else{ data[key]=el.value; }
@@ -108,7 +114,8 @@ function loadAll(){
   try{
     const data=JSON.parse(raw);
     $$(FIELD_SELECTORS).forEach(el=>{
-      const key=el.id||el.name||el.dataset.team||el.className;
+      const key=el.dataset.field || el.id || el.name;
+      if(!key) return;
       if(el.type==='radio'){ if(data[key+'__'+el.value]) el.checked=true; }
       else if(el.type==='checkbox'){ el.checked=(data[key]==='__checked__'); }
       else{ if(data[key]!=null) el.value=data[key]; }


### PR DESCRIPTION
## Summary
- switch save/load routines to use a dedicated `data-field` key instead of class names
- provide each team and action input with a unique `data-field` attribute

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f823f5d5083208c042dd02b425363