### PR TITLE
Improve tab accessibility and keyboard navigation

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -17,6 +17,7 @@ main{max-width:1200px;margin:12px auto;padding:0 16px;display:grid;grid-template
 nav{position:sticky;top:68px;align-self:start}
 nav .tab{display:block;padding:10px 12px;border:1px solid var(--line);border-radius:10px;margin-bottom:8px;background:#0f1822;color:var(--ink);cursor:pointer;font-weight:600;text-align:left}
 nav .tab.active{background:#162334;border-color:#2b405c}
+nav .tab:focus{outline:2px solid var(--accent)}
 section.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px}
 section.card h2{font-size:16px;margin:0 0 10px}
 section.card .grid{display:grid;gap:10px}

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -6,21 +6,45 @@ export const TABS = [
 ];
 
 export function showTab(name){
-  document.querySelectorAll('nav .tab').forEach(b=>b.classList.toggle('active', b.textContent===name));
+  document.querySelectorAll('nav .tab').forEach(b=>{
+    const active = b.textContent === name;
+    b.classList.toggle('active', active);
+    b.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
   document.querySelectorAll('.view').forEach(v=>v.style.display = (v.dataset.tab===name)?'block':'none');
   localStorage.setItem('v9_activeTab', name);
 }
 
 export function initTabs(){
   const nav = document.getElementById('tabs');
+  nav.setAttribute('role','tablist');
   TABS.forEach((t,i)=>{
     const b=document.createElement('button');
     b.className='tab'+(i===0?' active':'');
     b.textContent=t;
+    b.setAttribute('role','tab');
+    b.setAttribute('tabindex','0');
+    b.setAttribute('aria-selected', i===0 ? 'true' : 'false');
     b.onclick=()=>showTab(t);
     nav.appendChild(b);
   });
   document.querySelectorAll('.view').forEach((v,i)=>v.style.display=(i===0)?'block':'none');
+
+  nav.addEventListener('keydown', e=>{
+    const tabs = Array.from(nav.querySelectorAll('.tab'));
+    const currentIndex = tabs.indexOf(document.activeElement);
+    if(e.key === 'ArrowRight' || e.key === 'ArrowLeft'){
+      e.preventDefault();
+      let newIndex = currentIndex + (e.key === 'ArrowRight' ? 1 : -1);
+      if(newIndex < 0) newIndex = tabs.length - 1;
+      if(newIndex >= tabs.length) newIndex = 0;
+      tabs[newIndex].focus();
+    } else if(e.key === 'Enter' || e.key === ' '){
+      e.preventDefault();
+      document.activeElement.click();
+    }
+  });
+
   const savedTab = localStorage.getItem('v9_activeTab');
   if(savedTab && TABS.includes(savedTab)) showTab(savedTab);
 }


### PR DESCRIPTION
## Summary
- add ARIA roles and tabindex to tabs
- manage aria-selected on active tab
- support arrow key navigation and Enter/Space activation
- add visible focus style for tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f8bdfb0d4832086ac8b957df889ab