### PR TITLE
Use semantic controls for chips and improve accessibility

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -30,10 +30,13 @@ textarea{min-height:80px;resize:vertical}
 .row{display:flex;gap:8px;align-items:center}
 .pill{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid var(--line);border-radius:999px;background:#0f1822;color:#fff;font-weight:700}
 .chip{display:inline-flex;align-items:center;justify-content:center;padding:8px 10px;border:1px solid var(--line);
-  border-radius:999px;background:#0f1822;cursor:pointer;user-select:none}
-.chip.active{background:var(--accent);color:#051b32;border-color:#2d74b8}
-.chip.red.active{background:var(--red);color:#fff;border-color:#a52623}
-.chip.yellow.active{background:var(--yellow);color:#231b00;border-color:#8a7400}
+  border-radius:999px;background:#0f1822;cursor:pointer;user-select:none;position:relative}
+.chip>input{position:absolute;opacity:0;width:0;height:0}
+button.chip{background:#0f1822;border:1px solid var(--line)}
+button.chip[aria-pressed="true"],.chip:has(input:checked){background:var(--accent);color:#051b32;border-color:#2d74b8}
+button.chip.red[aria-pressed="true"],.chip.red:has(input:checked){background:var(--red);color:#fff;border-color:#a52623}
+button.chip.yellow[aria-pressed="true"],.chip.yellow:has(input:checked){background:var(--yellow);color:#231b00;border-color:#8a7400}
+button.chip:focus-visible,.chip:has(input:focus-visible){outline:2px solid var(--accent);outline-offset:2px}
 .chip-group{display:flex;flex-wrap:wrap;gap:8px}
 .hint{color:var(--muted);font-size:12px}
 .badge{padding:2px 8px;border-radius:8px;font-size:12px;border:1px solid var(--line);background:#0f1822;color:var(--muted)}

--- a/index.html
+++ b/index.html
@@ -42,27 +42,27 @@
         <div>
           <label><strong>RAUDONA</strong></label>
           <div class="chip-group" id="chips_red">
-            <span class="chip red" data-value="GKS &lt; 9">GKS &lt; 9</span>
-            <span class="chip red" data-value="KD &lt; 8 ar &gt; 30/min">KD &lt; 8 ar &gt; 30/min</span>
-            <span class="chip red" data-value="AKS &lt; 90 mmHg">AKS &lt; 90 mmHg</span>
-            <span class="chip red" data-value="SpO₂ &lt; 90%">SpO₂ &lt; 90%</span>
-            <span class="chip red" data-value="ŠSD &gt; 120/min">ŠSD &gt; 120/min</span>
-            <span class="chip red" data-value="Stridoras">Stridoras</span>
-            <span class="chip red" data-value="Lūžę 2 ilgieji kaulai/dubuo">Lūžę 2 ilgieji kaulai/dubuo</span>
-            <span class="chip red" data-value="Kiauriniai suž. kakle/krūtinėje/juosmenyje">Kiauriniai suž. kakle/krūtinėje/juosmenyje</span>
-            <span class="chip red" data-value="Įtariamas vidinis kraujavimas">Įtariamas vidinis kraujavimas</span>
-            <span class="chip red" data-value="Nestabili krūtinės ląsta">Nestabili krūtinės ląsta</span>
-            <span class="chip red" data-value="Nudegimas &gt;18% ar KT nudegimas">Nudegimas &gt;18% ar KT nudegimas</span>
-            <span class="chip red" data-value="Amputacijos aukščiau plašt./pėdų">Amputacijos aukščiau plašt./pėdų</span>
+            <button type="button" class="chip red" data-value="GKS &lt; 9" aria-pressed="false">GKS &lt; 9</button>
+            <button type="button" class="chip red" data-value="KD &lt; 8 ar &gt; 30/min" aria-pressed="false">KD &lt; 8 ar &gt; 30/min</button>
+            <button type="button" class="chip red" data-value="AKS &lt; 90 mmHg" aria-pressed="false">AKS &lt; 90 mmHg</button>
+            <button type="button" class="chip red" data-value="SpO₂ &lt; 90%" aria-pressed="false">SpO₂ &lt; 90%</button>
+            <button type="button" class="chip red" data-value="ŠSD &gt; 120/min" aria-pressed="false">ŠSD &gt; 120/min</button>
+            <button type="button" class="chip red" data-value="Stridoras" aria-pressed="false">Stridoras</button>
+            <button type="button" class="chip red" data-value="Lūžę 2 ilgieji kaulai/dubuo" aria-pressed="false">Lūžę 2 ilgieji kaulai/dubuo</button>
+            <button type="button" class="chip red" data-value="Kiauriniai suž. kakle/krūtinėje/juosmenyje" aria-pressed="false">Kiauriniai suž. kakle/krūtinėje/juosmenyje</button>
+            <button type="button" class="chip red" data-value="Įtariamas vidinis kraujavimas" aria-pressed="false">Įtariamas vidinis kraujavimas</button>
+            <button type="button" class="chip red" data-value="Nestabili krūtinės ląsta" aria-pressed="false">Nestabili krūtinės ląsta</button>
+            <button type="button" class="chip red" data-value="Nudegimas &gt;18% ar KT nudegimas" aria-pressed="false">Nudegimas &gt;18% ar KT nudegimas</button>
+            <button type="button" class="chip red" data-value="Amputacijos aukščiau plašt./pėdų" aria-pressed="false">Amputacijos aukščiau plašt./pėdų</button>
           </div>
         </div>
         <div>
           <label><strong>GELTONA</strong></label>
           <div class="chip-group" id="chips_yellow">
-            <span class="chip yellow" data-value="Pėst./dvir./motociklo trauma">Pėst./dvir./motociklo trauma</span>
-            <span class="chip yellow" data-value="Sprogimas/susišaudymas">Sprogimas/susišaudymas</span>
-            <span class="chip yellow" data-value="Kritimas &gt;3 m ar nardymas">Kritimas &gt;3 m ar nardymas</span>
-            <span class="chip yellow" data-value="Reikėjo gelbėtojų pagalbos">Reikėjo gelbėtojų pagalbos</span>
+            <button type="button" class="chip yellow" data-value="Pėst./dvir./motociklo trauma" aria-pressed="false">Pėst./dvir./motociklo trauma</button>
+            <button type="button" class="chip yellow" data-value="Sprogimas/susišaudymas" aria-pressed="false">Sprogimas/susišaudymas</button>
+            <button type="button" class="chip yellow" data-value="Kritimas &gt;3 m ar nardymas" aria-pressed="false">Kritimas &gt;3 m ar nardymas</button>
+            <button type="button" class="chip yellow" data-value="Reikėjo gelbėtojų pagalbos" aria-pressed="false">Reikėjo gelbėtojų pagalbos</button>
           </div>
         </div>
       </div>
@@ -74,9 +74,9 @@
       <h2>A – Kvėpavimo takai</h2>
       <label>Takai</label>
       <div class="chip-group" id="a_airway_group" data-single="true">
-        <span class="chip" data-value="Atviri">Atviri</span>
-        <span class="chip" data-value="Užtikrinti (intub./GMP)">Užtikrinti (intub./GMP)</span>
-        <span class="chip" data-value="Kita">Kita</span>
+        <label class="chip"><input type="radio" name="a_airway_group" value="Atviri">Atviri</label>
+        <label class="chip"><input type="radio" name="a_airway_group" value="Užtikrinti (intub./GMP)">Užtikrinti (intub./GMP)</label>
+        <label class="chip"><input type="radio" name="a_airway_group" value="Kita">Kita</label>
       </div>
       <div class="row" style="margin-top:8px"><label style="margin:0">Pastabos</label><input id="a_notes" type="text" placeholder="Trumpai..."></div>
     </section>
@@ -90,8 +90,8 @@
         <div>
           <label>Alsavimas</label>
           <div class="row">
-            <div><div class="subtle">Kairė</div><div class="chip-group" id="b_breath_left_group" data-single="true"><span class="chip" data-value="+">+</span><span class="chip" data-value="-">-</span></div></div>
-            <div><div class="subtle">Dešinė</div><div class="chip-group" id="b_breath_right_group" data-single="true"><span class="chip" data-value="+">+</span><span class="chip" data-value="-">-</span></div></div>
+            <div><div class="subtle">Kairė</div><div class="chip-group" id="b_breath_left_group" data-single="true"><label class="chip"><input type="radio" name="b_breath_left_group" value="+">+</label><label class="chip"><input type="radio" name="b_breath_left_group" value="-">-</label></div></div>
+            <div><div class="subtle">Dešinė</div><div class="chip-group" id="b_breath_right_group" data-single="true"><label class="chip"><input type="radio" name="b_breath_right_group" value="+">+</label><label class="chip"><input type="radio" name="b_breath_right_group" value="-">-</label></div></div>
           </div>
         </div>
       </div>
@@ -122,12 +122,12 @@
         </div>
         <div>
           <label>Vyzdžiai – Kairė</label>
-          <div class="chip-group" id="d_pupil_left_group" data-single="true"><span class="chip" data-value="n.y.">n.y.</span><span class="chip" data-value="kita">kita</span></div>
+          <div class="chip-group" id="d_pupil_left_group" data-single="true"><label class="chip"><input type="radio" name="d_pupil_left_group" value="n.y.">n.y.</label><label class="chip"><input type="radio" name="d_pupil_left_group" value="kita">kita</label></div>
           <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." style="margin-top:6px;display:none">
         </div>
         <div>
           <label>Vyzdžiai – Dešinė</label>
-          <div class="chip-group" id="d_pupil_right_group" data-single="true"><span class="chip" data-value="n.y.">n.y.</span><span class="chip" data-value="kita">kita</span></div>
+          <div class="chip-group" id="d_pupil_right_group" data-single="true"><label class="chip"><input type="radio" name="d_pupil_right_group" value="n.y.">n.y.</label><label class="chip"><input type="radio" name="d_pupil_right_group" value="kita">kita</label></div>
           <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." style="margin-top:6px;display:none">
         </div>
       </div>

--- a/js/app.js
+++ b/js/app.js
@@ -9,8 +9,26 @@ const IMG=['Galvos KT','Kaklo KT','Viso kūno KT','Krūtinės Ro','Dubens Ro'];
 const LABS=['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
 const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas','Radiologas'];
 
-const imgWrap=$('#imaging_basic'); IMG.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; imgWrap.appendChild(s);});
-const labsWrap=$('#labs_basic'); LABS.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; labsWrap.appendChild(s);});
+const imgWrap=$('#imaging_basic');
+IMG.forEach(n=>{
+  const b=document.createElement('button');
+  b.type='button';
+  b.className='chip';
+  b.dataset.value=n;
+  b.setAttribute('aria-pressed','false');
+  b.textContent=n;
+  imgWrap.appendChild(b);
+});
+const labsWrap=$('#labs_basic');
+LABS.forEach(n=>{
+  const b=document.createElement('button');
+  b.type='button';
+  b.className='chip';
+  b.dataset.value=n;
+  b.setAttribute('aria-pressed','false');
+  b.textContent=n;
+  labsWrap.appendChild(b);
+});
 const fastAreas=['Perikardas','Dešinė pleura','Kairė pleura','RUQ','LUQ','Dubuo']; const fastWrap=$('#fastGrid');
 fastAreas.forEach(a=>{const box=document.createElement('div'); box.innerHTML=`<label>${a}</label><div class="row"><label class="pill"><input type="radio" name="fast_${a}" value="Yra"> Yra</label><label class="pill"><input type="radio" name="fast_${a}" value="Nėra"> Nėra</label></div>`; fastWrap.appendChild(box);});
 const teamWrap=$('#teamGrid'); TEAM_ROLES.forEach(r=>{
@@ -103,7 +121,7 @@ function saveAll(){
     else{ data[key]=el.value; }
   });
   ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group']
-    .forEach(sel=>{ const arr=$$('.chip.active',$(sel)).map(c=>c.dataset.value); data['chips:'+sel]=arr; });
+    .forEach(sel=>{ data['chips:'+sel]=listChips(sel); });
   function pack(container){ return Array.from(container.children).map(card=>({ name:card.querySelector('.act_chk').parentElement.textContent.trim(), on:card.querySelector('.act_chk').checked, time:card.querySelector('.act_time').value, dose:card.querySelector('.act_dose').value, note:card.querySelector('.act_note').value }));}
   data['meds']=pack($('#medications')); data['procs']=pack($('#procedures'));
   data['bodymap_svg']=BodySVG.serialize();
@@ -121,12 +139,17 @@ function loadAll(){
       else{ if(data[key]!=null) el.value=data[key]; }
     });
     ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group']
-      .forEach(sel=>{ const arr=data['chips:'+sel]||[]; $$('.chip',$(sel)).forEach(c=>c.classList.toggle('active',arr.includes(c.dataset.value))); });
+      .forEach(sel=>{
+        const arr=data['chips:'+sel]||[];
+        const container=$(sel);
+        $$('button.chip',container).forEach(b=>b.setAttribute('aria-pressed',arr.includes(b.dataset.value)?'true':'false'));
+        $$('input',container).forEach(i=>{ i.checked=arr.includes(i.value); });
+      });
     function unpack(container,records){ if(!Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; card.querySelector('.act_dose').value=r.dose||''; card.querySelector('.act_note').value=r.note||'';});}
     unpack($('#medications'),data['meds']); unpack($('#procedures'),data['procs']);
     if(data['bodymap_svg']) BodySVG.load(data['bodymap_svg']);
-    $('#d_pupil_left_note').style.display = ($$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
-    $('#d_pupil_right_note').style.display = ($$('.chip.active', $('#d_pupil_right_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
+    $('#d_pupil_left_note').style.display = listChips('#d_pupil_left_group').includes('kita')?'block':'none';
+    $('#d_pupil_right_note').style.display = listChips('#d_pupil_right_group').includes('kita')?'block':'none';
   }catch(e){}
 }
 

--- a/js/autoActivate.js
+++ b/js/autoActivate.js
@@ -22,7 +22,14 @@ function autoActivateFromEMS(){
   Object.entries(autoMap.red).forEach(([label,fn])=>{
     if(fn()){
       const chip = $$('.chip', red).find(c=>c.dataset.value===label);
-      if(chip && !chip.classList.contains('active')) chip.classList.add('active');
+      if(chip){
+        if(chip.tagName==='BUTTON'){
+          chip.setAttribute('aria-pressed','true');
+        }else{
+          const input=chip.querySelector('input');
+          if(input) input.checked=true;
+        }
+      }
     }
   });
 }

--- a/js/chips.js
+++ b/js/chips.js
@@ -2,28 +2,52 @@ import { $, $$ } from './utils.js';
 
 export function initChips(saveAll){
   document.addEventListener('click', e => {
-    const chip = e.target.closest('.chip');
-    if(!chip) return;
-    const group = chip.parentElement;
+    const btn = e.target.closest('button.chip');
+    if(!btn) return;
+    const group = btn.parentElement;
     const single = group?.dataset?.single === 'true';
     if(single){
-      $$('.chip', group).forEach(c => c.classList.remove('active'));
-      chip.classList.add('active');
+      $$('.chip', group).forEach(b => b.setAttribute('aria-pressed','false'));
+      btn.setAttribute('aria-pressed','true');
     } else {
-      chip.classList.toggle('active');
+      const pressed = btn.getAttribute('aria-pressed') === 'true';
+      btn.setAttribute('aria-pressed', pressed ? 'false' : 'true');
     }
     if(group.id==='d_pupil_left_group'){
-      $('#d_pupil_left_note').style.display = (chip.dataset.value==='kita' && chip.classList.contains('active')) ? 'block' : 'none';
-      if(chip.dataset.value!=='kita') $('#d_pupil_left_note').value='';
+      const active = btn.dataset.value==='kita' && btn.getAttribute('aria-pressed')==='true';
+      $('#d_pupil_left_note').style.display = active ? 'block' : 'none';
+      if(!active) $('#d_pupil_left_note').value='';
     }
     if(group.id==='d_pupil_right_group'){
-      $('#d_pupil_right_note').style.display = (chip.dataset.value==='kita' && chip.classList.contains('active')) ? 'block' : 'none';
-      if(chip.dataset.value!=='kita') $('#d_pupil_right_note').value='';
+      const active = btn.dataset.value==='kita' && btn.getAttribute('aria-pressed')==='true';
+      $('#d_pupil_right_note').style.display = active ? 'block' : 'none';
+      if(!active) $('#d_pupil_right_note').value='';
+    }
+    if(typeof saveAll === 'function') saveAll();
+  }, true);
+
+  document.addEventListener('change', e => {
+    const input = e.target.matches('.chip > input') ? e.target : null;
+    if(!input) return;
+    const group = input.closest('.chip-group');
+    if(group?.id==='d_pupil_left_group'){
+      const active = input.value==='kita' && input.checked;
+      $('#d_pupil_left_note').style.display = active ? 'block' : 'none';
+      if(!active) $('#d_pupil_left_note').value='';
+    }
+    if(group?.id==='d_pupil_right_group'){
+      const active = input.value==='kita' && input.checked;
+      $('#d_pupil_right_note').style.display = active ? 'block' : 'none';
+      if(!active) $('#d_pupil_right_note').value='';
     }
     if(typeof saveAll === 'function') saveAll();
   }, true);
 }
 
 export function listChips(sel){
-  return $$('.chip.active', $(sel)).map(c=>c.dataset.value);
+  const root = $(sel);
+  const buttons = $$('button.chip[aria-pressed="true"]', root).map(b=>b.dataset.value);
+  const inputs = $$('input:checked', root).map(i=>i.value);
+  return [...buttons, ...inputs];
 }
+


### PR DESCRIPTION
## Summary
- Replace span chips with `<button>` or `<label><input>` for stateful controls
- Toggle chip state via `aria-pressed` or form inputs and update save/load logic
- Style new chip elements with focus indicators and color variants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f8c10a3548320ad72b965e0766087