### PR TITLE
Split medications by pain and bleeding categories

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -64,7 +64,8 @@ label.chip input{
 .chip-group{display:flex;flex-wrap:wrap;gap:8px}
 .hint{color:var(--muted);font-size:12px}
 .badge{padding:2px 8px;border-radius:8px;font-size:12px;border:1px solid var(--line);background:#152231;color:var(--muted)}
-.split{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+.split{display:flex;gap:12px;flex-wrap:wrap}
+.split>div{flex:1}
 .subtle{font-size:12px;color:var(--muted)}
 .divider{height:1px;background:var(--line);margin:10px 0}
 /* SVG body map */

--- a/index.html
+++ b/index.html
@@ -230,7 +230,8 @@
     <section class="card view" data-tab="Intervencijos">
       <h2>Intervencijos</h2>
       <div class="split">
-        <div><h3 style="margin:0 0 6px;font-size:14px;color:var(--muted)">Medikamentai</h3><div class="grid cols-3" id="medications"></div></div>
+        <div><h3 style="margin:0 0 6px;font-size:14px;color:var(--muted)">Medikamentai – skausmo kontrolė</h3><div class="grid cols-3" id="pain_meds"></div></div>
+        <div><h3 style="margin:0 0 6px;font-size:14px;color:var(--muted)">Medikamentai – kraujavimo kontrolė</h3><div class="grid cols-3" id="bleeding_meds"></div></div>
         <div><h3 style="margin:0 0 6px;font-size:14px;color:var(--muted)">Procedūros</h3><div class="grid cols-3" id="procedures"></div></div>
       </div>
       <div class="hint" style="margin-top:6px">Paspaudus ant vaisto/procedūros automatiškai užpildomas laikas (galima koreguoti).</div>

--- a/js/actions.js
+++ b/js/actions.js
@@ -1,6 +1,7 @@
 import { $, nowHM } from './utils.js';
 
-export const MEDS = ['TXA','Fentanilis','Paracetamolis','Ketoprofenas','O- kraujas','Fibryga','Ca gliukonatas'];
+export const PAIN_MEDS = ['Fentanilis','Paracetamolis','Ketoprofenas'];
+export const BLEEDING_MEDS = ['TXA','O- kraujas','Fibryga','Ca gliukonatas'];
 export const PROCS = ['Intubacija','Krikotirotomija','Pleuros drenažas','Adatinė dekompresija','Kūno šildymas','Turniketas','Dubens diržas','Gipsavimas','Siuvimas','Repocizija'];
 
 function buildActionCard(group, name, saveAll){
@@ -23,8 +24,10 @@ function buildActionCard(group, name, saveAll){
 }
 
 export function initActions(saveAll){
-  const medsWrap=$('#medications');
+  const painWrap=$('#pain_meds');
+  const bleedingWrap=$('#bleeding_meds');
   const procsWrap=$('#procedures');
-  MEDS.forEach(n=>medsWrap.appendChild(buildActionCard('med', n, saveAll)));
+  PAIN_MEDS.forEach(n=>painWrap.appendChild(buildActionCard('med', n, saveAll)));
+  BLEEDING_MEDS.forEach(n=>bleedingWrap.appendChild(buildActionCard('med', n, saveAll)));
   PROCS.forEach(n=>procsWrap.appendChild(buildActionCard('proc', n, saveAll)));
 }

--- a/js/app.js
+++ b/js/app.js
@@ -105,7 +105,7 @@ function saveAll(){
   ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group']
     .forEach(sel=>{ const arr=$$('.chip.active',$(sel)).map(c=>c.dataset.value); data['chips:'+sel]=arr; });
   function pack(container){ return Array.from(container.children).map(card=>({ name:card.querySelector('.act_chk').parentElement.textContent.trim(), on:card.querySelector('.act_chk').checked, time:card.querySelector('.act_time').value, dose:card.querySelector('.act_dose').value, note:card.querySelector('.act_note').value }));}
-  data['meds']=pack($('#medications')); data['procs']=pack($('#procedures'));
+  data['pain_meds']=pack($('#pain_meds')); data['bleeding_meds']=pack($('#bleeding_meds')); data['procs']=pack($('#procedures'));
   data['bodymap_svg']=BodySVG.serialize();
   localStorage.setItem('trauma_v9', JSON.stringify(data));
 }
@@ -123,7 +123,7 @@ function loadAll(){
     ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group']
       .forEach(sel=>{ const arr=data['chips:'+sel]||[]; $$('.chip',$(sel)).forEach(c=>c.classList.toggle('active',arr.includes(c.dataset.value))); });
     function unpack(container,records){ if(!Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; card.querySelector('.act_dose').value=r.dose||''; card.querySelector('.act_note').value=r.note||'';});}
-    unpack($('#medications'),data['meds']); unpack($('#procedures'),data['procs']);
+    unpack($('#pain_meds'),data['pain_meds']); unpack($('#bleeding_meds'),data['bleeding_meds']); unpack($('#procedures'),data['procs']);
     if(data['bodymap_svg']) BodySVG.load(data['bodymap_svg']);
     $('#d_pupil_left_note').style.display = ($$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
     $('#d_pupil_right_note').style.display = ($$('.chip.active', $('#d_pupil_right_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
@@ -180,7 +180,7 @@ document.getElementById('btnGen').addEventListener('click',()=>{
   out.push('\n--- E Kita ---'); out.push([$('#e_temp').value?('T '+$('#e_temp').value+'°C'):null, $('#e_back_ny').checked?'Nugara: n.y.':($('#e_back_notes').value?('Nugara: '+$('#e_back_notes').value):null), $('#e_other').value?('Kita: '+$('#e_other').value):null, bodymapSummary()].filter(Boolean).join(' | '));
 
   function collect(container){ return Array.from(container.children).map(card=>{ const on=card.querySelector('.act_chk').checked; if(!on) return null; const name=card.querySelector('.act_chk').parentElement.textContent.trim(); const time=card.querySelector('.act_time').value; const dose=card.querySelector('.act_dose').value; const note=card.querySelector('.act_note').value; return [name, time?('laikas '+time):null, dose?('dozė '+dose):null, note?('pastabos '+note):null].filter(Boolean).join(' | '); }).filter(Boolean);}
-  const meds=collect($('#medications')), procs=collect($('#procedures')); if(meds.length||procs.length){ out.push('\n--- Intervencijos ---'); if(meds.length) out.push('Medikamentai:\n'+meds.join('\n')); if(procs.length) out.push('Procedūros:\n'+procs.join('\n')); }
+  const pain=collect($('#pain_meds')), bleeding=collect($('#bleeding_meds')), procs=collect($('#procedures')); if(pain.length||bleeding.length||procs.length){ out.push('\n--- Intervencijos ---'); if(pain.length) out.push('Medikamentai (skausmo kontrolė):\n'+pain.join('\n')); if(bleeding.length) out.push('Medikamentai (kraujavimo kontrolė):\n'+bleeding.join('\n')); if(procs.length) out.push('Procedūros:\n'+procs.join('\n')); }
 
   const imgs=listChips('#imaging_basic'); const fr=fastAreas.map(a=>{ const y=document.querySelector('input[name="fast_'+a+'"][value="Yra"]')?.checked; const n=document.querySelector('input[name="fast_'+a+'"][value="Nėra"]')?.checked; return y? a+': skystis Yra' : (n? a+': skystis Nėra' : null); }).filter(Boolean);
   if(imgs.length||fr.length){ out.push('\n--- Vaizdiniai tyrimai ---'); if(imgs.length) out.push('Užsakyta: '+imgs.join(', ')); if(fr.length) out.push('FAST: '+fr.join(' | ')); }


### PR DESCRIPTION
## Summary
- Separate pain-control and bleeding-control medication grids in Intervencijos section
- Populate new grids via PAIN_MEDS and BLEEDING_MEDS arrays and update save/load/report logic
- Make split layout flexible for three equally sized groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a018fa80908320895e1897b64d6790