### PR TITLE
feat: separate medication groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,7 +230,12 @@
     <section class="card view" data-tab="Intervencijos">
       <h2>Intervencijos</h2>
       <div class="split">
-        <div><h3 style="margin:0 0 6px;font-size:14px;color:var(--muted)">Medikamentai</h3><div class="grid cols-3" id="medications"></div></div>
+        <div>
+          <h3 style="margin:0 0 6px;font-size:14px;color:var(--muted)">Skausmo kontrolės medikamentai</h3>
+          <div class="grid cols-3" id="pain_meds"></div>
+          <h3 style="margin:12px 0 6px;font-size:14px;color:var(--muted)">Kraujavimo kontrolės medikamentai</h3>
+          <div class="grid cols-3" id="bleeding_meds"></div>
+        </div>
         <div><h3 style="margin:0 0 6px;font-size:14px;color:var(--muted)">Procedūros</h3><div class="grid cols-3" id="procedures"></div></div>
       </div>
       <div class="hint" style="margin-top:6px">Paspaudus ant vaisto/procedūros automatiškai užpildomas laikas (galima koreguoti).</div>

--- a/js/actions.js
+++ b/js/actions.js
@@ -1,6 +1,7 @@
 import { $, nowHM } from './utils.js';
 
-export const MEDS = ['TXA','Fentanilis','Paracetamolis','Ketoprofenas','O- kraujas','Fibryga','Ca gliukonatas'];
+export const PAIN_MEDS = ['Fentanilis','Paracetamolis','Ketoprofenas'];
+export const BLEEDING_MEDS = ['TXA','O- kraujas','Fibryga','Ca gliukonatas'];
 export const PROCS = ['Intubacija','Krikotirotomija','Pleuros drenažas','Adatinė dekompresija','Kūno šildymas','Turniketas','Dubens diržas','Gipsavimas','Siuvimas','Repocizija'];
 
 function buildActionCard(group, name, saveAll){
@@ -23,8 +24,10 @@ function buildActionCard(group, name, saveAll){
 }
 
 export function initActions(saveAll){
-  const medsWrap=$('#medications');
+  const painWrap=$('#pain_meds');
+  const bleedingWrap=$('#bleeding_meds');
   const procsWrap=$('#procedures');
-  MEDS.forEach(n=>medsWrap.appendChild(buildActionCard('med', n, saveAll)));
+  PAIN_MEDS.forEach(n=>painWrap.appendChild(buildActionCard('pain', n, saveAll)));
+  BLEEDING_MEDS.forEach(n=>bleedingWrap.appendChild(buildActionCard('bleed', n, saveAll)));
   PROCS.forEach(n=>procsWrap.appendChild(buildActionCard('proc', n, saveAll)));
 }

--- a/js/app.js
+++ b/js/app.js
@@ -111,12 +111,9 @@ function saveAll(){
   if(painContainer) data['pain_meds']=pack(painContainer);
   const bleedContainer=$('#bleeding_meds');
   if(bleedContainer) data['bleeding_meds']=pack(bleedContainer);
-  const oldMedsContainer=$('#medications');
-  if(oldMedsContainer) data['meds']=pack(oldMedsContainer);
   data['procs']=pack($('#procedures'));
   data['bodymap_svg']=BodySVG.serialize();
   localStorage.setItem(LS_KEY_CURRENT, JSON.stringify(data));
-  if(LS_KEY_OLD!==LS_KEY_CURRENT) localStorage.removeItem(LS_KEY_OLD);
 }
 function loadAll(){
   const raw=localStorage.getItem(LS_KEY_CURRENT) || localStorage.getItem(LS_KEY_OLD); if(!raw) return;
@@ -134,8 +131,6 @@ function loadAll(){
     function unpack(container,records){ if(!container || !Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; card.querySelector('.act_dose').value=r.dose||''; card.querySelector('.act_note').value=r.note||'';});}
     unpack($('#pain_meds'), data['pain_meds'] || data['meds']);
     unpack($('#bleeding_meds'), data['bleeding_meds']);
-    const oldMedsContainer=$('#medications');
-    if(oldMedsContainer && data['meds']) unpack(oldMedsContainer, data['meds']);
     unpack($('#procedures'),data['procs']);
     if(data['bodymap_svg']) BodySVG.load(data['bodymap_svg']);
     $('#d_pupil_left_note').style.display = ($$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita'))?'block':'none';

--- a/js/app.js
+++ b/js/app.js
@@ -93,6 +93,8 @@ const BodySVG=(function(){
 
 /* ===== Save / Load ===== */
 const FIELD_SELECTORS='input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select';
+const LS_KEY_CURRENT='trauma_v10';
+const LS_KEY_OLD='trauma_v9';
 function saveAll(){
   const data={};
   $$(FIELD_SELECTORS).forEach(el=>{
@@ -105,12 +107,19 @@ function saveAll(){
   ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group']
     .forEach(sel=>{ const arr=$$('.chip.active',$(sel)).map(c=>c.dataset.value); data['chips:'+sel]=arr; });
   function pack(container){ return Array.from(container.children).map(card=>({ name:card.querySelector('.act_chk').parentElement.textContent.trim(), on:card.querySelector('.act_chk').checked, time:card.querySelector('.act_time').value, dose:card.querySelector('.act_dose').value, note:card.querySelector('.act_note').value }));}
-  data['meds']=pack($('#medications')); data['procs']=pack($('#procedures'));
+  const painContainer=$('#pain_meds');
+  if(painContainer) data['pain_meds']=pack(painContainer);
+  const bleedContainer=$('#bleeding_meds');
+  if(bleedContainer) data['bleeding_meds']=pack(bleedContainer);
+  const oldMedsContainer=$('#medications');
+  if(oldMedsContainer) data['meds']=pack(oldMedsContainer);
+  data['procs']=pack($('#procedures'));
   data['bodymap_svg']=BodySVG.serialize();
-  localStorage.setItem('trauma_v9', JSON.stringify(data));
+  localStorage.setItem(LS_KEY_CURRENT, JSON.stringify(data));
+  if(LS_KEY_OLD!==LS_KEY_CURRENT) localStorage.removeItem(LS_KEY_OLD);
 }
 function loadAll(){
-  const raw=localStorage.getItem('trauma_v9'); if(!raw) return;
+  const raw=localStorage.getItem(LS_KEY_CURRENT) || localStorage.getItem(LS_KEY_OLD); if(!raw) return;
   try{
     const data=JSON.parse(raw);
     $$(FIELD_SELECTORS).forEach(el=>{
@@ -122,8 +131,12 @@ function loadAll(){
     });
     ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group']
       .forEach(sel=>{ const arr=data['chips:'+sel]||[]; $$('.chip',$(sel)).forEach(c=>c.classList.toggle('active',arr.includes(c.dataset.value))); });
-    function unpack(container,records){ if(!Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; card.querySelector('.act_dose').value=r.dose||''; card.querySelector('.act_note').value=r.note||'';});}
-    unpack($('#medications'),data['meds']); unpack($('#procedures'),data['procs']);
+    function unpack(container,records){ if(!container || !Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; card.querySelector('.act_dose').value=r.dose||''; card.querySelector('.act_note').value=r.note||'';});}
+    unpack($('#pain_meds'), data['pain_meds'] || data['meds']);
+    unpack($('#bleeding_meds'), data['bleeding_meds']);
+    const oldMedsContainer=$('#medications');
+    if(oldMedsContainer && data['meds']) unpack(oldMedsContainer, data['meds']);
+    unpack($('#procedures'),data['procs']);
     if(data['bodymap_svg']) BodySVG.load(data['bodymap_svg']);
     $('#d_pupil_left_note').style.display = ($$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
     $('#d_pupil_right_note').style.display = ($$('.chip.active', $('#d_pupil_right_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
@@ -150,7 +163,7 @@ function gksSum(a,k,m){ a=+a||0;k=+k||0;m=+m||0; return (a&&k&&m)?(a+k+m):''; }
 const getSingleValue=sel=>listChips(sel)[0]||'';
 function bodymapSummary(){
   try{
-    const data=JSON.parse(localStorage.getItem('trauma_v9')||'{}'); if(!data.bodymap_svg) return '';
+    const data=JSON.parse(localStorage.getItem(LS_KEY_CURRENT) || localStorage.getItem(LS_KEY_OLD) || '{}'); if(!data.bodymap_svg) return '';
     const o=JSON.parse(data.bodymap_svg); const cnt={front:{Ž:0,S:0,N:0}, back:{Ž:0,S:0,N:0}};
     (o.marks||[]).forEach(m=>{ if(cnt[m.side] && cnt[m.side][m.type]!=null) cnt[m.side][m.type]++; });
     const total=(cnt.front.Ž+cnt.front.S+cnt.front.N)+(cnt.back.Ž+cnt.back.S+cnt.back.N);
@@ -179,8 +192,16 @@ document.getElementById('btnGen').addEventListener('click',()=>{
 
   out.push('\n--- E Kita ---'); out.push([$('#e_temp').value?('T '+$('#e_temp').value+'°C'):null, $('#e_back_ny').checked?'Nugara: n.y.':($('#e_back_notes').value?('Nugara: '+$('#e_back_notes').value):null), $('#e_other').value?('Kita: '+$('#e_other').value):null, bodymapSummary()].filter(Boolean).join(' | '));
 
-  function collect(container){ return Array.from(container.children).map(card=>{ const on=card.querySelector('.act_chk').checked; if(!on) return null; const name=card.querySelector('.act_chk').parentElement.textContent.trim(); const time=card.querySelector('.act_time').value; const dose=card.querySelector('.act_dose').value; const note=card.querySelector('.act_note').value; return [name, time?('laikas '+time):null, dose?('dozė '+dose):null, note?('pastabos '+note):null].filter(Boolean).join(' | '); }).filter(Boolean);}
-  const meds=collect($('#medications')), procs=collect($('#procedures')); if(meds.length||procs.length){ out.push('\n--- Intervencijos ---'); if(meds.length) out.push('Medikamentai:\n'+meds.join('\n')); if(procs.length) out.push('Procedūros:\n'+procs.join('\n')); }
+  function collect(container){ if(!container) return []; return Array.from(container.children).map(card=>{ const on=card.querySelector('.act_chk').checked; if(!on) return null; const name=card.querySelector('.act_chk').parentElement.textContent.trim(); const time=card.querySelector('.act_time').value; const dose=card.querySelector('.act_dose').value; const note=card.querySelector('.act_note').value; return [name, time?('laikas '+time):null, dose?('dozė '+dose):null, note?('pastabos '+note):null].filter(Boolean).join(' | '); }).filter(Boolean);}
+  const pain=collect($('#pain_meds')),
+        bleed=collect($('#bleeding_meds')),
+        procs=collect($('#procedures'));
+  if(pain.length||bleed.length||procs.length){
+    out.push('\n--- Intervencijos ---');
+    if(pain.length) out.push('Skausmo kontrolės medikamentai:\n'+pain.join('\n'));
+    if(bleed.length) out.push('Kraujavimo kontrolės medikamentai:\n'+bleed.join('\n'));
+    if(procs.length) out.push('Procedūros:\n'+procs.join('\n'));
+  }
 
   const imgs=listChips('#imaging_basic'); const fr=fastAreas.map(a=>{ const y=document.querySelector('input[name="fast_'+a+'"][value="Yra"]')?.checked; const n=document.querySelector('input[name="fast_'+a+'"][value="Nėra"]')?.checked; return y? a+': skystis Yra' : (n? a+': skystis Nėra' : null); }).filter(Boolean);
   if(imgs.length||fr.length){ out.push('\n--- Vaizdiniai tyrimai ---'); if(imgs.length) out.push('Užsakyta: '+imgs.join(', ')); if(fr.length) out.push('FAST: '+fr.join(' | ')); }
@@ -194,4 +215,4 @@ document.getElementById('btnGen').addEventListener('click',()=>{
 
 document.getElementById('btnCopy').addEventListener('click',async()=>{ try{ await navigator.clipboard.writeText($('#output').value||''); alert('Nukopijuota.'); }catch(e){ alert('Nepavyko nukopijuoti.'); }});
 document.getElementById('btnSave').addEventListener('click',()=>{ saveAll(); alert('Išsaugota naršyklėje.');});
-document.getElementById('btnClear').addEventListener('click',()=>{ if(confirm('Išvalyti viską?')){ localStorage.removeItem('trauma_v9'); location.reload(); }});
+document.getElementById('btnClear').addEventListener('click',()=>{ if(confirm('Išvalyti viską?')){ localStorage.removeItem(LS_KEY_CURRENT); localStorage.removeItem(LS_KEY_OLD); location.reload(); }});


### PR DESCRIPTION
## Summary
- store pain and bleeding medications separately and load them back
- add report sections for pain and bleeding medications
- version localStorage key with backward compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a018fcbb0c8320a146b6e79a56647f