### PR TITLE
Rename activation tab and enhance EMS inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <header>
   <div class="wrap">
     <h1>Traumos forma – Desktop v9</h1>
-    <div class="sub">Aktyvacija (EMS) · ABCDE · LT · SVG kūno žemėlapis</div>
+    <div class="sub">Aktyvacija · ABCDE · LT · SVG kūno žemėlapis</div>
     <div class="toolbar">
       <button type="button" class="btn primary" id="btnGen">Sugeneruoti ataskaitą</button>
       <button type="button" class="btn" id="btnCopy">Kopijuoti</button>
@@ -25,8 +25,8 @@
   <nav id="tabs"></nav>
 
   <div id="views">
-    <!-- Aktyvacija (EMS) -->
-    <section class="card view" data-tab="Aktyvacija (EMS)">
+    <!-- Aktyvacija -->
+    <section class="card view" data-tab="Aktyvacija">
       <h2>Traumos komandos aktyvacija <span class="badge">EMS rodikliai → auto</span></h2>
       <div class="grid cols-3">
         <div><label>EMS ŠSD (k./min)</label><input id="ems_hr" type="number" min="0" max="250"></div>
@@ -36,7 +36,11 @@
       <div class="grid cols-3" style="margin-top:8px">
         <div class="row"><div style="flex:1"><label>EMS AKS s</label><input id="ems_sbp" type="number" min="0" max="300"></div><div style="flex:1"><label>EMS AKS d</label><input id="ems_dbp" type="number" min="0" max="200"></div></div>
         <div><label>EMS GKS (A-K-M)</label><div class="row"><input id="ems_gksa" type="number" min="1" max="4" placeholder="A"><input id="ems_gksk" type="number" min="1" max="5" placeholder="K"><input id="ems_gksm" type="number" min="1" max="6" placeholder="M"></div></div>
-        <div><label>EMS Temperatūra (nebūtina)</label><input id="ems_temp" type="number" step="0.1"></div>
+        <div><label>GMP pranešimo laikas</label><input id="ems_time" type="time"></div>
+      </div>
+      <div class="grid cols-2" style="margin-top:8px">
+        <div><label>Traumos mechanizmas</label><input id="ems_mechanism" type="text"></div>
+        <div><label>Pastabos</label><input id="ems_notes" type="text" placeholder="Trumpai..."></div>
       </div>
       <div class="split" style="margin-top:12px">
         <div>

--- a/js/app.js
+++ b/js/app.js
@@ -163,10 +163,11 @@ function bodymapSummary(){
 document.getElementById('btnGen').addEventListener('click',()=>{
   const out=[];
   const red=listChips('#chips_red'), yellow=listChips('#chips_yellow');
-  const ems={ hr:$('#ems_hr').value, rr:$('#ems_rr').value, spo2:$('#ems_spo2').value, sbp:$('#ems_sbp').value, dbp:$('#ems_dbp').value, gksa:$('#ems_gksa').value, gksk:$('#ems_gksk').value, gksm:$('#ems_gksm').value };
+  const ems={ hr:$('#ems_hr').value, rr:$('#ems_rr').value, spo2:$('#ems_spo2').value, sbp:$('#ems_sbp').value, dbp:$('#ems_dbp').value, gksa:$('#ems_gksa').value, gksk:$('#ems_gksk').value, gksm:$('#ems_gksm').value, time:$('#ems_time').value, mechanism:$('#ems_mechanism').value, notes:$('#ems_notes').value };
   const gksEMS=gksSum(ems.gksa,ems.gksk,ems.gksm);
+  const emsMeta=[ems.time?`GMP ${ems.time}`:null, ems.mechanism?`Mechanizmas: ${ems.mechanism}`:null].filter(Boolean).join('; ');
   const emsLine=[ems.hr?`ŠSD ${ems.hr}/min`:null, ems.rr?`KD ${ems.rr}/min`:null, ems.spo2?`SpO₂ ${ems.spo2}%`:null, (ems.sbp||ems.dbp)?`AKS ${ems.sbp}/${ems.dbp}`:null, gksEMS?`GKS ${gksEMS} (A${ems.gksa}-K${ems.gksk}-M${ems.gksm})`:null].filter(Boolean).join('; ');
-  out.push('--- Aktyvacija (EMS) ---'); if(emsLine) out.push(emsLine); if(red.length) out.push('RAUDONA: '+red.join(', ')); if(yellow.length) out.push('GELTONA: '+yellow.join(', '));
+  out.push('--- Aktyvacija ---'); if(emsMeta) out.push(emsMeta); if(emsLine) out.push(emsLine); if(ems.notes) out.push('Pastabos: '+ems.notes); if(red.length) out.push('RAUDONA: '+red.join(', ')); if(yellow.length) out.push('GELTONA: '+yellow.join(', '));
 
   out.push('\n--- A Kvėpavimo takai ---'); out.push(['Takai: '+(getSingleValue('#a_airway_group')||'-'), $('#a_notes').value?('Pastabos: '+$('#a_notes').value):null].filter(Boolean).join(' | '));
 

--- a/js/autoActivate.js
+++ b/js/autoActivate.js
@@ -28,7 +28,7 @@ function autoActivateFromEMS(){
 }
 
 export function initAutoActivate(saveAll){
-  ['#ems_hr','#ems_rr','#ems_spo2','#ems_sbp','#ems_dbp','#ems_gksa','#ems_gksk','#ems_gksm','#ems_temp']
+  ['#ems_hr','#ems_rr','#ems_spo2','#ems_sbp','#ems_dbp','#ems_gksa','#ems_gksk','#ems_gksm']
     .forEach(sel=>{
       const el = $(sel);
       if(el) el.addEventListener('input', ()=>{ autoActivateFromEMS(); if(typeof saveAll==='function') saveAll(); });

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -1,7 +1,7 @@
 import { $ } from './utils.js';
 
 export const TABS = [
-  'Aktyvacija (EMS)','A – Kvėpavimo takai','B – Kvėpavimas','C – Kraujotaka',
+  'Aktyvacija','A – Kvėpavimo takai','B – Kvėpavimas','C – Kraujotaka',
   'D – Sąmonė','E – Kita','Intervencijos','Vaizdiniai tyrimai','Laboratorija','Komanda','Ataskaita'
 ];
 


### PR DESCRIPTION
## Summary
- Rename "Aktyvacija (EMS)" tab to "Aktyvacija"
- Add EMS message time, trauma mechanism, and notes fields while removing temperature
- Update auto-activation and report generation for new EMS inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a01a3519188320bce3d96cdffee020