### PR TITLE
feat: add Sprendimas tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,6 +247,29 @@
     <section class="card view" data-tab="Laboratorija"><h2>Laboratoriniai tyrimai</h2><div class="chip-group" id="labs_basic"></div></section>
     <section class="card view" data-tab="Komanda"><h2>Komandos nariai</h2><div class="grid cols-3" id="teamGrid"></div></section>
     <section class="card view" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Spauskite „Sugeneruoti ataskaitą“..."></textarea><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
+    <section class="card view" data-tab="Sprendimas">
+      <h2>Sprendimas</h2>
+      <div><label>Laikas</label><input id="spr_time" type="time"></div>
+      <div style="margin-top:8px">
+        <label>Sprendimas</label>
+        <div class="chip-group" id="spr_decision_group" data-single="true">
+          <button type="button" class="chip" data-value="Stacionarizavimas" aria-pressed="false">Stacionarizavimas</button>
+          <button type="button" class="chip" data-value="Namo" aria-pressed="false">Namo</button>
+          <button type="button" class="chip" data-value="Stebėjimas SMPS" aria-pressed="false">Stebėjimas SMPS</button>
+          <button type="button" class="chip" data-value="Mirtis" aria-pressed="false">Mirtis</button>
+          <button type="button" class="chip" data-value="Pervežimas į kitą ligoninę" aria-pressed="false">Pervežimas į kitą ligoninę</button>
+        </div>
+      </div>
+      <div class="grid cols-3" style="margin-top:8px">
+        <div><label>ŠSD (k./min)</label><input id="spr_hr" type="number" min="0" max="250"></div>
+        <div><label>KD (k./min)</label><input id="spr_rr" type="number" min="0" max="80"></div>
+        <div><label>SpO₂ (%)</label><input id="spr_spo2" type="number" min="0" max="100"></div>
+      </div>
+      <div class="row" style="margin-top:8px">
+        <div style="flex:1"><label>AKS s</label><input id="spr_sbp" type="number" min="0" max="300"></div>
+        <div style="flex:1"><label>AKS d</label><input id="spr_dbp" type="number" min="0" max="200"></div>
+      </div>
+    </section>
   </div>
 </main>
 

--- a/js/app.js
+++ b/js/app.js
@@ -102,7 +102,7 @@ function saveAll(){
     else if(el.type==='checkbox'){ data[key]=el.checked?'__checked__':(el.value||''); }
     else{ data[key]=el.value; }
   });
-  ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group']
+  ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group']
     .forEach(sel=>{ const arr=$$('.chip.active',$(sel)).map(c=>c.dataset.value); data['chips:'+sel]=arr; });
   function pack(container){ return Array.from(container.children).map(card=>({ name:card.querySelector('.act_chk').parentElement.textContent.trim(), on:card.querySelector('.act_chk').checked, time:card.querySelector('.act_time').value, dose:card.querySelector('.act_dose').value, note:card.querySelector('.act_note').value }));}
   data['pain_meds']=pack($('#pain_meds')); data['bleeding_meds']=pack($('#bleeding_meds')); data['other_meds']=pack($('#other_meds')); data['procs']=pack($('#procedures'));
@@ -120,7 +120,7 @@ function loadAll(){
       else if(el.type==='checkbox'){ el.checked=(data[key]==='__checked__'); }
       else{ if(data[key]!=null) el.value=data[key]; }
     });
-    ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group']
+  ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group']
       .forEach(sel=>{ const arr=data['chips:'+sel]||[]; $$('.chip',$(sel)).forEach(c=>c.classList.toggle('active',arr.includes(c.dataset.value))); });
     function unpack(container,records){ if(!Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; card.querySelector('.act_dose').value=r.dose||''; card.querySelector('.act_note').value=r.note||'';});}
     unpack($('#pain_meds'),data['pain_meds']); unpack($('#bleeding_meds'),data['bleeding_meds']); unpack($('#other_meds'),data['other_meds']); unpack($('#procedures'),data['procs']);
@@ -196,6 +196,20 @@ document.getElementById('btnGen').addEventListener('click',()=>{
   const labs=listChips('#labs_basic'); if(labs.length){ out.push('\n--- Laboratorija ---'); out.push(labs.join(', ')); }
 
   const team=TEAM_ROLES.map(r=>{ const el=document.querySelector('input[data-team="'+r+'"]'); const v=el?.value?.trim(); return v? r+': '+v : null; }).filter(Boolean); if(team.length){ out.push('\n--- Komanda ---'); out.push(team.join(' | ')); }
+
+  const sprDecision=getSingleValue('#spr_decision_group');
+  const sprVitals=[
+    $('#spr_hr').value?('ŠSD '+$('#spr_hr').value+'/min'):null,
+    $('#spr_rr').value?('KD '+$('#spr_rr').value+'/min'):null,
+    $('#spr_spo2').value?('SpO₂ '+$('#spr_spo2').value+'%'):null,
+    ($('#spr_sbp').value||$('#spr_dbp').value)?('AKS '+$('#spr_sbp').value+'/'+$('#spr_dbp').value):null
+  ].filter(Boolean).join('; ');
+  if(sprDecision || $('#spr_time').value || sprVitals){
+    out.push('\n--- Sprendimas ---');
+    const meta=[ $('#spr_time').value?('Laikas '+$('#spr_time').value):null, sprDecision?('Sprendimas: '+sprDecision):null ].filter(Boolean).join(' | ');
+    if(meta) out.push(meta);
+    if(sprVitals) out.push(sprVitals);
+  }
 
   $('#output').value=out.filter(Boolean).join('\n'); showTab('Ataskaita'); saveAll();
 });

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -2,7 +2,7 @@ import { $ } from './utils.js';
 
 export const TABS = [
   'Aktyvacija','A – Kvėpavimo takai','B – Kvėpavimas','C – Kraujotaka',
-  'D – Sąmonė','E – Kita','Intervencijos','Vaizdiniai tyrimai','Laboratorija','Komanda','Ataskaita'
+  'D – Sąmonė','E – Kita','Intervencijos','Vaizdiniai tyrimai','Laboratorija','Komanda','Ataskaita','Sprendimas'
 ];
 
 export function showTab(name){


### PR DESCRIPTION
## Summary
- add new **Sprendimas** tab with time, disposition buttons, and vital signs fields
- persist and include decision data in generated report

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a01e0569588320860d1c6783d03911