### PR TITLE
Restrict activation to one team and show status

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -64,6 +64,9 @@ label.chip input{
 .chip-group{display:flex;flex-wrap:wrap;gap:8px}
 .hint{color:var(--muted);font-size:12px}
 .badge{padding:2px 8px;border-radius:8px;font-size:12px;border:1px solid var(--line);background:#152231;color:var(--muted)}
+.activation-dot{width:12px;height:12px;border-radius:50%;display:none;margin-left:8px}
+.activation-dot.red{background:var(--red);display:inline-block}
+.activation-dot.yellow{background:var(--yellow);display:inline-block}
 .split{display:flex;gap:12px;flex-wrap:wrap}
 .split>div{flex:1}
 .subtle{font-size:12px;color:var(--muted)}

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <header>
   <div class="wrap">
     <h1>Traumos forma – Desktop v9</h1>
-    <div class="sub">Aktyvacija · ABCDE · LT · SVG kūno žemėlapis</div>
+    <div class="sub">Aktyvacija · ABCDE · LT · SVG kūno žemėlapis <span id="activationIndicator" class="activation-dot"></span></div>
     <div class="toolbar">
       <button type="button" class="btn primary" id="btnGen">Sugeneruoti ataskaitą</button>
       <button type="button" class="btn" id="btnCopy">Kopijuoti</button>

--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,6 @@
 import { $, $$, nowHM } from './utils.js';
 import { initTabs, showTab } from './tabs.js';
-import { initChips, listChips } from './chips.js';
+import { initChips, listChips, setChipActive, isChipActive } from './chips.js';
 import { initAutoActivate } from './autoActivate.js';
 import { initActions } from './actions.js';
 
@@ -91,6 +91,52 @@ const BodySVG=(function(){
   return {serialize,load,counts,get side(){return side;},get tool(){return activeTool;}};
 })();
 
+/* ===== Activation indicator ===== */
+function ensureSingleTeam(){
+  const red=$('#chips_red');
+  const yellow=$('#chips_yellow');
+  const redActive=$$('.chip.active', red).length>0;
+  const yellowActive=$$('.chip.active', yellow).length>0;
+  if(redActive && yellowActive){
+    $$('.chip', yellow).forEach(c=>setChipActive(c,false));
+  }
+}
+function updateActivationIndicator(){
+  const dot=$('#activationIndicator');
+  const redActive=$$('.chip.active', $('#chips_red')).length>0;
+  const yellowActive=$$('.chip.active', $('#chips_yellow')).length>0;
+  dot.classList.remove('red','yellow');
+  dot.style.display='none';
+  if(redActive){ dot.classList.add('red'); dot.style.display='inline-block'; }
+  else if(yellowActive){ dot.classList.add('yellow'); dot.style.display='inline-block'; }
+}
+function setupActivationControls(){
+  const redGroup=$('#chips_red');
+  const yellowGroup=$('#chips_yellow');
+  redGroup.addEventListener('click',e=>{
+    const chip=e.target.closest('.chip');
+    if(!chip) return;
+    if(isChipActive(chip)){
+      $$('.chip', yellowGroup).forEach(c=>setChipActive(c,false));
+    }
+    ensureSingleTeam();
+    updateActivationIndicator();
+    saveAll();
+  });
+  yellowGroup.addEventListener('click',e=>{
+    const chip=e.target.closest('.chip');
+    if(!chip) return;
+    if(isChipActive(chip)){
+      $$('.chip', redGroup).forEach(c=>setChipActive(c,false));
+    }
+    ensureSingleTeam();
+    updateActivationIndicator();
+    saveAll();
+  });
+}
+window.updateActivationIndicator=updateActivationIndicator;
+window.ensureSingleTeam=ensureSingleTeam;
+
 /* ===== Save / Load ===== */
 const FIELD_SELECTORS='input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select';
 function saveAll(){
@@ -127,6 +173,8 @@ function loadAll(){
     if(data['bodymap_svg']) BodySVG.load(data['bodymap_svg']);
     $('#d_pupil_left_note').style.display = ($$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
     $('#d_pupil_right_note').style.display = ($$('.chip.active', $('#d_pupil_right_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
+    ensureSingleTeam();
+    updateActivationIndicator();
   }catch(e){}
 }
 
@@ -140,6 +188,7 @@ function init(){
   initChips(saveAll);
   initAutoActivate(saveAll);
   initActions(saveAll);
+  setupActivationControls();
   document.addEventListener('input', saveAll);
   loadAll();
 }

--- a/js/autoActivate.js
+++ b/js/autoActivate.js
@@ -31,6 +31,12 @@ function autoActivateFromEMS(){
       delete chip.dataset.auto;
     }
   });
+  if($$('.chip.active', red).length){
+    const yellow=$('#chips_yellow');
+    if(yellow) $$('.chip', yellow).forEach(c=>setChipActive(c,false));
+  }
+  window.ensureSingleTeam && window.ensureSingleTeam();
+  window.updateActivationIndicator && window.updateActivationIndicator();
 }
 
 export function initAutoActivate(saveAll){


### PR DESCRIPTION
## Summary
- add header indicator for active trauma team
- ensure red and yellow activations are mutually exclusive
- clear opposing team on auto-activation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0209e99188320a18caab3e206cc2e