### PR TITLE
Allow unselecting lab test chips

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -3,7 +3,8 @@ import { $, $$ } from './utils.js';
 export function isChipActive(chip){
   if(chip.tagName === 'BUTTON') return chip.getAttribute('aria-pressed') === 'true';
   const input = chip.querySelector('input');
-  return !!input && input.checked;
+  if(input) return input.checked;
+  return chip.classList.contains('active');
 }
 
 export function setChipActive(chip, active){

--- a/js/chips.test.js
+++ b/js/chips.test.js
@@ -1,0 +1,14 @@
+describe('chips', () => {
+  test('allows toggling chip without input element', () => {
+    document.body.innerHTML = `
+      <div id="labs_basic"><span class="chip" data-value="Hgb"></span></div>
+    `;
+    const { initChips, isChipActive } = require('./chips.js');
+    initChips();
+    const chip = document.querySelector('#labs_basic .chip');
+    chip.click();
+    expect(isChipActive(chip)).toBe(true);
+    chip.click();
+    expect(isChipActive(chip)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- fix chip activation logic to allow toggling chips without inputs (lab tests)
- add regression test ensuring chip toggling works

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a021d2d18c8320aec5cfeeb71e591f