### PR TITLE
Add medication search filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,6 +254,7 @@
     <!-- Intervencijos -->
     <section class="card view" data-tab="Intervencijos">
       <h2>Intervencijos</h2>
+      <input id="medSearch" type="text" placeholder="Ieškoti medikamentų..." style="margin-bottom:8px;width:100%">
       <div class="split">
         <div><h3 style="margin:0 0 6px;font-size:14px;color:var(--muted)">Medikamentai – skausmo kontrolė</h3><div class="grid cols-3" id="pain_meds"></div></div>
         <div><h3 style="margin:0 0 6px;font-size:14px;color:var(--muted)">Medikamentai – kraujavimo kontrolė</h3><div class="grid cols-3" id="bleeding_meds"></div></div>

--- a/js/actions.js
+++ b/js/actions.js
@@ -33,4 +33,17 @@ export function initActions(saveAll){
   BLEEDING_MEDS.forEach(n=>bleedingWrap.appendChild(buildActionCard('med', n, saveAll)));
   OTHER_MEDS.forEach(n=>otherWrap.appendChild(buildActionCard('med', n, saveAll)));
   PROCS.forEach(n=>procsWrap.appendChild(buildActionCard('proc', n, saveAll)));
+  const medSearch=$('#medSearch');
+  if(medSearch){
+    const wraps=[painWrap,bleedingWrap,otherWrap];
+    medSearch.addEventListener('input',()=>{
+      const q=medSearch.value.trim().toLowerCase();
+      wraps.forEach(wrap=>{
+        wrap.querySelectorAll('.card').forEach(card=>{
+          const name=card.querySelector('label').textContent.toLowerCase();
+          card.style.display=name.includes(q)?'':'none';
+        });
+      });
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Add search input to Intervencijos section for medications
- Filter medication cards across categories based on search text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0267f82f4832092058b17fd38d6d8