### PR TITLE
Replace EMS terminology with GMP

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,20 +27,20 @@
   <div id="views">
     <!-- Aktyvacija -->
     <section class="card view" data-tab="Aktyvacija">
-      <h2>Traumos komandos aktyvacija <span class="badge">EMS rodikliai → auto</span></h2>
+        <h2>Traumos komandos aktyvacija <span class="badge">GMP rodikliai → auto</span></h2>
       <div class="grid cols-3">
-        <div><label>EMS ŠSD (k./min)</label><input id="ems_hr" type="number" min="0" max="250"></div>
-        <div><label>EMS KD (k./min)</label><input id="ems_rr" type="number" min="0" max="80"></div>
-        <div><label>EMS SpO₂ (%)</label><input id="ems_spo2" type="number" min="0" max="100"></div>
+          <div><label>GMP ŠSD (k./min)</label><input id="gmp_hr" type="number" min="0" max="250"></div>
+          <div><label>GMP KD (k./min)</label><input id="gmp_rr" type="number" min="0" max="80"></div>
+          <div><label>GMP SpO₂ (%)</label><input id="gmp_spo2" type="number" min="0" max="100"></div>
       </div>
       <div class="grid cols-3" style="margin-top:8px">
-        <div class="row"><div style="flex:1"><label>EMS AKS s</label><input id="ems_sbp" type="number" min="0" max="300"></div><div style="flex:1"><label>EMS AKS d</label><input id="ems_dbp" type="number" min="0" max="200"></div></div>
-        <div><label>EMS GKS (A-K-M)</label><div class="row"><input id="ems_gksa" type="number" min="1" max="4" placeholder="A"><input id="ems_gksk" type="number" min="1" max="5" placeholder="K"><input id="ems_gksm" type="number" min="1" max="6" placeholder="M"></div></div>
-        <div><label>GMP pranešimo laikas</label><input id="ems_time" type="time"></div>
+          <div class="row"><div style="flex:1"><label>GMP AKS s</label><input id="gmp_sbp" type="number" min="0" max="300"></div><div style="flex:1"><label>GMP AKS d</label><input id="gmp_dbp" type="number" min="0" max="200"></div></div>
+          <div><label>GMP GKS (A-K-M)</label><div class="row"><input id="gmp_gksa" type="number" min="1" max="4" placeholder="A"><input id="gmp_gksk" type="number" min="1" max="5" placeholder="K"><input id="gmp_gksm" type="number" min="1" max="6" placeholder="M"></div></div>
+          <div><label>GMP pranešimo laikas</label><input id="gmp_time" type="time"></div>
       </div>
       <div class="grid cols-2" style="margin-top:8px">
-        <div><label>Traumos mechanizmas</label><input id="ems_mechanism" type="text"></div>
-        <div><label>Pastabos</label><input id="ems_notes" type="text" placeholder="Trumpai..."></div>
+          <div><label>Traumos mechanizmas</label><input id="gmp_mechanism" type="text"></div>
+          <div><label>Pastabos</label><input id="gmp_notes" type="text" placeholder="Trumpai..."></div>
       </div>
       <div class="split" style="margin-top:12px">
         <div>
@@ -70,7 +70,7 @@
           </div>
         </div>
       </div>
-      <div class="hint" style="margin-top:6px">Auto-aktyvacija – tik iš EMS rodiklių; rankiniai pakeitimai išlieka.</div>
+        <div class="hint" style="margin-top:6px">Auto-aktyvacija – tik iš GMP rodiklių; rankiniai pakeitimai išlieka.</div>
     </section>
 
     <!-- A -->

--- a/js/app.js
+++ b/js/app.js
@@ -226,11 +226,11 @@ function bodymapSummary(){
 document.getElementById('btnGen').addEventListener('click',()=>{
   const out=[];
   const red=listChips('#chips_red'), yellow=listChips('#chips_yellow');
-  const ems={ hr:$('#ems_hr').value, rr:$('#ems_rr').value, spo2:$('#ems_spo2').value, sbp:$('#ems_sbp').value, dbp:$('#ems_dbp').value, gksa:$('#ems_gksa').value, gksk:$('#ems_gksk').value, gksm:$('#ems_gksm').value, time:$('#ems_time').value, mechanism:$('#ems_mechanism').value, notes:$('#ems_notes').value };
-  const gksEMS=gksSum(ems.gksa,ems.gksk,ems.gksm);
-  const emsMeta=[ems.time?`GMP ${ems.time}`:null, ems.mechanism?`Mechanizmas: ${ems.mechanism}`:null].filter(Boolean).join('; ');
-  const emsLine=[ems.hr?`ŠSD ${ems.hr}/min`:null, ems.rr?`KD ${ems.rr}/min`:null, ems.spo2?`SpO₂ ${ems.spo2}%`:null, (ems.sbp||ems.dbp)?`AKS ${ems.sbp}/${ems.dbp}`:null, gksEMS?`GKS ${gksEMS} (A${ems.gksa}-K${ems.gksk}-M${ems.gksm})`:null].filter(Boolean).join('; ');
-  out.push('--- Aktyvacija ---'); if(emsMeta) out.push(emsMeta); if(emsLine) out.push(emsLine); if(ems.notes) out.push('Pastabos: '+ems.notes); if(red.length) out.push('RAUDONA: '+red.join(', ')); if(yellow.length) out.push('GELTONA: '+yellow.join(', '));
+  const gmp={ hr:$('#gmp_hr').value, rr:$('#gmp_rr').value, spo2:$('#gmp_spo2').value, sbp:$('#gmp_sbp').value, dbp:$('#gmp_dbp').value, gksa:$('#gmp_gksa').value, gksk:$('#gmp_gksk').value, gksm:$('#gmp_gksm').value, time:$('#gmp_time').value, mechanism:$('#gmp_mechanism').value, notes:$('#gmp_notes').value };
+  const gksGMP=gksSum(gmp.gksa,gmp.gksk,gmp.gksm);
+  const gmpMeta=[gmp.time?`GMP ${gmp.time}`:null, gmp.mechanism?`Mechanizmas: ${gmp.mechanism}`:null].filter(Boolean).join('; ');
+  const gmpLine=[gmp.hr?`ŠSD ${gmp.hr}/min`:null, gmp.rr?`KD ${gmp.rr}/min`:null, gmp.spo2?`SpO₂ ${gmp.spo2}%`:null, (gmp.sbp||gmp.dbp)?`AKS ${gmp.sbp}/${gmp.dbp}`:null, gksGMP?`GKS ${gksGMP} (A${gmp.gksa}-K${gmp.gksk}-M${gmp.gksm})`:null].filter(Boolean).join('; ');
+  out.push('--- Aktyvacija ---'); if(gmpMeta) out.push(gmpMeta); if(gmpLine) out.push(gmpLine); if(gmp.notes) out.push('Pastabos: '+gmp.notes); if(red.length) out.push('RAUDONA: '+red.join(', ')); if(yellow.length) out.push('GELTONA: '+yellow.join(', '));
 
   out.push('\n--- A Kvėpavimo takai ---'); out.push(['Takai: '+(getSingleValue('#a_airway_group')||'-'), $('#a_notes').value?('Pastabos: '+$('#a_notes').value):null].filter(Boolean).join(' | '));
 

--- a/js/autoActivate.js
+++ b/js/autoActivate.js
@@ -1,24 +1,24 @@
 import { $, $$ } from './utils.js';
 import { setChipActive } from './chips.js';
 
-function emsGKS(){
-  const a = +($('#ems_gksa')?.value || 0);
-  const k = +($('#ems_gksk')?.value || 0);
-  const m = +($('#ems_gksm')?.value || 0);
+function gmpGKS(){
+  const a = +($('#gmp_gksa')?.value || 0);
+  const k = +($('#gmp_gksk')?.value || 0);
+  const m = +($('#gmp_gksm')?.value || 0);
   return (a && k && m) ? (a + k + m) : 0;
 }
 
 const autoMap = {
   red: {
-    'AKS < 90 mmHg': () => { const s = +($('#ems_sbp')?.value || 0); return s > 0 && s < 90; },
-    'SpO₂ < 90%': () => { const s = +($('#ems_spo2')?.value || 0); return s > 0 && s < 90; },
-    'KD < 8 ar > 30/min': () => { const r = +($('#ems_rr')?.value || 0); return r > 0 && (r < 8 || r > 30); },
-    'ŠSD > 120/min': () => { const h = +($('#ems_hr')?.value || 0); return h > 120; },
-    'GKS < 9': () => { const g = emsGKS(); return g > 0 && g < 9; }
+      'AKS < 90 mmHg': () => { const s = +($('#gmp_sbp')?.value || 0); return s > 0 && s < 90; },
+      'SpO₂ < 90%': () => { const s = +($('#gmp_spo2')?.value || 0); return s > 0 && s < 90; },
+      'KD < 8 ar > 30/min': () => { const r = +($('#gmp_rr')?.value || 0); return r > 0 && (r < 8 || r > 30); },
+      'ŠSD > 120/min': () => { const h = +($('#gmp_hr')?.value || 0); return h > 120; },
+      'GKS < 9': () => { const g = gmpGKS(); return g > 0 && g < 9; }
   }
 };
 
-function autoActivateFromEMS(){
+function autoActivateFromGMP(){
   const red = $('#chips_red');
   Object.entries(autoMap.red).forEach(([label,fn])=>{
     const chip = $$('.chip', red).find(c=>c.dataset.value===label);
@@ -40,11 +40,11 @@ function autoActivateFromEMS(){
 }
 
 export function initAutoActivate(saveAll){
-  ['#ems_hr','#ems_rr','#ems_spo2','#ems_sbp','#ems_dbp','#ems_gksa','#ems_gksk','#ems_gksm']
+    ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm']
     .forEach(sel=>{
       const el = $(sel);
-      if(el) el.addEventListener('input', ()=>{ autoActivateFromEMS(); if(typeof saveAll==='function') saveAll(); });
+      if(el) el.addEventListener('input', ()=>{ autoActivateFromGMP(); if(typeof saveAll==='function') saveAll(); });
     });
 }
 
-export { autoActivateFromEMS };
+export { autoActivateFromGMP };

--- a/js/autoActivate.test.js
+++ b/js/autoActivate.test.js
@@ -1,21 +1,21 @@
-describe('autoActivateFromEMS', () => {
-  test('activates and deactivates chip based on EMS values', () => {
+describe('autoActivateFromGMP', () => {
+  test('activates and deactivates chip based on GMP values', () => {
     document.body.innerHTML = `
-      <input id="ems_sbp" />
+      <input id="gmp_sbp" />
       <div id="chips_red">
         <button type="button" class="chip red" data-value="AKS < 90 mmHg" aria-pressed="false"></button>
       </div>
     `;
-    const { autoActivateFromEMS } = require('./autoActivate.js');
+    const { autoActivateFromGMP } = require('./autoActivate.js');
     const { isChipActive } = require('./chips.js');
-    const input = document.getElementById('ems_sbp');
+    const input = document.getElementById('gmp_sbp');
     const chip = document.querySelector('#chips_red .chip');
     input.value = '80';
-    autoActivateFromEMS();
+    autoActivateFromGMP();
     expect(isChipActive(chip)).toBe(true);
     expect(chip.dataset.auto).toBe('true');
     input.value = '120';
-    autoActivateFromEMS();
+    autoActivateFromGMP();
     expect(isChipActive(chip)).toBe(false);
     expect(chip.dataset.auto).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- rename EMS labels and fields to GMP in activation form
- update auto activation logic and variables to use GMP naming
- adjust tests for new GMP terminology

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a02d702664832082e9dd290deeff1b