### PR TITLE
Add "Dabar" button for GMP notification time

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       <div class="grid cols-3" style="margin-top:8px">
         <div class="row"><div style="flex:1"><label>EMS AKS s</label><input id="ems_sbp" type="number" min="0" max="300"></div><div style="flex:1"><label>EMS AKS d</label><input id="ems_dbp" type="number" min="0" max="200"></div></div>
         <div><label>EMS GKS (A-K-M)</label><div class="row"><input id="ems_gksa" type="number" min="1" max="4" placeholder="A"><input id="ems_gksk" type="number" min="1" max="5" placeholder="K"><input id="ems_gksm" type="number" min="1" max="6" placeholder="M"></div></div>
-        <div><label>GMP pranešimo laikas</label><input id="ems_time" type="time"></div>
+        <div><label>GMP pranešimo laikas</label><div class="row"><input id="ems_time" type="time" style="flex:1"><button type="button" class="btn" id="btnEmsNow">Dabar</button></div></div>
       </div>
       <div class="grid cols-2" style="margin-top:8px">
         <div><label>Traumos mechanizmas</label><input id="ems_mechanism" type="text"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -192,6 +192,10 @@ function init(){
   initActions(saveAll);
   setupActivationControls();
   document.addEventListener('input', saveAll);
+  $('#btnEmsNow').addEventListener('click', () => {
+    $('#ems_time').value = nowHM();
+    saveAll();
+  });
   $('#btnOxygen').addEventListener('click', ()=>{
     const box = $('#oxygenFields');
     const show = getComputedStyle(box).display === 'none';


### PR DESCRIPTION
## Summary
- add activation page button to fill GMP notification time with current time
- update initialization logic to populate time and save when pressed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a02db878288320a31726563bd254b6