### PR TITLE
feat: auto-fill standard medication doses

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@
         <div><h3 style="margin:0 0 6px;font-size:14px;color:var(--muted)">Medikamentai – kita</h3><div class="grid cols-3" id="other_meds"></div></div>
         <div><h3 style="margin:0 0 6px;font-size:14px;color:var(--muted)">Procedūros</h3><div class="grid cols-3" id="procedures"></div></div>
       </div>
-      <div class="hint" style="margin-top:6px">Paspaudus ant vaisto/procedūros automatiškai užpildomas laikas (galima koreguoti).</div>
+      <div class="hint" style="margin-top:6px">Paspaudus ant vaisto/procedūros automatiškai užpildomi laikas ir standartinė dozė (galima koreguoti).</div>
     </section>
 
     <!-- Vaizdai / Laboratorija / Komanda / Ataskaita -->

--- a/js/actions.js
+++ b/js/actions.js
@@ -5,6 +5,21 @@ export const BLEEDING_MEDS = ['TXA','O- kraujas','Fibryga','Ca gliukonatas'];
 export const OTHER_MEDS = ['Ringerio tirpalas','Noradrenalinas','Metoklopramidas','Ondansetronas'];
 export const PROCS = ['Intubacija','Krikotirotomija','Pleuros drenažas','Adatinė dekompresija','Kūno šildymas','Turniketas','Dubens diržas','Gipsavimas','Siuvimas','Repocizija'];
 
+// Default doses for medications
+export const DEFAULT_DOSES = {
+  'Fentanilis': '100 mcg',
+  'Paracetamolis': '1 g',
+  'Ketoprofenas': '100 mg',
+  'TXA': '1 g',
+  'O- kraujas': '2 V',
+  'Fibryga': '1 g',
+  'Ca gliukonatas': '1 g',
+  'Ringerio tirpalas': '500 ml',
+  'Noradrenalinas': '0.1 µg/kg/min',
+  'Metoklopramidas': '10 mg',
+  'Ondansetronas': '8 mg'
+};
+
 function buildActionCard(group, name, saveAll){
   const card=document.createElement('div');
   card.className='card';
@@ -22,6 +37,7 @@ function buildActionCard(group, name, saveAll){
 
   const chk=card.querySelector('.act_chk');
   const time=card.querySelector('.act_time');
+  const dose=card.querySelector('.act_dose');
   const detail=card.querySelector('.detail');
 
   function update(){
@@ -29,7 +45,14 @@ function buildActionCard(group, name, saveAll){
     else detail.classList.add('collapsed');
   }
 
-  chk.addEventListener('change',()=>{ if(chk.checked && !time.value) time.value=nowHM(); update(); if(typeof saveAll==='function') saveAll(); });
+  chk.addEventListener('change',()=>{
+    if(chk.checked){
+      if(!time.value) time.value=nowHM();
+      if(!dose.value && DEFAULT_DOSES[name]) dose.value = DEFAULT_DOSES[name];
+    }
+    update();
+    if(typeof saveAll==='function') saveAll();
+  });
 
   card.addEventListener('click',e=>{
     if(e.target.closest('label.pill') || e.target.closest('.detail')) return;
@@ -37,7 +60,15 @@ function buildActionCard(group, name, saveAll){
     update();
   });
 
-  card.querySelector('label.pill').addEventListener('click',()=>{ setTimeout(()=>{ if(chk.checked && !time.value){ time.value=nowHM(); if(typeof saveAll==='function') saveAll(); }},0);});
+  card.querySelector('label.pill').addEventListener('click',()=>{
+    setTimeout(()=>{
+      if(chk.checked){
+        if(!time.value) time.value=nowHM();
+        if(!dose.value && DEFAULT_DOSES[name]) dose.value = DEFAULT_DOSES[name];
+        if(typeof saveAll==='function') saveAll();
+      }
+    },0);
+  });
 
   update();
   return card;

--- a/js/actions.test.js
+++ b/js/actions.test.js
@@ -1,0 +1,48 @@
+import { DEFAULT_DOSES, initActions } from './actions.js';
+
+describe('initActions default doses', () => {
+  test('fills default dose on check and allows edits', () => {
+    document.body.innerHTML = `
+      <div id="pain_meds"></div>
+      <div id="bleeding_meds"></div>
+      <div id="other_meds"></div>
+      <div id="procedures"></div>
+      <input id="medSearch" />
+    `;
+    initActions(() => {});
+    const card = [...document.querySelectorAll('#pain_meds .card')]
+      .find(c => c.querySelector('label').textContent.includes('Fentanilis'));
+    const chk = card.querySelector('.act_chk');
+    const dose = card.querySelector('.act_dose');
+    chk.checked = true;
+    chk.dispatchEvent(new Event('change'));
+    expect(dose.value).toBe(DEFAULT_DOSES['Fentanilis']);
+    dose.value = '150 mcg';
+    chk.checked = false;
+    chk.dispatchEvent(new Event('change'));
+    chk.checked = true;
+    chk.dispatchEvent(new Event('change'));
+    expect(dose.value).toBe('150 mcg');
+  });
+
+  test.each(['O- kraujas', 'Ondansetronas'])(
+    'fills default dose for %s',
+    (med) => {
+      document.body.innerHTML = `
+        <div id="pain_meds"></div>
+        <div id="bleeding_meds"></div>
+        <div id="other_meds"></div>
+        <div id="procedures"></div>
+        <input id="medSearch" />
+      `;
+      initActions(() => {});
+      const card = [...document.querySelectorAll('.card')]
+        .find(c => c.querySelector('label').textContent.includes(med));
+      const chk = card.querySelector('.act_chk');
+      const dose = card.querySelector('.act_dose');
+      chk.checked = true;
+      chk.dispatchEvent(new Event('change'));
+      expect(dose.value).toBe(DEFAULT_DOSES[med]);
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- auto-populate standard doses when medications are checked
- clarify hint about automatic time and dose entry
- test default dose prefill behavior
- adjust default blood and ondansetron doses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a02dfbf1e08320871505a4a708e2c8