### PR TITLE
Add 'Now' button for GMP notification time

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       <div class="grid cols-3" style="margin-top:8px">
           <div class="row"><div style="flex:1"><label>GMP AKS s</label><input id="gmp_sbp" type="number" min="0" max="300"></div><div style="flex:1"><label>GMP AKS d</label><input id="gmp_dbp" type="number" min="0" max="200"></div></div>
           <div><label>GMP GKS (A-K-M)</label><div class="row"><input id="gmp_gksa" type="number" min="1" max="4" placeholder="A"><input id="gmp_gksk" type="number" min="1" max="5" placeholder="K"><input id="gmp_gksm" type="number" min="1" max="6" placeholder="M"></div></div>
-          <div><label>GMP pranešimo laikas</label><input id="gmp_time" type="time"></div>
+          <div><label>GMP pranešimo laikas</label><div class="row" style="gap:8px;align-items:center;"><input id="gmp_time" type="time"><button type="button" class="btn ghost" id="btnGmpNow">Dabar</button></div></div>
       </div>
       <div class="grid cols-2" style="margin-top:8px">
           <div><label>Traumos mechanizmas</label><input id="gmp_mechanism" type="text"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -194,6 +194,7 @@ function init(){
   initActions(saveAll);
   setupActivationControls();
   document.addEventListener('input', saveAll);
+  $('#btnGmpNow').addEventListener('click', ()=>{ $('#gmp_time').value=nowHM(); saveAll(); });
   $('#btnOxygen').addEventListener('click', ()=>{
     const box = $('#oxygenFields');
     const show = getComputedStyle(box).display === 'none';


### PR DESCRIPTION
## Summary
- add a "Dabar" button next to GMP notification time
- clicking button fills time with current system time

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a02fd3a6f883209599696f513aec48