### PR TITLE
Place Ataskaita tab last

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,11 +264,10 @@
       <div class="hint" style="margin-top:6px">Paspaudus ant vaisto/procedūros automatiškai užpildomi laikas ir standartinė dozė (galima koreguoti).</div>
     </section>
 
-    <!-- Vaizdai / Laboratorija / Komanda / Ataskaita -->
+    <!-- Vaizdai / Laboratorija / Komanda / Sprendimas / Ataskaita -->
     <section class="card view" data-tab="Vaizdiniai tyrimai"><h2>Vaizdiniai tyrimai</h2><div class="chip-group" id="imaging_basic"></div><h3 style="margin-top:12px;font-size:14px;color:var(--muted)">FAST</h3><div class="grid cols-3" id="fastGrid"></div></section>
     <section class="card view" data-tab="Laboratorija"><h2>Laboratoriniai tyrimai</h2><div class="chip-group" id="labs_basic"></div></section>
     <section class="card view" data-tab="Komanda"><h2>Komandos nariai</h2><div class="grid cols-3" id="teamGrid"></div></section>
-    <section class="card view" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Spauskite „Sugeneruoti ataskaitą“..."></textarea><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
     <section class="card view" data-tab="Sprendimas">
       <h2>Sprendimas</h2>
       <div><label>Laikas</label><input id="spr_time" type="time"></div>
@@ -308,6 +307,7 @@
         <div style="flex:1"><label>AKS d</label><input id="spr_dbp" type="number" min="0" max="200"></div>
       </div>
     </section>
+    <section class="card view" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Spauskite „Sugeneruoti ataskaitą“..."></textarea><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
   </div>
 </main>
 

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -11,8 +11,8 @@ export const TABS = [
   { name: 'Vaizdiniai tyrimai', icon: '☢️' },
   { name: 'Laboratorija', icon: '🧪' },
   { name: 'Komanda', icon: '👥' },
-  { name: 'Ataskaita', icon: '📝' },
-  { name: 'Sprendimas', icon: '⚖️' }
+  { name: 'Sprendimas', icon: '⚖️' },
+  { name: 'Ataskaita', icon: '📝' }
 ];
 
 export const TAB_NAMES = TABS.map(t => t.name);


### PR DESCRIPTION
## Summary
- Move "Sprendimas" ahead of "Ataskaita" in tab list so "Ataskaita" renders last.
- Reorder corresponding sections in `index.html` to match new tab ordering.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a036ee9f908320a7543557e48fb43b