### PR TITLE
Add responsive two-column layout for consciousness section

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -85,7 +85,7 @@ label.chip input{
 .hidden{display:none}
 .detail{overflow:hidden;max-height:200px;opacity:1;transition:max-height .3s ease,opacity .3s ease}
 .collapsed{max-height:0;opacity:0;pointer-events:none}
-@media (max-width:980px){ main{grid-template-columns:1fr} nav{position:static} .cols-3{grid-template-columns:1fr 1fr} }
+@media (max-width:980px){ main{grid-template-columns:1fr} nav{position:static} .cols-3{grid-template-columns:1fr 1fr} .cols-2{grid-template-columns:1fr} }
 @media print{ header,nav,.toolbar{display:none!important} body{background:#fff;color:#000} section.card{break-inside:avoid} }
 
 /* Interventions compact layout */

--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
     <!-- D -->
     <section class="card view" data-tab="D – Sąmonė">
       <h2>D – Sąmonė</h2>
-      <div class="grid">
+      <div class="grid cols-2">
         <div>
           <label>GKS (A-K-M) <span class="subtle">(15b. mygtukas užpildo 4/5/6)</span></label>
           <div class="row">


### PR DESCRIPTION
## Summary
- switch consciousness section container to two-column grid
- collapse two-column grids to one column on small screens for better responsiveness

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a03a87b2e88320964438c95913066e