### PR TITLE
feat: add custom imaging entry option

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@
     </section>
 
     <!-- Vaizdai / Laboratorija / Komanda / Sprendimas / Ataskaita -->
-    <section class="card view" data-tab="Vaizdiniai tyrimai"><h2>Vaizdiniai tyrimai</h2><div class="chip-group" id="imaging_basic"></div><h3 style="margin-top:12px;font-size:14px;color:var(--muted)">FAST</h3><div class="grid cols-3" id="fastGrid"></div></section>
+    <section class="card view" data-tab="Vaizdiniai tyrimai"><h2>Vaizdiniai tyrimai</h2><div class="chip-group" id="imaging_basic"></div><input id="imaging_other" type="text" placeholder="Įvesti kitą tyrimą" style="display:none;margin-top:8px;"><h3 style="margin-top:12px;font-size:14px;color:var(--muted)">FAST</h3><div class="grid cols-3" id="fastGrid"></div></section>
     <section class="card view" data-tab="Laboratorija"><h2>Laboratoriniai tyrimai</h2><div class="chip-group" id="labs_basic"></div></section>
     <section class="card view" data-tab="Komanda"><h2>Komandos nariai</h2><div class="grid cols-3" id="teamGrid"></div></section>
     <section class="card view" data-tab="Sprendimas">

--- a/js/app.js
+++ b/js/app.js
@@ -5,7 +5,7 @@ import { initAutoActivate } from './autoActivate.js';
 import { initActions } from './actions.js';
 
 /* ===== Imaging / Labs / Team ===== */
-const IMG=['Galvos KT','Kaklo KT','Viso kūno KT','Krūtinės Ro','Dubens Ro'];
+const IMG=['Galvos KT','Kaklo KT','Viso kūno KT','Krūtinės Ro','Dubens Ro','Kita'];
 const LABS=['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
 const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas','Radiologas'];
 
@@ -178,6 +178,7 @@ function loadAll(){
     $('#spr_skyrius_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Stacionarizavimas'))?'block':'none';
     $('#spr_ligonine_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Pervežimas į kitą ligoninę'))?'block':'none';
     $('#spr_skyrius_kita').style.display = ($('#spr_skyrius').value === 'Kita') ? 'block' : 'none';
+    $('#imaging_other').style.display = ($$('.chip.active', $('#imaging_basic')).some(c=>c.dataset.value==='Kita'))?'block':'none';
     ensureSingleTeam();
     updateActivationIndicator();
   }catch(e){}
@@ -269,7 +270,14 @@ document.getElementById('btnGen').addEventListener('click',()=>{
     if(procs.length) out.push('Procedūros:\n'+procs.join('\n'));
   }
 
-  const imgs=listChips('#imaging_basic'); const fr=fastAreas.map(a=>{ const y=document.querySelector('input[name="fast_'+a+'"][value="Yra"]')?.checked; const n=document.querySelector('input[name="fast_'+a+'"][value="Nėra"]')?.checked; return y? a+': skystis Yra' : (n? a+': skystis Nėra' : null); }).filter(Boolean);
+  let imgs=listChips('#imaging_basic');
+  const otherIdx=imgs.indexOf('Kita');
+  if(otherIdx>=0){
+    imgs.splice(otherIdx,1);
+    const other=$('#imaging_other').value.trim();
+    if(other) imgs.push(other);
+  }
+  const fr=fastAreas.map(a=>{ const y=document.querySelector('input[name="fast_'+a+'"][value="Yra"]')?.checked; const n=document.querySelector('input[name="fast_'+a+'"][value="Nėra"]')?.checked; return y? a+': skystis Yra' : (n? a+': skystis Nėra' : null); }).filter(Boolean);
   if(imgs.length||fr.length){ out.push('\n--- Vaizdiniai tyrimai ---'); if(imgs.length) out.push('Užsakyta: '+imgs.join(', ')); if(fr.length) out.push('FAST: '+fr.join(' | ')); }
 
   const labs=listChips('#labs_basic'); if(labs.length){ out.push('\n--- Laboratorija ---'); out.push(labs.join(', ')); }

--- a/js/chips.js
+++ b/js/chips.js
@@ -39,6 +39,13 @@ export function initChips(saveAll){
       $('#d_pupil_right_note').style.display = (chip.dataset.value==='kita' && isChipActive(chip)) ? 'block' : 'none';
       if(chip.dataset.value!=='kita') $('#d_pupil_right_note').value='';
     }
+    if(group.id==='imaging_basic'){
+      const otherChip=$$('.chip', group).find(c=>c.dataset.value==='Kita');
+      const box=$('#imaging_other');
+      const show=otherChip && isChipActive(otherChip);
+      box.style.display = show ? 'block' : 'none';
+      if(!show) box.value='';
+    }
       if(group.id==='spr_decision_group'){
         const showSky = chip.dataset.value==='Stacionarizavimas' && isChipActive(chip);
         const boxSky = $('#spr_skyrius_container');

--- a/js/chips.test.js
+++ b/js/chips.test.js
@@ -35,4 +35,24 @@ describe('chips', () => {
     otherChip.click();
     expect(container.style.display).toBe('none');
   });
+
+  test('shows other imaging field when "Kita" selected', () => {
+    document.body.innerHTML = `
+      <div id="imaging_basic">
+        <span class="chip" data-value="Galvos KT"></span>
+        <span class="chip" data-value="Kita"></span>
+      </div>
+      <input id="imaging_other" style="display:none;" />
+    `;
+    const { initChips } = require('./chips.js');
+    initChips();
+    const [normalChip, otherChip] = document.querySelectorAll('#imaging_basic .chip');
+    const box = document.getElementById('imaging_other');
+    otherChip.click();
+    expect(box.style.display).toBe('block');
+    otherChip.click();
+    expect(box.style.display).toBe('none');
+    normalChip.click();
+    expect(box.style.display).toBe('none');
+  });
 });


### PR DESCRIPTION
## Summary
- allow specifying custom imaging study via new "Kita" chip and input
- include custom imaging in generated report and local storage persistence
- test that custom imaging field toggles correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a03a71214c8320b30b22e0ad9b3078