### PR TITLE
Refactor pupil note toggle logic

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -17,6 +17,13 @@ export function setChipActive(chip, active){
   chip.classList.toggle('active', active);
 }
 
+function togglePupilNote(side, chip){
+  const note = $(`#d_pupil_${side}_note`);
+  const show = chip.dataset.value==='kita' && isChipActive(chip);
+  note.style.display = show ? 'block' : 'none';
+  if(chip.dataset.value!=='kita') note.value='';
+}
+
 export function initChips(saveAll){
   document.addEventListener('click', e => {
     const chip = e.target.closest('.chip');
@@ -32,12 +39,10 @@ export function initChips(saveAll){
     }
 
     if(group.id==='d_pupil_left_group'){
-      $('#d_pupil_left_note').style.display = (chip.dataset.value==='kita' && isChipActive(chip)) ? 'block' : 'none';
-      if(chip.dataset.value!=='kita') $('#d_pupil_left_note').value='';
+      togglePupilNote('left', chip);
     }
     if(group.id==='d_pupil_right_group'){
-      $('#d_pupil_right_note').style.display = (chip.dataset.value==='kita' && isChipActive(chip)) ? 'block' : 'none';
-      if(chip.dataset.value!=='kita') $('#d_pupil_right_note').value='';
+      togglePupilNote('right', chip);
     }
       if(group.id==='spr_decision_group'){
         const showSky = chip.dataset.value==='Stacionarizavimas' && isChipActive(chip);

--- a/js/chips.test.js
+++ b/js/chips.test.js
@@ -35,4 +35,24 @@ describe('chips', () => {
     otherChip.click();
     expect(container.style.display).toBe('none');
   });
+
+  test('toggles pupil note visibility and clears value', () => {
+    document.body.innerHTML = `
+      <div id="d_pupil_left_group" data-single="true">
+        <button type="button" class="chip" data-value="n.y." aria-pressed="false"></button>
+        <button type="button" class="chip" data-value="kita" aria-pressed="false"></button>
+      </div>
+      <input id="d_pupil_left_note" style="display:none" />
+    `;
+    const { initChips } = require('./chips.js');
+    initChips();
+    const [nyChip, kitaChip] = document.querySelectorAll('#d_pupil_left_group .chip');
+    const note = document.getElementById('d_pupil_left_note');
+    kitaChip.click();
+    expect(note.style.display).toBe('block');
+    note.value = 'test';
+    nyChip.click();
+    expect(note.style.display).toBe('none');
+    expect(note.value).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- factor out pupil note toggle logic into helper
- ensure notes clear when other options are chosen
- add tests for pupil note toggling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a03a9f7c7483208c566822d674a98f