### PR TITLE
Generate full report when printing

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       <button type="button" class="btn" id="btnCopy">Kopijuoti</button>
       <button type="button" class="btn" id="btnSave">Išsaugoti</button>
       <button type="button" class="btn ghost" id="btnClear">Išvalyti</button>
-      <button type="button" class="btn warn" onclick="window.print()">🖨 Spausdinti</button>
+      <button type="button" class="btn warn" id="btnPrint">🖨 Spausdinti</button>
     </div>
   </div>
 </header>

--- a/js/app.js
+++ b/js/app.js
@@ -307,3 +307,9 @@ document.getElementById('btnGen').addEventListener('click',()=>{
 document.getElementById('btnCopy').addEventListener('click',async()=>{ try{ await navigator.clipboard.writeText($('#output').value||''); alert('Nukopijuota.'); }catch(e){ alert('Nepavyko nukopijuoti.'); }});
 document.getElementById('btnSave').addEventListener('click',()=>{ saveAll(); alert('Išsaugota naršyklėje.');});
 document.getElementById('btnClear').addEventListener('click',()=>{ if(confirm('Išvalyti viską?')){ localStorage.removeItem('trauma_v9'); location.reload(); }});
+document.getElementById('btnPrint').addEventListener('click',()=>{
+  const prevTab=localStorage.getItem('v9_activeTab');
+  document.getElementById('btnGen').click();
+  window.print();
+  if(prevTab) showTab(prevTab);
+});


### PR DESCRIPTION
## Summary
- Ensure print button triggers report generation before invoking the browser print dialog.
- Swap inline print handler for a dedicated `btnPrint` button.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a03ad18d688320a7f4865389a881d9