### PR TITLE
Add GKS input to decision view

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,14 @@
         <div style="flex:1"><label>AKS s</label><input id="spr_sbp" type="number" min="0" max="300"></div>
         <div style="flex:1"><label>AKS d</label><input id="spr_dbp" type="number" min="0" max="200"></div>
       </div>
+      <div style="margin-top:8px">
+        <label>GKS (A-K-M)</label>
+        <div class="row">
+          <input id="spr_gksa" type="number" min="1" max="4" placeholder="A">
+          <input id="spr_gksk" type="number" min="1" max="5" placeholder="K">
+          <input id="spr_gksm" type="number" min="1" max="6" placeholder="M">
+        </div>
+      </div>
     </section>
     <section class="card view" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Spauskite „Sugeneruoti ataskaitą“..."></textarea><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
   </div>

--- a/js/app.js
+++ b/js/app.js
@@ -283,11 +283,13 @@ document.getElementById('btnGen').addEventListener('click',()=>{
     const sprLigonine = sprDecision==='Pervežimas į kitą ligoninę'
       ? $('#spr_ligonine').value
       : '';
+    const sprGks=gksSum($('#spr_gksa').value,$('#spr_gksk').value,$('#spr_gksm').value);
     const sprVitals=[
       $('#spr_hr').value?('ŠSD '+$('#spr_hr').value+'/min'):null,
       $('#spr_rr').value?('KD '+$('#spr_rr').value+'/min'):null,
       $('#spr_spo2').value?('SpO₂ '+$('#spr_spo2').value+'%'):null,
-      ($('#spr_sbp').value||$('#spr_dbp').value)?('AKS '+$('#spr_sbp').value+'/'+$('#spr_dbp').value):null
+      ($('#spr_sbp').value||$('#spr_dbp').value)?('AKS '+$('#spr_sbp').value+'/'+$('#spr_dbp').value):null,
+      sprGks?(`GKS ${sprGks} (A${$('#spr_gksa').value}-K${$('#spr_gksk').value}-M${$('#spr_gksm').value})`):null
     ].filter(Boolean).join('; ');
     if(sprDecision || $('#spr_time').value || sprVitals){
       out.push('\n--- Sprendimas ---');


### PR DESCRIPTION
## Summary
- add GKS (A-K-M) inputs to decision section
- include decision GKS values in generated summary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a03b59856883208ec0c8cc1eb5d0ce