### PR TITLE
Improve pupil selection accessibility with radio fieldsets

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,13 +145,31 @@
         </div>
         <div class="grid cols-2">
           <div>
-            <label>Vyzdžiai – Kairė</label>
-            <div class="chip-group" id="d_pupil_left_group" data-single="true"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip" data-value="kita" aria-pressed="false">kita</button></div>
+            <fieldset class="chip-group" id="d_pupil_left_group" style="border:0;padding:0;margin:0">
+              <legend>Vyzdžiai – Kairė</legend>
+              <label class="chip" data-value="n.y.">
+                <input type="radio" name="d_pupil_left" value="n.y.">
+                n.y.
+              </label>
+              <label class="chip" data-value="kita">
+                <input type="radio" name="d_pupil_left" value="kita">
+                kita
+              </label>
+            </fieldset>
             <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." style="margin-top:6px;display:none">
           </div>
           <div>
-            <label>Vyzdžiai – Dešinė</label>
-            <div class="chip-group" id="d_pupil_right_group" data-single="true"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip" data-value="kita" aria-pressed="false">kita</button></div>
+            <fieldset class="chip-group" id="d_pupil_right_group" style="border:0;padding:0;margin:0">
+              <legend>Vyzdžiai – Dešinė</legend>
+              <label class="chip" data-value="n.y.">
+                <input type="radio" name="d_pupil_right" value="n.y.">
+                n.y.
+              </label>
+              <label class="chip" data-value="kita">
+                <input type="radio" name="d_pupil_right" value="kita">
+                kita
+              </label>
+            </fieldset>
             <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." style="margin-top:6px;display:none">
           </div>
         </div>

--- a/js/chips.js
+++ b/js/chips.js
@@ -21,6 +21,9 @@ export function initChips(saveAll){
   document.addEventListener('click', e => {
     const chip = e.target.closest('.chip');
     if(!chip) return;
+    const input = chip.querySelector('input');
+    if(input && input.type === 'radio') return; // radios handled natively
+
     const group = chip.parentElement;
     const single = group?.dataset?.single === 'true';
 
@@ -31,34 +34,47 @@ export function initChips(saveAll){
       setChipActive(chip, !isChipActive(chip));
     }
 
-    if(group.id==='d_pupil_left_group'){
-      $('#d_pupil_left_note').style.display = (chip.dataset.value==='kita' && isChipActive(chip)) ? 'block' : 'none';
-      if(chip.dataset.value!=='kita') $('#d_pupil_left_note').value='';
-    }
-    if(group.id==='d_pupil_right_group'){
-      $('#d_pupil_right_note').style.display = (chip.dataset.value==='kita' && isChipActive(chip)) ? 'block' : 'none';
-      if(chip.dataset.value!=='kita') $('#d_pupil_right_note').value='';
-    }
-      if(group.id==='spr_decision_group'){
-        const showSky = chip.dataset.value==='Stacionarizavimas' && isChipActive(chip);
-        const boxSky = $('#spr_skyrius_container');
-        boxSky.style.display = showSky ? 'block' : 'none';
-        if(!showSky){
-          $('#spr_skyrius').value='';
-          $('#spr_skyrius_kita').style.display='none';
-          $('#spr_skyrius_kita').value='';
-        }
-
-        const showHosp = chip.dataset.value==='Pervežimas į kitą ligoninę' && isChipActive(chip);
-        const boxHosp = $('#spr_ligonine_container');
-        boxHosp.style.display = showHosp ? 'block' : 'none';
-        if(!showHosp){
-          $('#spr_ligonine').value='';
-        }
+    if(group.id==='spr_decision_group'){
+      const showSky = chip.dataset.value==='Stacionarizavimas' && isChipActive(chip);
+      const boxSky = $('#spr_skyrius_container');
+      boxSky.style.display = showSky ? 'block' : 'none';
+      if(!showSky){
+        $('#spr_skyrius').value='';
+        $('#spr_skyrius_kita').style.display='none';
+        $('#spr_skyrius_kita').value='';
       }
+
+      const showHosp = chip.dataset.value==='Pervežimas į kitą ligoninę' && isChipActive(chip);
+      const boxHosp = $('#spr_ligonine_container');
+      boxHosp.style.display = showHosp ? 'block' : 'none';
+      if(!showHosp){
+        $('#spr_ligonine').value='';
+      }
+    }
     delete chip.dataset.auto;
     if(typeof saveAll === 'function') saveAll();
   }, true);
+
+  document.addEventListener('change', e => {
+    const input = e.target;
+    if(input.type !== 'radio') return;
+    const chip = input.closest('.chip');
+    const group = chip?.parentElement;
+    if(!group) return;
+    $$('input[type="radio"]', group).forEach(r => {
+      const parent = r.closest('.chip');
+      parent.classList.toggle('active', r.checked);
+    });
+    if(group.id==='d_pupil_left_group'){
+      $('#d_pupil_left_note').style.display = input.value==='kita' ? 'block' : 'none';
+      if(input.value!=='kita') $('#d_pupil_left_note').value='';
+    }
+    if(group.id==='d_pupil_right_group'){
+      $('#d_pupil_right_note').style.display = input.value==='kita' ? 'block' : 'none';
+      if(input.value!=='kita') $('#d_pupil_right_note').value='';
+    }
+    if(typeof saveAll === 'function') saveAll();
+  });
 }
 
 export function listChips(sel){


### PR DESCRIPTION
## Summary
- Replace pupil chip buttons with fieldset-based radio inputs styled as chips
- Simplify chip handling to rely on native radio behaviour and show notes for "kita"

## Testing
- `npm test`
- `npx @axe-core/cli index.html` *(no output)*
- `node -e "const fs=require('fs'); const {JSDOM}=require('jsdom'); const dom=new JSDOM(fs.readFileSync('index.html','utf8')); ['d_pupil_left_group','d_pupil_right_group'].forEach(id=>{ const fsEl=dom.window.document.getElementById(id); console.log(id, fsEl.tagName, fsEl.querySelectorAll('input[type=radio]').length);});"`


------
https://chatgpt.com/codex/tasks/task_e_68a03a97d36c8320b8ff5520a4ee8b7e