### PR TITLE
refactor pupil note toggling

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -17,6 +17,15 @@ export function setChipActive(chip, active){
   chip.classList.toggle('active', active);
 }
 
+function togglePupilNote(side, chip){
+  const groupId = `d_pupil_${side}_group`;
+  if(chip.parentElement?.id !== groupId) return;
+  const note = $(`#d_pupil_${side}_note`);
+  const show = chip.dataset.value==='kita' && isChipActive(chip);
+  note.style.display = show ? 'block' : 'none';
+  if(!show) note.value='';
+}
+
 export function initChips(saveAll){
   document.addEventListener('click', e => {
     const chip = e.target.closest('.chip');
@@ -30,15 +39,8 @@ export function initChips(saveAll){
     } else {
       setChipActive(chip, !isChipActive(chip));
     }
-
-    if(group.id==='d_pupil_left_group'){
-      $('#d_pupil_left_note').style.display = (chip.dataset.value==='kita' && isChipActive(chip)) ? 'block' : 'none';
-      if(chip.dataset.value!=='kita') $('#d_pupil_left_note').value='';
-    }
-    if(group.id==='d_pupil_right_group'){
-      $('#d_pupil_right_note').style.display = (chip.dataset.value==='kita' && isChipActive(chip)) ? 'block' : 'none';
-      if(chip.dataset.value!=='kita') $('#d_pupil_right_note').value='';
-    }
+    togglePupilNote('left', chip);
+    togglePupilNote('right', chip);
     if(group.id==='imaging_basic'){
       const otherChip=$$('.chip', group).find(c=>c.dataset.value==='Kita');
       const box=$('#imaging_other');

--- a/js/chips.test.js
+++ b/js/chips.test.js
@@ -55,4 +55,24 @@ describe('chips', () => {
     normalChip.click();
     expect(box.style.display).toBe('none');
   });
+
+  test('toggles pupil note visibility and clears value when switching options', () => {
+    document.body.innerHTML = `
+      <div id="d_pupil_left_group" data-single="true">
+        <button type="button" class="chip" data-value="n.y." aria-pressed="false"></button>
+        <button type="button" class="chip" data-value="kita" aria-pressed="false"></button>
+      </div>
+      <input id="d_pupil_left_note" style="display:none;" />
+    `;
+    const { initChips } = require('./chips.js');
+    initChips();
+    const [nyChip, otherChip] = document.querySelectorAll('#d_pupil_left_group .chip');
+    const note = document.getElementById('d_pupil_left_note');
+    otherChip.click();
+    expect(note.style.display).toBe('block');
+    note.value = 'test';
+    nyChip.click();
+    expect(note.style.display).toBe('none');
+    expect(note.value).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- add togglePupilNote helper to show/hide pupil note inputs
- replace duplicate pupil note logic with helper calls
- test pupil note toggle clears value when switching options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a03c5f83948320a44709ea7e3ca383