### PR TITLE
Show intervention icons only next to section titles

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -93,4 +93,3 @@ section[data-tab="Intervencijos"] .split{gap:8px}
 section[data-tab="Intervencijos"] .card{padding:6px}
 section[data-tab="Intervencijos"] .card .grid{gap:6px}
 section[data-tab="Intervencijos"] h3{display:flex;align-items:center;gap:4px}
-section[data-tab="Intervencijos"] .act_icon{font-size:16px}

--- a/js/actions.js
+++ b/js/actions.js
@@ -25,9 +25,8 @@ function buildActionCard(group, name, saveAll){
   card.className='card';
   card.style.padding='6px';
   card.style.borderRadius='10px';
-  const slug=name.toLowerCase().replace(/\s+/g,'_').replace(/[^a-z0-9_]/g,'');
-  const icon = group==='med'?'💊':'🛠';
-  card.innerHTML=`<label class="pill"><input type="checkbox" class="act_chk" data-field="${group}_${slug}_chk"> <span class="act_icon">${icon}</span><span class="act_name">${name}</span></label>
+    const slug=name.toLowerCase().replace(/\s+/g,'_').replace(/[^a-z0-9_]/g,'');
+    card.innerHTML=`<label class="pill"><input type="checkbox" class="act_chk" data-field="${group}_${slug}_chk"><span class="act_name">${name}</span></label>
     <div class="detail collapsed">
       <div class="grid cols-3" style="margin-top:4px">
         <div><label>Laikas</label><input type="time" class="act_time" data-field="${group}_${slug}_time"></div>


### PR DESCRIPTION
## Summary
- remove per-item icons from intervention cards
- drop unused intervention icon styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a03ecd83bc8320b1c8a6fee02621d0