### PR TITLE
Refine D – Sąmonė section layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -33,6 +33,7 @@ input::placeholder,
 textarea::placeholder{color:var(--muted)}
 textarea{min-height:80px;resize:vertical}
 .row{display:flex;gap:8px;align-items:center}
+#d_gks_total{margin-left:auto;font-weight:700}
 .pill{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid var(--line);border-radius:999px;background:#152231;color:#fff;font-weight:700}
 .chip{
   display:inline-flex;

--- a/index.html
+++ b/index.html
@@ -133,29 +133,29 @@
     <!-- D -->
     <section class="card view" data-tab="D – Sąmonė">
       <h2>D – Sąmonė</h2>
-      <div class="grid cols-2">
+      <div class="grid cols-3">
         <div>
           <label>GKS (A-K-M) <span class="subtle">(15b. mygtukas užpildo 4/5/6)</span></label>
           <div class="row">
               <input id="d_gksa" type="number" min="1" max="4" placeholder="A">
               <input id="d_gksk" type="number" min="1" max="5" placeholder="K">
               <input id="d_gksm" type="number" min="1" max="6" placeholder="M">
+          </div>
+          <div class="row">
               <button type="button" class="btn" id="btnGCS15">15b.</button>
               <button type="button" class="btn" id="btnGCSCalc">Skaičiuoti</button>
               <span id="d_gks_total"></span>
-            </div>
+          </div>
         </div>
-        <div class="grid cols-2">
-          <div>
-            <label>Vyzdžiai – Kairė</label>
-            <div class="chip-group" id="d_pupil_left_group" data-single="true"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip" data-value="kita" aria-pressed="false">kita</button></div>
-            <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." style="margin-top:6px;display:none">
-          </div>
-          <div>
-            <label>Vyzdžiai – Dešinė</label>
-            <div class="chip-group" id="d_pupil_right_group" data-single="true"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip" data-value="kita" aria-pressed="false">kita</button></div>
-            <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." style="margin-top:6px;display:none">
-          </div>
+        <div>
+          <label>Vyzdžiai – Kairė</label>
+          <div class="chip-group" id="d_pupil_left_group" data-single="true"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip" data-value="kita" aria-pressed="false">kita</button></div>
+          <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." style="margin-top:6px;display:none">
+        </div>
+        <div>
+          <label>Vyzdžiai – Dešinė</label>
+          <div class="chip-group" id="d_pupil_right_group" data-single="true"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip" data-value="kita" aria-pressed="false">kita</button></div>
+          <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." style="margin-top:6px;display:none">
         </div>
       </div>
       <div class="row" style="margin-top:8px"><label style="margin:0">Pastabos</label><input id="d_notes" type="text" placeholder="Trumpai..."></div>


### PR DESCRIPTION
## Summary
- reorganize D – Sąmonė view into three-column grid
- separate GKS inputs from action buttons and show total on the right

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0468ffff08320ae10856638a41a42