### PR TITLE
Show total GKS on GMP activation page

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       </div>
       <div class="grid cols-3" style="margin-top:8px">
           <div class="row"><div style="flex:1"><label>GMP AKS s</label><input id="gmp_sbp" type="number" min="0" max="300"></div><div style="flex:1"><label>GMP AKS d</label><input id="gmp_dbp" type="number" min="0" max="200"></div></div>
-          <div><label>GMP GKS (A-K-M)</label><div class="row"><input id="gmp_gksa" type="number" min="1" max="4" placeholder="A"><input id="gmp_gksk" type="number" min="1" max="5" placeholder="K"><input id="gmp_gksm" type="number" min="1" max="6" placeholder="M"></div></div>
+          <div><label>GMP GKS (A-K-M)</label><div class="row"><input id="gmp_gksa" type="number" min="1" max="4" placeholder="A"><input id="gmp_gksk" type="number" min="1" max="5" placeholder="K"><input id="gmp_gksm" type="number" min="1" max="6" placeholder="M"><span id="gmp_gks_total"></span></div></div>
           <div><label>GMP pranešimo laikas</label><div class="row" style="gap:8px;align-items:center;"><input id="gmp_time" type="time"><button type="button" class="btn ghost" id="btnGmpNow">Dabar</button></div></div>
       </div>
       <div class="grid cols-2" style="margin-top:8px">

--- a/js/app.js
+++ b/js/app.js
@@ -233,10 +233,14 @@ function init(){
     initActions(saveAll);
     setupActivationControls();
     document.addEventListener('input', saveAll);
-    const updateGksTotal=()=>{
+    const updateDGksTotal=()=>{
       $('#d_gks_total').textContent=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value);
     };
-    ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).addEventListener('input', updateGksTotal));
+    ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).addEventListener('input', updateDGksTotal));
+    const updateGmpGksTotal=()=>{
+      $('#gmp_gks_total').textContent=gksSum($('#gmp_gksa').value,$('#gmp_gksk').value,$('#gmp_gksm').value);
+    };
+    ['#gmp_gksa','#gmp_gksk','#gmp_gksm'].forEach(sel=>$(sel).addEventListener('input', updateGmpGksTotal));
     $('#btnGmpNow').addEventListener('click', ()=>{ $('#gmp_time').value=nowHM(); saveAll(); });
   $('#btnOxygen').addEventListener('click', ()=>{
     const box = $('#oxygenFields');
@@ -257,7 +261,8 @@ function init(){
       saveAll();
     });
     loadAll();
-    updateGksTotal();
+    updateDGksTotal();
+    updateGmpGksTotal();
   }
   init();
 


### PR DESCRIPTION
## Summary
- Display summed GKS value in GMP activation section
- Calculate and update GMP GKS total automatically on input

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a046dca524832082679095883301ab