### PR TITLE
Add limits for vital parameter inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
         <div class="row" style="gap:8px;align-items:center;">
           <button type="button" class="btn" id="btnOxygen">O2</button>
           <div id="oxygenFields" class="row" style="display:none;gap:8px;">
-            <input id="b_oxygen_liters" type="number" min="0" placeholder="L/min" style="width:80px">
+            <input id="b_oxygen_liters" type="number" min="0" max="25" placeholder="L/min" style="width:80px">
             <select id="b_oxygen_type">
               <option value="Kaukė su rez.">Kaukė su rez.</option>
               <option value="Kaukė">Kaukė</option>

--- a/js/app.js
+++ b/js/app.js
@@ -225,6 +225,26 @@ $('#btnGCSCalc').addEventListener('click',()=>{
 });
 $('#e_back_ny').addEventListener('change',e=>{ $('#e_back_notes').disabled=e.target.checked; if(e.target.checked) $('#e_back_notes').value=''; saveAll();});
 
+function clampNumberInputs(){
+  const clamp=el=>{
+    if(el.value==='') return;
+    const min=el.getAttribute('min');
+    const max=el.getAttribute('max');
+    let val=parseFloat(el.value);
+    if(min!==null && val<parseFloat(min)) val=parseFloat(min);
+    if(max!==null && val>parseFloat(max)) val=parseFloat(max);
+    el.value=val;
+  };
+  $$('input[type="number"]').forEach(el=>{
+    const min=el.getAttribute('min');
+    const max=el.getAttribute('max');
+    if(min!==null || max!==null){
+      ['input','change'].forEach(evt=>el.addEventListener(evt,()=>clamp(el)));
+      clamp(el);
+    }
+  });
+}
+
 /* ===== Init modules ===== */
 function init(){
   initTabs();
@@ -261,6 +281,7 @@ function init(){
       saveAll();
     });
     loadAll();
+    clampNumberInputs();
     updateDGksTotal();
     updateGmpGksTotal();
   }


### PR DESCRIPTION
## Summary
- Clamp numeric inputs to their min/max values on change and after loading saved data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a048b8dc388320a36a405f86d5c8e9