### PR TITLE
Add quick-set button for decision time

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,7 +258,7 @@
     <section class="card view" data-tab="Komanda"><h2>Komandos nariai</h2><div class="grid cols-3" id="teamGrid"></div></section>
     <section class="card view" data-tab="Sprendimas">
       <h2>Sprendimas</h2>
-      <div><label>Laikas</label><input id="spr_time" type="time"></div>
+      <div><label>Laikas</label><div class="row" style="gap:8px;align-items:center;"><input id="spr_time" type="time"><button type="button" class="btn ghost" id="btnSprNow">Dabar</button></div></div>
       <div style="margin-top:8px">
         <label>Sprendimas</label>
         <div class="chip-group" id="spr_decision_group" data-single="true">

--- a/js/app.js
+++ b/js/app.js
@@ -251,6 +251,7 @@ function init(){
     };
     ['#gmp_gksa','#gmp_gksk','#gmp_gksm'].forEach(sel=>$(sel).addEventListener('input', updateGmpGksTotal));
     $('#btnGmpNow').addEventListener('click', ()=>{ $('#gmp_time').value=nowHM(); saveAll(); });
+    $('#btnSprNow').addEventListener('click', ()=>{ $('#spr_time').value=nowHM(); saveAll(); });
   $('#btnOxygen').addEventListener('click', ()=>{
     const box = $('#oxygenFields');
     const show = getComputedStyle(box).display === 'none';


### PR DESCRIPTION
## Summary
- Add "Dabar" button next to decision time field for quick current time entry
- Wire button to fill current time via existing nowHM utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0494574a48320b8f68f790801f50c