### PR TITLE
Remove radiologist field from team page

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -7,7 +7,7 @@ import { initActions } from './actions.js';
 /* ===== Imaging / Labs / Team ===== */
 const IMG=['Galvos KT','Kaklo KT','Viso kūno KT','Krūtinės Ro','Dubens Ro','Kita'];
 const LABS=['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
-const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas','Radiologas'];
+const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas'];
 
 const imgWrap=$('#imaging_basic'); IMG.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; imgWrap.appendChild(s);});
 const labsWrap=$('#labs_basic'); LABS.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; labsWrap.appendChild(s);});


### PR DESCRIPTION
## Summary
- Omit radiologist from trauma team roles so the team page no longer displays a radiologist field.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a04960c9488320bdc27424b8c9d913