### PR TITLE
Add custom medication field

### DIFF
--- a/js/actions.js
+++ b/js/actions.js
@@ -20,7 +20,8 @@ export const DEFAULT_DOSES = {
   'Ondansetronas': '8 mg'
 };
 
-function buildActionCard(group, name, saveAll){
+function buildActionCard(group, name, saveAll, opts={}){
+  const custom = opts.custom;
   const card=document.createElement('div');
   card.className='card';
   card.style.padding='6px';
@@ -29,6 +30,7 @@ function buildActionCard(group, name, saveAll){
     card.innerHTML=`<label class="pill"><input type="checkbox" class="act_chk" data-field="${group}_${slug}_chk"><span class="act_name">${name}</span></label>
     <div class="detail collapsed">
       <div class="grid cols-3" style="margin-top:4px">
+        ${custom?`<div><label>Pavadinimas</label><input type="text" class="act_custom_name" data-field="${group}_${slug}_custom"></div>`:''}
         <div><label>Laikas</label><input type="time" class="act_time" data-field="${group}_${slug}_time"></div>
         <div><label>Dozė/kiekis</label><input type="text" class="act_dose" data-field="${group}_${slug}_dose"></div>
         <div><label>Pastabos</label><input type="text" class="act_note" data-field="${group}_${slug}_note"></div>
@@ -85,6 +87,7 @@ export function initActions(saveAll){
   PAIN_MEDS.forEach(n=>painWrap.appendChild(buildActionCard('med', n, saveAll)));
   BLEEDING_MEDS.forEach(n=>bleedingWrap.appendChild(buildActionCard('med', n, saveAll)));
   OTHER_MEDS.forEach(n=>otherWrap.appendChild(buildActionCard('med', n, saveAll)));
+  otherWrap.appendChild(buildActionCard('med','Kita', saveAll, {custom:true}));
   PROCS.forEach(n=>procsWrap.appendChild(buildActionCard('proc', n, saveAll)));
   const medSearch=$('#medSearch');
   if(medSearch){

--- a/js/actions.test.js
+++ b/js/actions.test.js
@@ -45,4 +45,17 @@ describe('initActions default doses', () => {
       expect(dose.value).toBe(DEFAULT_DOSES[med]);
     }
   );
+
+  test('adds custom medication field', () => {
+    document.body.innerHTML = `
+      <div id="pain_meds"></div>
+      <div id="bleeding_meds"></div>
+      <div id="other_meds"></div>
+      <div id="procedures"></div>
+      <input id="medSearch" />
+    `;
+    initActions(() => {});
+    const customCard = document.querySelector('#other_meds .act_custom_name');
+    expect(customCard).not.toBeNull();
+  });
 });

--- a/js/app.js
+++ b/js/app.js
@@ -158,7 +158,7 @@ function saveAll(){
   });
   ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group']
     .forEach(sel=>{ const arr=$$('.chip.active',$(sel)).map(c=>c.dataset.value); data['chips:'+sel]=arr; });
-  function pack(container){ return Array.from(container.children).map(card=>({ name:card.querySelector('.act_name').textContent.trim(), on:card.querySelector('.act_chk').checked, time:card.querySelector('.act_time').value, dose:card.querySelector('.act_dose').value, note:card.querySelector('.act_note').value }));}
+  function pack(container){ return Array.from(container.children).map(card=>({ name:(card.querySelector('.act_custom_name')?card.querySelector('.act_custom_name').value:card.querySelector('.act_name').textContent.trim()), on:card.querySelector('.act_chk').checked, time:card.querySelector('.act_time').value, dose:card.querySelector('.act_dose').value, note:card.querySelector('.act_note').value }));}
   data['pain_meds']=pack($('#pain_meds')); data['bleeding_meds']=pack($('#bleeding_meds')); data['other_meds']=pack($('#other_meds')); data['procs']=pack($('#procedures'));
   data['bodymap_svg']=BodySVG.serialize();
   localStorage.setItem('trauma_v9', JSON.stringify(data));
@@ -176,7 +176,7 @@ function loadAll(){
     });
   ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group']
       .forEach(sel=>{ const arr=data['chips:'+sel]||[]; $$('.chip',$(sel)).forEach(c=>c.classList.toggle('active',arr.includes(c.dataset.value))); });
-    function unpack(container,records){ if(!Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; card.querySelector('.act_dose').value=r.dose||''; card.querySelector('.act_note').value=r.note||'';});}
+    function unpack(container,records){ if(!Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; card.querySelector('.act_dose').value=r.dose||''; card.querySelector('.act_note').value=r.note||''; const cn=card.querySelector('.act_custom_name'); if(cn) cn.value=r.name||'';});}
     unpack($('#pain_meds'),data['pain_meds']); unpack($('#bleeding_meds'),data['bleeding_meds']); unpack($('#other_meds'),data['other_meds']); unpack($('#procedures'),data['procs']);
     if(data['bodymap_svg']) BodySVG.load(data['bodymap_svg']);
     $('#d_pupil_left_note').style.display = ($$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
@@ -317,7 +317,7 @@ document.getElementById('btnGen').addEventListener('click',()=>{
 
   out.push('\n--- E Kita ---'); out.push([$('#e_temp').value?('T '+$('#e_temp').value+'°C'):null, $('#e_back_ny').checked?'Nugara: n.y.':($('#e_back_notes').value?('Nugara: '+$('#e_back_notes').value):null), $('#e_other').value?('Kita: '+$('#e_other').value):null, bodymapSummary()].filter(Boolean).join(' | '));
 
-  function collect(container){ return Array.from(container.children).map(card=>{ const on=card.querySelector('.act_chk').checked; if(!on) return null; const name=card.querySelector('.act_name').textContent.trim(); const time=card.querySelector('.act_time').value; const dose=card.querySelector('.act_dose').value; const note=card.querySelector('.act_note').value; return [name, time?('laikas '+time):null, dose?('dozė '+dose):null, note?('pastabos '+note):null].filter(Boolean).join(' | '); }).filter(Boolean);}
+  function collect(container){ return Array.from(container.children).map(card=>{ const on=card.querySelector('.act_chk').checked; if(!on) return null; const nameInput=card.querySelector('.act_custom_name'); const base=card.querySelector('.act_name').textContent.trim(); const customName=nameInput?nameInput.value.trim():''; const name=nameInput?customName:base; if(nameInput && !customName) return null; const time=card.querySelector('.act_time').value; const dose=card.querySelector('.act_dose').value; const note=card.querySelector('.act_note').value; return [name, time?('laikas '+time):null, dose?('dozė '+dose):null, note?('pastabos '+note):null].filter(Boolean).join(' | '); }).filter(Boolean);}
   const pain=collect($('#pain_meds')), bleeding=collect($('#bleeding_meds')), other=collect($('#other_meds')), procs=collect($('#procedures'));
   if(pain.length||bleeding.length||other.length||procs.length){
     out.push('\n--- Intervencijos ---');


### PR DESCRIPTION
## Summary
- Add configurable "Kita" card for recording medications not in default lists
- Persist custom medication names and include them in generated reports
- Test presence of custom medication input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a049b6f87c8320bbb387b2eac5650b