### PR TITLE
Refactor imaging tests page structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,18 @@
     </section>
 
     <!-- Vaizdai / Laboratorija / Komanda / Sprendimas / Ataskaita -->
-    <section class="card view" data-tab="Vaizdiniai tyrimai"><h2>Vaizdiniai tyrimai</h2><div class="chip-group" id="imaging_basic"></div><input id="imaging_other" type="text" placeholder="Įvesti kitą tyrimą" style="display:none;margin-top:8px;"><h3 style="margin-top:12px;font-size:14px;color:var(--muted)">FAST</h3><div class="grid cols-3" id="fastGrid"></div></section>
+    <section class="card view" data-tab="Vaizdiniai tyrimai">
+      <h2>Vaizdiniai tyrimai</h2>
+      <h3 style="font-size:14px;color:var(--muted)">KT</h3>
+      <div class="chip-group" id="imaging_ct"></div>
+      <h3 style="margin-top:8px;font-size:14px;color:var(--muted)">Rentgenogramos</h3>
+      <div class="chip-group" id="imaging_xray"></div>
+      <h3 style="margin-top:8px;font-size:14px;color:var(--muted)">Kiti</h3>
+      <div class="chip-group" id="imaging_other_group"></div>
+      <input id="imaging_other" type="text" placeholder="Įvesti kitą tyrimą" style="display:none;margin-top:8px;">
+      <h3 style="margin-top:12px;font-size:14px;color:var(--muted)">FAST</h3>
+      <div class="grid cols-3" id="fastGrid"></div>
+    </section>
     <section class="card view" data-tab="Laboratorija"><h2>Laboratoriniai tyrimai</h2><div class="chip-group" id="labs_basic"></div></section>
     <section class="card view" data-tab="Komanda"><h2>Komandos nariai</h2><div class="grid cols-3" id="teamGrid"></div></section>
     <section class="card view" data-tab="Sprendimas">

--- a/js/app.js
+++ b/js/app.js
@@ -5,12 +5,17 @@ import { initAutoActivate } from './autoActivate.js';
 import { initActions } from './actions.js';
 
 /* ===== Imaging / Labs / Team ===== */
-const IMG=['Galvos KT','Kaklo KT','Viso kūno KT','Krūtinės Ro','Dubens Ro','Kita'];
+const IMG_CT=['Galvos KT','Kaklo KT','Viso kūno KT'];
+const IMG_XRAY=['Krūtinės Ro','Dubens Ro'];
 const LABS=['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
 const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas'];
 
-const imgWrap=$('#imaging_basic'); IMG.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; imgWrap.appendChild(s);});
+const imgCtWrap=$('#imaging_ct'); IMG_CT.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; imgCtWrap.appendChild(s);});
+const imgXrayWrap=$('#imaging_xray'); IMG_XRAY.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; imgXrayWrap.appendChild(s);});
+const imgOtherWrap=$('#imaging_other_group'); ['Kita'].forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; imgOtherWrap.appendChild(s);});
 const labsWrap=$('#labs_basic'); LABS.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; labsWrap.appendChild(s);});
+const IMAGING_GROUPS=['#imaging_ct','#imaging_xray','#imaging_other_group'];
+const CHIP_GROUPS=['#chips_red','#chips_yellow',...IMAGING_GROUPS,'#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group'];
 const fastAreas=['Perikardas','Dešinė pleura','Kairė pleura','RUQ','LUQ','Dubuo']; const fastWrap=$('#fastGrid');
 fastAreas.forEach(a=>{const box=document.createElement('div'); box.innerHTML=`<label>${a}</label><div class="row"><label class="pill"><input type="radio" name="fast_${a}" value="Yra"> Yra</label><label class="pill"><input type="radio" name="fast_${a}" value="Nėra"> Nėra</label></div>`; fastWrap.appendChild(box);});
 const teamWrap=$('#teamGrid'); TEAM_ROLES.forEach(r=>{
@@ -156,8 +161,7 @@ function saveAll(){
     else if(el.type==='checkbox'){ data[key]=el.checked?'__checked__':(el.value||''); }
     else{ data[key]=el.value; }
   });
-  ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group']
-    .forEach(sel=>{ const arr=$$('.chip.active',$(sel)).map(c=>c.dataset.value); data['chips:'+sel]=arr; });
+  CHIP_GROUPS.forEach(sel=>{ const arr=$$('.chip.active',$(sel)).map(c=>c.dataset.value); data['chips:'+sel]=arr; });
   function pack(container){ return Array.from(container.children).map(card=>({ name:(card.querySelector('.act_custom_name')?card.querySelector('.act_custom_name').value:card.querySelector('.act_name').textContent.trim()), on:card.querySelector('.act_chk').checked, time:card.querySelector('.act_time').value, dose:card.querySelector('.act_dose').value, note:card.querySelector('.act_note').value }));}
   data['pain_meds']=pack($('#pain_meds')); data['bleeding_meds']=pack($('#bleeding_meds')); data['other_meds']=pack($('#other_meds')); data['procs']=pack($('#procedures'));
   data['bodymap_svg']=BodySVG.serialize();
@@ -174,8 +178,7 @@ function loadAll(){
       else if(el.type==='checkbox'){ el.checked=(data[key]==='__checked__'); }
       else{ if(data[key]!=null) el.value=data[key]; }
     });
-  ['#chips_red','#chips_yellow','#imaging_basic','#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group']
-      .forEach(sel=>{ const arr=data['chips:'+sel]||[]; $$('.chip',$(sel)).forEach(c=>c.classList.toggle('active',arr.includes(c.dataset.value))); });
+  CHIP_GROUPS.forEach(sel=>{ const arr=data['chips:'+sel]||[]; $$('.chip',$(sel)).forEach(c=>c.classList.toggle('active',arr.includes(c.dataset.value))); });
     function unpack(container,records){ if(!Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; card.querySelector('.act_dose').value=r.dose||''; card.querySelector('.act_note').value=r.note||''; const cn=card.querySelector('.act_custom_name'); if(cn) cn.value=r.name||'';});}
     unpack($('#pain_meds'),data['pain_meds']); unpack($('#bleeding_meds'),data['bleeding_meds']); unpack($('#other_meds'),data['other_meds']); unpack($('#procedures'),data['procs']);
     if(data['bodymap_svg']) BodySVG.load(data['bodymap_svg']);
@@ -186,7 +189,7 @@ function loadAll(){
     $('#spr_skyrius_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Stacionarizavimas'))?'block':'none';
     $('#spr_ligonine_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Pervežimas į kitą ligoninę'))?'block':'none';
     $('#spr_skyrius_kita').style.display = ($('#spr_skyrius').value === 'Kita') ? 'block' : 'none';
-    $('#imaging_other').style.display = ($$('.chip.active', $('#imaging_basic')).some(c=>c.dataset.value==='Kita'))?'block':'none';
+    $('#imaging_other').style.display = (IMAGING_GROUPS.some(sel=>$$('.chip.active', $(sel)).some(c=>c.dataset.value==='Kita')))?'block':'none';
     ensureSingleTeam();
     updateActivationIndicator();
     expandOutput();
@@ -349,10 +352,8 @@ document.getElementById('btnGen').addEventListener('click',()=>{
     if(procs.length) out.push('Procedūros:\n'+procs.join('\n'));
   }
 
-  let imgs=listChips('#imaging_basic');
-  const otherIdx=imgs.indexOf('Kita');
-  if(otherIdx>=0){
-    imgs.splice(otherIdx,1);
+  let imgs=[...listChips('#imaging_ct'), ...listChips('#imaging_xray')];
+  if(listChips('#imaging_other_group').includes('Kita')){
     const other=$('#imaging_other').value.trim();
     if(other) imgs.push(other);
   }

--- a/js/chips.js
+++ b/js/chips.js
@@ -41,10 +41,9 @@ export function initChips(saveAll){
     }
     togglePupilNote('left', chip);
     togglePupilNote('right', chip);
-    if(group.id==='imaging_basic'){
-      const otherChip=$$('.chip', group).find(c=>c.dataset.value==='Kita');
+    if(group.id.startsWith('imaging_')){
       const box=$('#imaging_other');
-      const show=otherChip && isChipActive(otherChip);
+      const show=!!document.querySelector('[id^="imaging_"] .chip.active[data-value="Kita"]');
       box.style.display = show ? 'block' : 'none';
       if(!show) box.value='';
     }

--- a/js/chips.test.js
+++ b/js/chips.test.js
@@ -38,15 +38,18 @@ describe('chips', () => {
 
   test('shows other imaging field when "Kita" selected', () => {
     document.body.innerHTML = `
-      <div id="imaging_basic">
+      <div id="imaging_ct">
         <span class="chip" data-value="Galvos KT"></span>
+      </div>
+      <div id="imaging_other_group">
         <span class="chip" data-value="Kita"></span>
       </div>
       <input id="imaging_other" style="display:none;" />
     `;
     const { initChips } = require('./chips.js');
     initChips();
-    const [normalChip, otherChip] = document.querySelectorAll('#imaging_basic .chip');
+    const normalChip = document.querySelector('#imaging_ct .chip');
+    const otherChip = document.querySelector('#imaging_other_group .chip');
     const box = document.getElementById('imaging_other');
     otherChip.click();
     expect(box.style.display).toBe('block');


### PR DESCRIPTION
## Summary
- Organize imaging tests into CT, X-ray, and other categories with dedicated chip groups
- Update chip handling and report generation for new imaging structure
- Adjust tests for revised imaging section behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a051c1d8588320850080da43954c5e