### PR TITLE
Add patient session management

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
   <div class="wrap">
     <h1>Traumos forma – Desktop v9</h1>
     <div class="sub">Aktyvacija · ABCDE · LT · SVG kūno žemėlapis <span id="activationIndicator" class="activation-dot"></span></div>
+    <div class="toolbar" id="sessionBar">
+      <select id="sessionSelect" style="width:auto"></select>
+      <button type="button" class="btn" id="btnNewSession">Nauja sesija</button>
+      <button type="button" class="btn" id="btnRenameSession">Pervadinti</button>
+    </div>
     <div class="toolbar">
       <button type="button" class="btn primary" id="btnGen">Sugeneruoti ataskaitą</button>
       <button type="button" class="btn" id="btnCopy">Kopijuoti</button>


### PR DESCRIPTION
## Summary
- Add session selector UI to create, rename and switch patient cases
- Save and load data per-session using `trauma_v9_<sessionId>` keys
- Remember the active session in localStorage so it loads on startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a056cbcf188320b563a89b0e701ac8