### PR TITLE
Improve laboratoriniai tyrimai layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -64,6 +64,8 @@ label.chip input{
 .chip.red.active{background:var(--red);color:#fff;border-color:#a52623}
 .chip.yellow.active{background:var(--yellow);color:#231b00;border-color:#8a7400}
 .chip-group{display:flex;flex-wrap:wrap;gap:8px}
+.labs-controls{display:flex;gap:8px;align-items:flex-start;flex-wrap:wrap}
+.labs-controls .chip-group{flex:1}
 .breath-chip{padding:12px 20px;font-size:18px}
 .hint{color:var(--muted);font-size:12px}
 .badge{padding:2px 8px;border-radius:8px;font-size:12px;border:1px solid var(--line);background:#152231;color:var(--muted)}

--- a/index.html
+++ b/index.html
@@ -277,8 +277,10 @@
     </section>
     <section class="card view" data-tab="Laboratorija">
       <h2>Laboratoriniai tyrimai</h2>
-      <div class="chip-group" id="labs_basic"></div>
-      <button type="button" class="btn" id="btnBloodOrder">Kraujo užsakymas</button>
+      <div class="labs-controls">
+        <div class="chip-group" id="labs_basic"></div>
+        <button type="button" class="btn" id="btnBloodOrder">Kraujo užsakymas</button>
+      </div>
     </section>
     <section class="card view" data-tab="Komanda"><h2>Komandos nariai</h2><div class="grid cols-3" id="teamGrid"></div></section>
     <section class="card view" data-tab="Sprendimas">


### PR DESCRIPTION
## Summary
- Arrange lab test chips and blood order button within a flex container for a cleaner, responsive layout.
- Add `.labs-controls` styles to align elements and allow wrapping on smaller screens.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a057018bb88320b77f4e89f1c77edf