### PR TITLE
Add patient info section and persistence tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,22 @@
   <nav id="tabs"></nav>
 
   <div id="views">
+    <!-- Pacientas -->
+    <section class="card view" data-tab="Pacientas">
+      <h2>Pacientas</h2>
+      <div class="grid cols-4">
+        <div><label>Vardas</label><input id="patient_name" type="text"></div>
+        <div><label>Amžius</label><input id="patient_age" type="number" min="0"></div>
+        <div><label>Lytis</label>
+          <select id="patient_sex">
+            <option value=""></option>
+            <option value="M">Vyras</option>
+            <option value="F">Moteris</option>
+          </select>
+        </div>
+        <div><label>Paciento ID</label><input id="patient_id" type="text"></div>
+      </div>
+    </section>
     <!-- Aktyvacija -->
     <section class="card view" data-tab="Aktyvacija">
         <h2>Traumos komandos aktyvacija <span class="badge">GMP rodikliai → auto</span></h2>

--- a/js/app.js
+++ b/js/app.js
@@ -220,7 +220,7 @@ window.updateActivationIndicator=updateActivationIndicator;
 window.ensureSingleTeam=ensureSingleTeam;
 
 /* ===== Save / Load ===== */
-const FIELD_SELECTORS='input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select';
+const FIELD_SELECTORS='input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select,#patient_name,#patient_age,#patient_sex,#patient_id';
 
 function expandOutput(){
   const ta = $('#output');
@@ -229,7 +229,7 @@ function expandOutput(){
   ta.style.height = ta.scrollHeight + 'px';
 }
 
-function saveAll(){
+export function saveAll(){
   if(!currentSessionId) return;
   const data={};
   $$(FIELD_SELECTORS).forEach(el=>{
@@ -245,7 +245,7 @@ function saveAll(){
   data['bodymap_svg']=BodySVG.serialize();
   localStorage.setItem(sessionKey(), JSON.stringify(data));
 }
-function loadAll(){
+export function loadAll(){
   if(!currentSessionId) return;
   const raw=localStorage.getItem(sessionKey()); if(!raw) return;
   try{
@@ -443,8 +443,11 @@ function bodymapSummary(){
   }catch(e){ return ''; }
 }
 
-document.getElementById('btnGen').addEventListener('click',()=>{
+export function generateReport(){
   const out=[];
+  const patient={ name:$('#patient_name').value, age:$('#patient_age').value, sex:$('#patient_sex').value, id:$('#patient_id').value };
+  const patientLine=[patient.name?`Vardas: ${patient.name}`:null, patient.age?`Amžius ${patient.age}`:null, patient.sex?`Lytis ${patient.sex}`:null, patient.id?`ID ${patient.id}`:null].filter(Boolean).join('; ');
+  if(patientLine){ out.push('--- Pacientas ---'); out.push(patientLine); }
   const red=listChips('#chips_red'), yellow=listChips('#chips_yellow');
   const gmp={ hr:$('#gmp_hr').value, rr:$('#gmp_rr').value, spo2:$('#gmp_spo2').value, sbp:$('#gmp_sbp').value, dbp:$('#gmp_dbp').value, gksa:$('#gmp_gksa').value, gksk:$('#gmp_gksk').value, gksm:$('#gmp_gksm').value, time:$('#gmp_time').value, mechanism:$('#gmp_mechanism').value, notes:$('#gmp_notes').value };
   const gksGMP=gksSum(gmp.gksa,gmp.gksk,gmp.gksm);
@@ -522,7 +525,8 @@ document.getElementById('btnGen').addEventListener('click',()=>{
     expandOutput();
     showTab('Ataskaita');
     saveAll();
-  });
+}
+document.getElementById('btnGen').addEventListener('click', generateReport);
 
 document.getElementById('btnCopy').addEventListener('click',async()=>{ try{ await navigator.clipboard.writeText($('#output').value||''); alert('Nukopijuota.'); }catch(e){ alert('Nepavyko nukopijuoti.'); }});
 document.getElementById('btnSave').addEventListener('click',()=>{ saveAll(); alert('Išsaugota naršyklėje.');});

--- a/js/patient.test.js
+++ b/js/patient.test.js
@@ -1,0 +1,85 @@
+const setupDom = () => {
+  document.body.innerHTML = `
+    <button id="btnCopy"></button>
+    <button id="btnSave"></button>
+    <button id="btnClear"></button>
+    <button id="btnPrint"></button>
+    <button id="btnGCS15"></button>
+    <button id="btnGCSCalc"></button>
+    <input type="checkbox" id="e_back_ny" />
+    <button id="btnGen"></button>
+    <textarea id="output"></textarea>
+    <svg id="bodySvg"><g id="layer-front"></g><g id="layer-back"></g><g id="marks"></g></svg>
+    <div id="front-shape"></div>
+    <div id="back-shape"></div>
+    <button id="btnSide"></button>
+    <button id="btnUndo"></button>
+    <button id="btnClearMap"></button>
+    <button id="btnExportSvg"></button>
+    <div class="map-toolbar"><button class="tool" data-tool="Ž"></button></div>
+  `;
+  const divIds = [
+    'chips_red','chips_yellow','imaging_ct','imaging_xray','imaging_other_group','labs_basic',
+    'a_airway_group','b_breath_left_group','b_breath_right_group','d_pupil_left_group','d_pupil_right_group','spr_decision_group',
+    'pain_meds','bleeding_meds','other_meds','procedures','fastGrid','teamGrid','oxygenFields','dpvFields',
+    'spr_skyrius_container','spr_ligonine_container','imaging_other'
+  ];
+  divIds.forEach(id=>{ const d=document.createElement('div'); d.id=id; document.body.appendChild(d); });
+  const textInputs=['a_notes','gmp_mechanism','gmp_notes','b_oxygen_type','b_dpv_fio2','d_pupil_left_note','d_pupil_right_note','d_notes','e_back_notes','e_other','spr_skyrius_kita','spr_ligonine','patient_name','patient_id'];
+  textInputs.forEach(id=>{ const i=document.createElement('input'); i.id=id; i.type='text'; document.body.appendChild(i); });
+  const numberInputs=['b_rr','b_spo2','b_oxygen_liters','c_hr','c_sbp','c_dbp','c_caprefill','d_gksa','d_gksk','d_gksm','e_temp',
+    'spr_hr','spr_rr','spr_spo2','spr_sbp','spr_dbp','spr_gksa','spr_gksk','spr_gksm','patient_age','gmp_hr','gmp_rr','gmp_spo2',
+    'gmp_sbp','gmp_dbp','gmp_gksa','gmp_gksk','gmp_gksm'];
+  numberInputs.forEach(id=>{ const i=document.createElement('input'); i.id=id; i.type='number'; document.body.appendChild(i); });
+  const timeInputs=['gmp_time','spr_time'];
+  timeInputs.forEach(id=>{ const i=document.createElement('input'); i.id=id; i.type='time'; document.body.appendChild(i); });
+  const patientSex=document.createElement('select'); patientSex.id='patient_sex'; ['','M','F'].forEach(v=>{ const o=document.createElement('option'); o.value=v; o.textContent=v; patientSex.appendChild(o); }); document.body.appendChild(patientSex);
+  const sprSkyrius=document.createElement('select'); sprSkyrius.id='spr_skyrius'; sprSkyrius.appendChild(document.createElement('option')); document.body.appendChild(sprSkyrius);
+};
+
+describe('patient fields', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+    setupDom();
+    localStorage.setItem('trauma_current_session','test');
+  });
+
+  test('persist with saveAll/loadAll', () => {
+    const { saveAll, loadAll } = require('./app.js');
+    document.getElementById('patient_name').value='Jonas';
+    document.getElementById('patient_age').value='25';
+    document.getElementById('patient_sex').value='M';
+    document.getElementById('patient_id').value='ID123';
+    saveAll();
+    const stored = JSON.parse(localStorage.getItem('trauma_v9_test'));
+    expect(stored.patient_name).toBe('Jonas');
+    expect(stored.patient_age).toBe('25');
+    expect(stored.patient_sex).toBe('M');
+    expect(stored.patient_id).toBe('ID123');
+    document.getElementById('patient_name').value='';
+    document.getElementById('patient_age').value='';
+    document.getElementById('patient_sex').value='';
+    document.getElementById('patient_id').value='';
+    loadAll();
+    expect(document.getElementById('patient_name').value).toBe('Jonas');
+    expect(document.getElementById('patient_age').value).toBe('25');
+    expect(document.getElementById('patient_sex').value).toBe('M');
+    expect(document.getElementById('patient_id').value).toBe('ID123');
+  });
+
+  test('report includes patient info', () => {
+    const { generateReport } = require('./app.js');
+    document.getElementById('patient_name').value='Jonas';
+    document.getElementById('patient_age').value='25';
+    document.getElementById('patient_sex').value='M';
+    document.getElementById('patient_id').value='ID123';
+    generateReport();
+    const report=document.getElementById('output').value;
+    expect(report.startsWith('--- Pacientas ---')).toBe(true);
+    expect(report).toContain('Jonas');
+    expect(report).toContain('25');
+    expect(report).toContain('M');
+    expect(report).toContain('ID123');
+  });
+});


### PR DESCRIPTION
## Summary
- Add "Pacientas" view with fields for name, age, sex, and patient ID
- Save and load patient details and include them at top of generated report
- Test patient data persistence and report integration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a05a83b094832092044d9a45626819