### PR TITLE
Add ARIA roles and tests for chip groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       <div class="split" style="margin-top:12px">
         <div>
           <label><strong>RAUDONA</strong></label>
-          <div class="chip-group" id="chips_red">
+          <div class="chip-group" id="chips_red" aria-label="RAUDONA">
             <button type="button" class="chip red" data-value="GKS &lt; 9" aria-pressed="false">GKS &lt; 9</button>
             <button type="button" class="chip red" data-value="KD &lt; 8 ar &gt; 30/min" aria-pressed="false">KD &lt; 8 ar &gt; 30/min</button>
             <button type="button" class="chip red" data-value="AKS &lt; 90 mmHg" aria-pressed="false">AKS &lt; 90 mmHg</button>
@@ -67,7 +67,7 @@
         </div>
         <div>
           <label><strong>GELTONA</strong></label>
-          <div class="chip-group" id="chips_yellow">
+          <div class="chip-group" id="chips_yellow" aria-label="GELTONA">
             <button type="button" class="chip yellow" data-value="Pėst./dvir./motociklo trauma" aria-pressed="false">Pėst./dvir./motociklo trauma</button>
             <button type="button" class="chip yellow" data-value="Sprogimas/susišaudymas" aria-pressed="false">Sprogimas/susišaudymas</button>
             <button type="button" class="chip yellow" data-value="Kritimas &gt;3 m ar nardymas" aria-pressed="false">Kritimas &gt;3 m ar nardymas</button>
@@ -82,7 +82,7 @@
     <section class="card view" data-tab="A – Kvėpavimo takai">
       <h2>A – Kvėpavimo takai</h2>
       <label>Takai</label>
-      <div class="chip-group" id="a_airway_group" data-single="true">
+      <div class="chip-group" id="a_airway_group" data-single="true" aria-label="Takai">
         <button type="button" class="chip" data-value="Atviri" aria-pressed="false">Atviri</button>
         <button type="button" class="chip" data-value="Užtikrinti (intub./GMP)" aria-pressed="false">Užtikrinti (intub./GMP)</button>
         <button type="button" class="chip" data-value="Kita" aria-pressed="false">Kita</button>
@@ -100,8 +100,8 @@
       <div style="margin-top:8px">
         <label>Alsavimas</label>
         <div class="row">
-          <div><div class="subtle">Kairė</div><div class="chip-group" id="b_breath_left_group" data-single="true"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false">+</button><button type="button" class="chip breath-chip" data-value="-" aria-pressed="false">-</button></div></div>
-          <div><div class="subtle">Dešinė</div><div class="chip-group" id="b_breath_right_group" data-single="true"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false">+</button><button type="button" class="chip breath-chip" data-value="-" aria-pressed="false">-</button></div></div>
+          <div><div class="subtle">Kairė</div><div class="chip-group" id="b_breath_left_group" data-single="true" aria-label="Alsavimas – Kairė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false">+</button><button type="button" class="chip breath-chip" data-value="-" aria-pressed="false">-</button></div></div>
+          <div><div class="subtle">Dešinė</div><div class="chip-group" id="b_breath_right_group" data-single="true" aria-label="Alsavimas – Dešinė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false">+</button><button type="button" class="chip breath-chip" data-value="-" aria-pressed="false">-</button></div></div>
         </div>
       </div>
       <div class="row" style="margin-top:8px;flex-wrap:wrap">
@@ -152,12 +152,12 @@
         </div>
         <div>
           <label>Vyzdžiai – Kairė</label>
-          <div class="chip-group" id="d_pupil_left_group" data-single="true"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip" data-value="kita" aria-pressed="false">kita</button></div>
+          <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip" data-value="kita" aria-pressed="false">kita</button></div>
           <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." style="margin-top:6px;display:none">
         </div>
         <div>
           <label>Vyzdžiai – Dešinė</label>
-          <div class="chip-group" id="d_pupil_right_group" data-single="true"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip" data-value="kita" aria-pressed="false">kita</button></div>
+          <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip" data-value="kita" aria-pressed="false">kita</button></div>
           <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." style="margin-top:6px;display:none">
         </div>
       </div>
@@ -271,11 +271,11 @@
     <section class="card view" data-tab="Vaizdiniai tyrimai">
       <h2>Vaizdiniai tyrimai</h2>
       <h3 style="font-size:14px;color:var(--muted)">KT</h3>
-      <div class="chip-group" id="imaging_ct"></div>
+      <div class="chip-group" id="imaging_ct" aria-label="KT"></div>
       <h3 style="margin-top:8px;font-size:14px;color:var(--muted)">Rentgenogramos</h3>
-      <div class="chip-group" id="imaging_xray"></div>
+      <div class="chip-group" id="imaging_xray" aria-label="Rentgenogramos"></div>
       <h3 style="margin-top:8px;font-size:14px;color:var(--muted)">Kiti</h3>
-      <div class="chip-group" id="imaging_other_group"></div>
+      <div class="chip-group" id="imaging_other_group" aria-label="Kiti vaizdiniai tyrimai"></div>
       <input id="imaging_other" type="text" placeholder="Įvesti kitą tyrimą" style="display:none;margin-top:8px;">
       <h3 style="margin-top:12px;font-size:14px;color:var(--muted)">FAST</h3>
       <div class="grid cols-3" id="fastGrid"></div>
@@ -283,7 +283,7 @@
     <section class="card view" data-tab="Laboratorija">
       <h2>Laboratoriniai tyrimai</h2>
       <div class="labs-controls">
-        <div class="chip-group" id="labs_basic"></div>
+        <div class="chip-group" id="labs_basic" aria-label="Laboratoriniai tyrimai"></div>
         <button type="button" class="btn" id="btnBloodOrder">Kraujo užsakymas</button>
       </div>
     </section>
@@ -293,7 +293,7 @@
       <div><label>Laikas</label><div class="row" style="gap:8px;align-items:center;"><input id="spr_time" type="time"><button type="button" class="btn ghost" id="btnSprNow">Dabar</button></div></div>
       <div style="margin-top:8px">
         <label>Sprendimas</label>
-        <div class="chip-group" id="spr_decision_group" data-single="true">
+        <div class="chip-group" id="spr_decision_group" data-single="true" aria-label="Sprendimas">
           <button type="button" class="chip" data-value="Stacionarizavimas" aria-pressed="false">Stacionarizavimas</button>
           <button type="button" class="chip" data-value="Namo" aria-pressed="false">Namo</button>
           <button type="button" class="chip" data-value="Stebėjimas SMPS" aria-pressed="false">Stebėjimas SMPS</button>

--- a/js/chips.js
+++ b/js/chips.js
@@ -1,5 +1,7 @@
 import { $, $$ } from './utils.js';
 
+let clickListenerAdded = false;
+
 export function isChipActive(chip){
   if(chip.tagName === 'BUTTON') return chip.getAttribute('aria-pressed') === 'true';
   const input = chip.querySelector('input');
@@ -15,6 +17,9 @@ export function setChipActive(chip, active){
     if(input) input.checked = active;
   }
   chip.classList.toggle('active', active);
+  if(chip.getAttribute('role') === 'radio'){
+    chip.setAttribute('aria-checked', active ? 'true' : 'false');
+  }
 }
 
 function togglePupilNote(side, chip){
@@ -27,6 +32,20 @@ function togglePupilNote(side, chip){
 }
 
 export function initChips(saveAll){
+  $$('.chip').forEach(chip => {
+    const group = chip.parentElement;
+    const single = group?.dataset?.single === 'true';
+    if(group){
+      group.setAttribute('role', single ? 'radiogroup' : 'group');
+    }
+    if(single){
+      chip.setAttribute('role', 'radio');
+      chip.setAttribute('aria-checked', isChipActive(chip) ? 'true' : 'false');
+    }
+  });
+  if(clickListenerAdded) return;
+  clickListenerAdded = true;
+
   document.addEventListener('click', e => {
     const chip = e.target.closest('.chip');
     if(!chip) return;

--- a/js/chips.test.js
+++ b/js/chips.test.js
@@ -12,6 +12,28 @@ describe('chips', () => {
     expect(isChipActive(chip)).toBe(false);
   });
 
+  test('sets proper roles and aria-checked for single-selection groups', () => {
+    document.body.innerHTML = `
+      <div id="multi"><span class="chip" data-value="a"></span><span class="chip" data-value="b"></span></div>
+      <div id="single" data-single="true"><span class="chip" data-value="1"></span><span class="chip" data-value="2"></span></div>
+    `;
+    const { initChips } = require('./chips.js');
+    initChips();
+    const multi = document.getElementById('multi');
+    const single = document.getElementById('single');
+    expect(multi.getAttribute('role')).toBe('group');
+    expect(single.getAttribute('role')).toBe('radiogroup');
+    const [c1, c2] = single.querySelectorAll('.chip');
+    expect(c1.getAttribute('role')).toBe('radio');
+    expect(c1.getAttribute('aria-checked')).toBe('false');
+    c1.click();
+    expect(c1.getAttribute('aria-checked')).toBe('true');
+    expect(c2.getAttribute('aria-checked')).toBe('false');
+    c2.click();
+    expect(c1.getAttribute('aria-checked')).toBe('false');
+    expect(c2.getAttribute('aria-checked')).toBe('true');
+  });
+
   test('shows hospital field when transfer decision selected', () => {
     document.body.innerHTML = `
       <div id="spr_decision_group" data-single="true">


### PR DESCRIPTION
## Summary
- assign ARIA group and radio roles to chips and toggle `aria-checked`
- label chip groups in `index.html` with descriptive `aria-label`
- add Jest test for role/aria-checked behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a05a9dba9883209e7ed4d4761a468e