### PR TITLE
Add keyboard and ARIA support to chips

### DIFF
--- a/js/chips.test.js
+++ b/js/chips.test.js
@@ -26,12 +26,44 @@ describe('chips', () => {
     const [c1, c2] = single.querySelectorAll('.chip');
     expect(c1.getAttribute('role')).toBe('radio');
     expect(c1.getAttribute('aria-checked')).toBe('false');
+    expect(c1.getAttribute('aria-pressed')).toBe('false');
     c1.click();
     expect(c1.getAttribute('aria-checked')).toBe('true');
+    expect(c1.getAttribute('aria-pressed')).toBe('true');
     expect(c2.getAttribute('aria-checked')).toBe('false');
+    expect(c2.getAttribute('aria-pressed')).toBe('false');
     c2.click();
     expect(c1.getAttribute('aria-checked')).toBe('false');
+    expect(c1.getAttribute('aria-pressed')).toBe('false');
     expect(c2.getAttribute('aria-checked')).toBe('true');
+    expect(c2.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('assigns role and tabindex to non-button chips', () => {
+    document.body.innerHTML = `
+      <div id="group"><span class="chip" data-value="x"></span></div>
+    `;
+    const { initChips } = require('./chips.js');
+    initChips();
+    const chip = document.querySelector('#group .chip');
+    expect(chip.getAttribute('role')).toBe('button');
+    expect(chip.getAttribute('tabindex')).toBe('0');
+    expect(chip.getAttribute('aria-pressed')).toBe('false');
+    chip.click();
+    expect(chip.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('toggles chip with keyboard interaction', () => {
+    document.body.innerHTML = `
+      <div id="group"><span class="chip" data-value="x"></span></div>
+    `;
+    const { initChips, isChipActive } = require('./chips.js');
+    initChips();
+    const chip = document.querySelector('#group .chip');
+    chip.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(isChipActive(chip)).toBe(true);
+    chip.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(isChipActive(chip)).toBe(false);
   });
 
   test('shows hospital field when transfer decision selected', () => {


### PR DESCRIPTION
## Summary
- Assign `role="button"` and `tabindex="0"` to non-button chips
- Toggle chips on Enter or Space keydown
- Keep `aria-pressed` in sync across all chip types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a061a1c66083208e936508ccf3ef69