### PR TITLE
Add inline GKS calculator

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -64,6 +64,8 @@ label.chip input{
 .chip.red.active{background:var(--red);color:#fff;border-color:#a52623}
 .chip.yellow.active{background:var(--yellow);color:#231b00;border-color:#8a7400}
 .chip-group{display:flex;flex-wrap:wrap;gap:8px}
+.gcs-calc{margin-top:8px;border:1px solid var(--line);border-radius:10px;padding:8px;background:#152231}
+.gcs-calc .grid{margin-bottom:8px}
 .labs-controls{display:flex;gap:8px;align-items:flex-start;flex-wrap:wrap}
 .labs-controls .chip-group{flex:1}
 .breath-chip{padding:12px 20px;font-size:18px}

--- a/index.html
+++ b/index.html
@@ -166,6 +166,47 @@
               <button type="button" class="btn" id="btnGCSCalc">Skaičiuoti</button>
               <span id="d_gks_total"></span>
           </div>
+          <div id="d_gcs_calc" class="gcs-calc" style="display:none">
+            <div class="grid cols-3">
+              <div>
+                <label>Akių atmerkimas (A)</label>
+                <select id="d_gcs_calc_a">
+                  <option value=""></option>
+                  <option value="4">akys atmerktos spontaniškai</option>
+                  <option value="3">akys atveriamos į garsą</option>
+                  <option value="2">akys atveriamos į skausmą</option>
+                  <option value="1">akys neatveriamos</option>
+                </select>
+              </div>
+              <div>
+                <label>Kalba (K)</label>
+                <select id="d_gcs_calc_k">
+                  <option value=""></option>
+                  <option value="5">orientuota kalba</option>
+                  <option value="4">paini kalba</option>
+                  <option value="3">atskiri žodžiai</option>
+                  <option value="2">neaiškūs garsai</option>
+                  <option value="1">nereaguoja</option>
+                </select>
+              </div>
+              <div>
+                <label>Judesių reakcija (M)</label>
+                <select id="d_gcs_calc_m">
+                  <option value=""></option>
+                  <option value="6">vykdo komandas</option>
+                  <option value="5">lokalizuoja skausmą</option>
+                  <option value="4">atitraukia nuo skausmo</option>
+                  <option value="3">nenormali fleksija (lenkia į skausmą)</option>
+                  <option value="2">nenormali ekstensija (ištiesia į skausmą)</option>
+                  <option value="1">nereaguoja</option>
+                </select>
+              </div>
+            </div>
+            <div class="row" style="margin-top:8px">
+              <button type="button" class="btn" id="d_gcs_apply">Taikyti</button>
+              <span id="d_gcs_calc_total"></span>
+            </div>
+          </div>
         </div>
         <div>
           <label>Vyzdžiai – Kairė</label>
@@ -354,6 +395,49 @@
           <input id="spr_gksa" type="number" min="1" max="4" placeholder="A">
           <input id="spr_gksk" type="number" min="1" max="5" placeholder="K">
           <input id="spr_gksm" type="number" min="1" max="6" placeholder="M">
+          <button type="button" class="btn" id="btnSprGCSCalc">Skaičiuoti</button>
+          <span id="spr_gks_total"></span>
+        </div>
+        <div id="spr_gcs_calc" class="gcs-calc" style="display:none">
+          <div class="grid cols-3">
+            <div>
+              <label>Akių atmerkimas (A)</label>
+              <select id="spr_gcs_calc_a">
+                <option value=""></option>
+                <option value="4">akys atmerktos spontaniškai</option>
+                <option value="3">akys atveriamos į garsą</option>
+                <option value="2">akys atveriamos į skausmą</option>
+                <option value="1">akys neatveriamos</option>
+              </select>
+            </div>
+            <div>
+              <label>Kalba (K)</label>
+              <select id="spr_gcs_calc_k">
+                <option value=""></option>
+                <option value="5">orientuota kalba</option>
+                <option value="4">paini kalba</option>
+                <option value="3">atskiri žodžiai</option>
+                <option value="2">neaiškūs garsai</option>
+                <option value="1">nereaguoja</option>
+              </select>
+            </div>
+            <div>
+              <label>Judesių reakcija (M)</label>
+              <select id="spr_gcs_calc_m">
+                <option value=""></option>
+                <option value="6">vykdo komandas</option>
+                <option value="5">lokalizuoja skausmą</option>
+                <option value="4">atitraukia nuo skausmo</option>
+                <option value="3">nenormali fleksija (lenkia į skausmą)</option>
+                <option value="2">nenormali ekstensija (ištiesia į skausmą)</option>
+                <option value="1">nereaguoja</option>
+              </select>
+            </div>
+          </div>
+          <div class="row" style="margin-top:8px">
+            <button type="button" class="btn" id="spr_gcs_apply">Taikyti</button>
+            <span id="spr_gcs_calc_total"></span>
+          </div>
         </div>
       </div>
     </section>

--- a/js/app.js
+++ b/js/app.js
@@ -302,39 +302,34 @@ $('#btnGCS15').addEventListener('click',()=>{
   ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
   saveAll();
 });
-$('#btnGCSCalc').addEventListener('click',()=>{
-  const choose=(title,opts)=>{
-    const msg=[title].concat(opts.map(o=>`${o.value} - ${o.text}`)).join('\n');
-    const val=parseInt(prompt(msg)||'',10);
-    return opts.some(o=>o.value===val)?val:0;
-  };
-  const a=choose('Akių atmerkimas (A)',[
-    {value:4,text:'spontaniškai'},
-    {value:3,text:'į garsą'},
-    {value:2,text:'į skausmą'},
-    {value:1,text:'nereaguoja'}
-  ]);
-  const k=choose('Kalba (K)',[
-    {value:5,text:'orientuotas'},
-    {value:4,text:'paini'},
-    {value:3,text:'žodžiai'},
-    {value:2,text:'garsai'},
-    {value:1,text:'nėra'}
-  ]);
-  const m=choose('Judesių reakcija (M)',[
-    {value:6,text:'vykdo komandas'},
-    {value:5,text:'lokalizuoja skausmą'},
-    {value:4,text:'atitraukia nuo skausmo'},
-    {value:3,text:'lenkia nuo skausmo'},
-    {value:2,text:'atpalaiduoja'},
-    {value:1,text:'nereaguoja'}
-  ]);
-  if(a) $('#d_gksa').value=a;
-  if(k) $('#d_gksk').value=k;
-  if(m) $('#d_gksm').value=m;
-  ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
-  saveAll();
-});
+function setupGcsCalc(prefix){
+  const panel=$(`#${prefix}_gcs_calc`);
+  const selA=$(`#${prefix}_gcs_calc_a`);
+  const selK=$(`#${prefix}_gcs_calc_k`);
+  const selM=$(`#${prefix}_gcs_calc_m`);
+  const apply=$(`#${prefix}_gcs_apply`);
+  const total=$(`#${prefix}_gcs_calc_total`);
+  if(!panel||!selA||!selK||!selM||!apply||!total) return ()=>{};
+  const update=()=>{ total.textContent=gksSum(selA.value,selK.value,selM.value); };
+  [selA,selK,selM].forEach(sel=>sel.addEventListener('change',update));
+  apply.addEventListener('click',()=>{
+    if(selA.value) $(`#${prefix}_gksa`).value=selA.value;
+    if(selK.value) $(`#${prefix}_gksk`).value=selK.value;
+    if(selM.value) $(`#${prefix}_gksm`).value=selM.value;
+    ['#'+prefix+'_gksa','#'+prefix+'_gksk','#'+prefix+'_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
+    panel.style.display='none';
+    saveAll();
+  });
+  return ()=>{ panel.style.display = panel.style.display==='none' ? 'block' : 'none'; };
+}
+if($('#d_gcs_calc') && $('#btnGCSCalc')){
+  const toggleDGcs=setupGcsCalc('d');
+  $('#btnGCSCalc').addEventListener('click',toggleDGcs);
+}
+if($('#spr_gcs_calc') && $('#btnSprGCSCalc')){
+  const toggleSprGcs=setupGcsCalc('spr');
+  $('#btnSprGCSCalc').addEventListener('click',toggleSprGcs);
+}
 $('#e_back_ny').addEventListener('change',e=>{ $('#e_back_notes').disabled=e.target.checked; if(e.target.checked) $('#e_back_notes').value=''; saveAll();});
 
 function clampNumberInputs(){
@@ -409,6 +404,12 @@ function init(){
       $('#gmp_gks_total').textContent=gksSum($('#gmp_gksa').value,$('#gmp_gksk').value,$('#gmp_gksm').value);
     };
     ['#gmp_gksa','#gmp_gksk','#gmp_gksm'].forEach(sel=>$(sel).addEventListener('input', updateGmpGksTotal));
+    if($('#spr_gks_total')){
+      const updateSprGksTotal=()=>{
+        $('#spr_gks_total').textContent=gksSum($('#spr_gksa').value,$('#spr_gksk').value,$('#spr_gksm').value);
+      };
+      ['#spr_gksa','#spr_gksk','#spr_gksm'].forEach(sel=>$(sel).addEventListener('input', updateSprGksTotal));
+    }
     $('#btnGmpNow').addEventListener('click', ()=>{ $('#gmp_time').value=nowHM(); saveAll(); });
     $('#btnSprNow').addEventListener('click', ()=>{ $('#spr_time').value=nowHM(); saveAll(); });
   $('#btnOxygen').addEventListener('click', ()=>{


### PR DESCRIPTION
## Summary
- Replace prompt-based GKS scoring with inline calculator panel in consciousness section
- Add identical GKS calculator to the decision section and display totals
- Style new calculator panels
- Expand Lithuanian GKS option texts to full phrases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06a8769c8832080169fe17041ae57