### PR TITLE
Add blood order section with group buttons

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -66,8 +66,8 @@ label.chip input{
 .chip-group{display:flex;flex-wrap:wrap;gap:8px}
 .gcs-calc{margin-top:8px;border:1px solid var(--line);border-radius:10px;padding:8px;background:#152231}
 .gcs-calc .grid{margin-bottom:8px}
-.labs-controls{display:flex;gap:8px;align-items:flex-start;flex-wrap:wrap}
-.labs-controls .chip-group{flex:1}
+.blood-order-box{margin-top:8px;border:1px solid var(--line);border-radius:10px;padding:8px}
+.blood-order-box .row{gap:8px;flex-wrap:wrap;align-items:center}
 .breath-chip{padding:12px 20px;font-size:18px}
 .hint{color:var(--muted);font-size:12px}
 .badge{padding:2px 8px;border-radius:8px;font-size:12px;border:1px solid var(--line);background:#152231;color:var(--muted)}

--- a/index.html
+++ b/index.html
@@ -340,12 +340,12 @@
     </section>
     <section class="card view" data-tab="Laboratorija">
       <h2>Laboratoriniai tyrimai</h2>
-      <div class="labs-controls">
-        <div class="chip-group" id="labs_basic" aria-label="Laboratoriniai tyrimai"></div>
-        <button type="button" class="btn" id="btnBloodOrder">Kraujo užsakymas</button>
-        <div id="bloodOrderForm" class="row" style="display:none;">
-          <input type="number" id="bloodUnits" placeholder="Vnt">
-          <input type="text" id="bloodGroup" placeholder="Grupė">
+      <div class="chip-group" id="labs_basic" aria-label="Laboratoriniai tyrimai"></div>
+      <div class="blood-order-box">
+        <label>Kraujo užsakymas</label>
+        <div class="row" style="gap:8px;flex-wrap:wrap;align-items:center;">
+          <input type="number" id="bloodUnits" placeholder="Vnt" style="width:80px;">
+          <div class="chip-group" id="bloodGroup" data-single="true" aria-label="Kraujo grupė"></div>
           <button type="button" class="btn" id="addBloodOrder">Pridėti</button>
         </div>
       </div>

--- a/js/app.js
+++ b/js/app.js
@@ -68,24 +68,21 @@ function initSessions(){
 const IMG_CT=['Galvos KT','Kaklo KT','Viso kūno KT'];
 const IMG_XRAY=['Krūtinės Ro','Dubens Ro'];
 const LABS=['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
+const BLOOD_GROUPS=['0-','0+','A-','A+','B-','B+','AB-','AB+'];
 const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas'];
 
 const imgCtWrap=$('#imaging_ct'); IMG_CT.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; imgCtWrap.appendChild(s);});
 const imgXrayWrap=$('#imaging_xray'); IMG_XRAY.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; imgXrayWrap.appendChild(s);});
 const imgOtherWrap=$('#imaging_other_group'); ['Kita'].forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; imgOtherWrap.appendChild(s);});
 const labsWrap=$('#labs_basic'); LABS.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; labsWrap.appendChild(s);});
-const btnBloodOrder=$('#btnBloodOrder');
-const bloodOrderForm=$('#bloodOrderForm');
+const bloodGroupWrap=$('#bloodGroup'); if(bloodGroupWrap){ BLOOD_GROUPS.forEach(g=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=g; s.textContent=g; bloodGroupWrap.appendChild(s);}); }
 const bloodUnitsInput=$('#bloodUnits');
-const bloodGroupInput=$('#bloodGroup');
 const addBloodOrderBtn=$('#addBloodOrder');
-if(btnBloodOrder && bloodOrderForm && addBloodOrderBtn){
-  btnBloodOrder.addEventListener('click',()=>{
-    bloodOrderForm.style.display=bloodOrderForm.style.display==='none'?'flex':'none';
-  });
+if(bloodUnitsInput && bloodGroupWrap && addBloodOrderBtn){
   addBloodOrderBtn.addEventListener('click',()=>{
     const units=bloodUnitsInput.value.trim();
-    const group=bloodGroupInput.value.trim();
+    const groupEl=$$('.chip',bloodGroupWrap).find(c=>isChipActive(c));
+    const group=groupEl?.dataset.value||'';
     if(!units||!group) return;
     const val=`Kraujo užsakymas: ${units} vnt ${group}`;
     const chip=document.createElement('span');
@@ -96,8 +93,7 @@ if(btnBloodOrder && bloodOrderForm && addBloodOrderBtn){
     setChipActive(chip,true);
     saveAll();
     bloodUnitsInput.value='';
-    bloodGroupInput.value='';
-    bloodOrderForm.style.display='none';
+    $$('.chip',bloodGroupWrap).forEach(c=>setChipActive(c,false));
   });
 }
 const IMAGING_GROUPS=['#imaging_ct','#imaging_xray','#imaging_other_group'];


### PR DESCRIPTION
## Summary
- add dedicated blood order box in laboratory tab
- include selectable blood group chips and logic
- style blood order container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06f197258832081525d75229e532c