### PR TITLE
Improve GCS calculator accessibility

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -305,18 +305,41 @@ function setupGcsCalc(prefix){
   const selM=$(`#${prefix}_gcs_calc_m`);
   const apply=$(`#${prefix}_gcs_apply`);
   const total=$(`#${prefix}_gcs_calc_total`);
+  const btn = prefix==='spr' ? $('#btnSprGCSCalc') : $('#btnGCSCalc');
   if(!panel||!selA||!selK||!selM||!apply||!total) return ()=>{};
+
   const update=()=>{ total.textContent=gksSum(selA.value,selK.value,selM.value); };
   [selA,selK,selM].forEach(sel=>sel.addEventListener('change',update));
+
+  const close=()=>{
+    panel.style.display='none';
+    document.removeEventListener('keydown',onKey);
+    document.removeEventListener('click',onDocClick);
+    if(btn) btn.focus();
+  };
+  const onKey=e=>{ if(e.key==='Escape') close(); };
+  const onDocClick=e=>{ if(!panel.contains(e.target) && e.target!==btn) close(); };
+
   apply.addEventListener('click',()=>{
     if(selA.value) $(`#${prefix}_gksa`).value=selA.value;
     if(selK.value) $(`#${prefix}_gksk`).value=selK.value;
     if(selM.value) $(`#${prefix}_gksm`).value=selM.value;
     ['#'+prefix+'_gksa','#'+prefix+'_gksk','#'+prefix+'_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
-    panel.style.display='none';
+    close();
     saveAll();
   });
-  return ()=>{ panel.style.display = panel.style.display==='none' ? 'block' : 'none'; };
+
+  return ()=>{
+    const hidden=panel.style.display==='none';
+    if(hidden){
+      panel.style.display='block';
+      document.addEventListener('keydown',onKey);
+      document.addEventListener('click',onDocClick);
+      selA.focus();
+    }else{
+      close();
+    }
+  };
 }
 if($('#d_gcs_calc') && $('#btnGCSCalc')){
   const toggleDGcs=setupGcsCalc('d');

--- a/js/patient.test.js
+++ b/js/patient.test.js
@@ -7,6 +7,13 @@ const setupDom = () => {
     <button id="btnPdf"></button>
     <button id="btnGCS15"></button>
     <button id="btnGCSCalc"></button>
+    <div id="d_gcs_calc" style="display:none">
+      <select id="d_gcs_calc_a"></select>
+      <select id="d_gcs_calc_k"></select>
+      <select id="d_gcs_calc_m"></select>
+      <button id="d_gcs_apply"></button>
+      <span id="d_gcs_calc_total"></span>
+    </div>
     <input type="checkbox" id="e_back_ny" />
     <button id="btnGen"></button>
     <textarea id="output"></textarea>
@@ -82,5 +89,33 @@ describe('patient fields', () => {
     expect(report).toContain('25');
     expect(report).toContain('M');
     expect(report).toContain('ID123');
+  });
+
+  test('GCS panel focuses first select and closes on Escape', () => {
+    require('./app.js');
+    const btn=document.getElementById('btnGCSCalc');
+    const panel=document.getElementById('d_gcs_calc');
+    const selA=document.getElementById('d_gcs_calc_a');
+
+    btn.click();
+    expect(panel.style.display).toBe('block');
+    expect(document.activeElement).toBe(selA);
+
+    document.dispatchEvent(new KeyboardEvent('keydown',{key:'Escape'}));
+    expect(panel.style.display).toBe('none');
+    expect(document.activeElement).toBe(btn);
+  });
+
+  test('GCS panel closes when clicking outside', () => {
+    require('./app.js');
+    const btn=document.getElementById('btnGCSCalc');
+    const panel=document.getElementById('d_gcs_calc');
+
+    btn.click();
+    expect(panel.style.display).toBe('block');
+
+    document.body.click();
+    expect(panel.style.display).toBe('none');
+    expect(document.activeElement).toBe(btn);
   });
 });


### PR DESCRIPTION
## Summary
- Close GCS calculator when Escape is pressed or when clicking outside the panel
- Manage focus by directing it to the first select on open and back to the trigger button on close
- Test GCS panel focus and closing behaviors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a071506b7c8320a71cb38b23838296