### PR TITLE
Add timeline logging for actions and vital signs

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -81,6 +81,10 @@ label.chip input{
 .med-search{margin-bottom:8px;width:100%}
 .subtle{font-size:12px;color:var(--muted)}
 .divider{height:1px;background:var(--line);margin:10px 0}
+
+.timeline-list{border:1px solid var(--line);border-radius:10px;padding:8px;max-height:300px;overflow-y:auto}
+.timeline-entry{padding:4px 0;border-bottom:1px solid var(--line)}
+.timeline-entry:last-child{border-bottom:none}
 /* SVG body map */
 .map-toolbar{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin:6px 0}
 .tool{padding:8px 10px;border-radius:10px;border:1px solid var(--line);background:#152231;color:var(--ink);min-height:36px;cursor:pointer;font-weight:700}

--- a/index.html
+++ b/index.html
@@ -441,6 +441,19 @@
         </div>
       </div>
     </section>
+    <section class="card view" data-tab="Laiko juosta">
+      <h2>Laiko juosta</h2>
+      <div class="row" style="gap:8px;margin-bottom:8px;">
+        <select id="timelineFilter">
+          <option value="">Visi</option>
+          <option value="med">Vaistai</option>
+          <option value="proc">Procedūros</option>
+          <option value="vital">Gyvybiniai rodikliai</option>
+        </select>
+        <button type="button" class="btn" id="timelineExport">Eksportuoti</button>
+      </div>
+      <div id="timelineList" class="timeline-list"></div>
+    </section>
     <section class="card view" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Spauskite „Sugeneruoti ataskaitą“..."></textarea><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
   </div>
 </main>

--- a/js/actions.js
+++ b/js/actions.js
@@ -1,4 +1,5 @@
 import { $, nowHM } from './utils.js';
+import { logEvent } from './timeline.js';
 
 export const PAIN_MEDS = ['Fentanilis','Paracetamolis','Ketoprofenas'];
 export const BLEEDING_MEDS = ['TXA','O- kraujas','Fibryga','Ca gliukonatas'];
@@ -53,6 +54,7 @@ function buildActionCard(group, name, saveAll, opts={}){
     if(chk.checked){
       if(!time.value) time.value=nowHM();
       if(includeDose && dose && !dose.value && DEFAULT_DOSES[name]) dose.value = DEFAULT_DOSES[name];
+      logEvent(group, name, includeDose && dose ? dose.value : '', time.value);
     }
     update();
     if(typeof saveAll==='function') saveAll();

--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,7 @@ import { initTabs, showTab } from './tabs.js';
 import { initChips, listChips, setChipActive, isChipActive } from './chips.js';
 import { initAutoActivate } from './autoActivate.js';
 import { initActions } from './actions.js';
+import { logEvent, initTimeline } from './timeline.js';
 
 /* ===== Sessions ===== */
 let currentSessionId = localStorage.getItem('trauma_current_session') || null;
@@ -389,9 +390,28 @@ function init(){
   initTabs();
   initChips(saveAll);
   initAutoActivate(saveAll);
-    initActions(saveAll);
-    setupActivationControls();
-    document.addEventListener('input', saveAll);
+  initActions(saveAll);
+  initTimeline();
+  setupActivationControls();
+  document.addEventListener('input', saveAll);
+
+  const vitals = {
+    '#gmp_hr': 'GMP ŠSD',
+    '#gmp_rr': 'GMP KD',
+    '#gmp_spo2': 'GMP SpO₂',
+    '#gmp_sbp': 'GMP AKS s',
+    '#gmp_dbp': 'GMP AKS d',
+    '#b_rr': 'KD',
+    '#b_spo2': 'SpO₂',
+    '#c_hr': 'ŠSD',
+    '#c_sbp': 'AKS s',
+    '#c_dbp': 'AKS d',
+    '#c_caprefill': 'KPL'
+  };
+  Object.entries(vitals).forEach(([sel,label])=>{
+    const el=$(sel);
+    if(el) el.addEventListener('change',()=>{ if(el.value) logEvent('vital', label, el.value); });
+  });
     const updateDGksTotal=()=>{
       $('#d_gks_total').textContent=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value);
     };

--- a/js/timeline.js
+++ b/js/timeline.js
@@ -1,0 +1,49 @@
+import { $, nowHM } from './utils.js';
+
+const entries = [];
+
+export function logEvent(type, label, value = '', time = nowHM()) {
+  entries.push({ time, type, label, value });
+  renderTimeline();
+}
+
+export function getEntries(filter = '') {
+  return entries
+    .filter(e => !filter || e.type === filter)
+    .sort((a, b) => a.time.localeCompare(b.time));
+}
+
+export function renderTimeline() {
+  const list = $('#timelineList');
+  if (!list) return;
+  const filter = $('#timelineFilter')?.value || '';
+  list.innerHTML = '';
+  getEntries(filter).forEach(e => {
+    const div = document.createElement('div');
+    div.className = 'timeline-entry';
+    div.textContent = `${e.time} – ${e.label}${e.value ? ': ' + e.value : ''}`;
+    list.appendChild(div);
+  });
+}
+
+export function initTimeline() {
+  $('#timelineFilter')?.addEventListener('change', renderTimeline);
+  $('#timelineExport')?.addEventListener('click', () => {
+    const csv = entries
+      .map(e => `${e.time},${e.type},${e.label},${e.value}`)
+      .join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'timeline.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+  renderTimeline();
+}
+
+export function clearTimeline() {
+  entries.length = 0;
+  renderTimeline();
+}


### PR DESCRIPTION
## Summary
- add timeline module to track medications, procedures, and vital sign updates
- log timeline entries from action selections and vital input changes
- provide new "Laiko juosta" tab with filters and CSV export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0719e0d808320a0c0b0f2aceb358f