### PR TITLE
Display timezone in timeline entries

### DIFF
--- a/js/timeline.js
+++ b/js/timeline.js
@@ -1,4 +1,4 @@
-import { $, nowHM } from './utils.js';
+import { $, nowHM, timeZoneOffset } from './utils.js';
 
 const entries = [];
 
@@ -17,11 +17,12 @@ export function renderTimeline() {
   const list = $('#timelineList');
   if (!list) return;
   const filter = $('#timelineFilter')?.value || '';
+  const tz = timeZoneOffset();
   list.innerHTML = '';
   getEntries(filter).forEach(e => {
     const div = document.createElement('div');
     div.className = 'timeline-entry';
-    div.textContent = `${e.time} – ${e.label}${e.value ? ': ' + e.value : ''}`;
+    div.textContent = `${e.time} ${tz} – ${e.label}${e.value ? ': ' + e.value : ''}`;
     list.appendChild(div);
   });
 }
@@ -29,8 +30,9 @@ export function renderTimeline() {
 export function initTimeline() {
   $('#timelineFilter')?.addEventListener('change', renderTimeline);
   $('#timelineExport')?.addEventListener('click', () => {
+    const tz = timeZoneOffset();
     const csv = entries
-      .map(e => `${e.time},${e.type},${e.label},${e.value}`)
+      .map(e => `${e.time} ${tz},${e.type},${e.label},${e.value}`)
       .join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);

--- a/js/timeline.test.js
+++ b/js/timeline.test.js
@@ -1,0 +1,14 @@
+import { logEvent, clearTimeline } from './timeline.js';
+
+describe('timeline timezone', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="timelineList"></div>';
+    clearTimeline();
+  });
+
+  test('rendered entries include timezone', () => {
+    logEvent('test', 'label', 'value', '12:00');
+    const text = document.getElementById('timelineList').textContent;
+    expect(text).toMatch(/UTC/);
+  });
+});

--- a/js/utils.js
+++ b/js/utils.js
@@ -5,3 +5,12 @@ export const nowHM = () => {
   const p = n => String(n).padStart(2, '0');
   return `${p(d.getHours())}:${p(d.getMinutes())}`;
 };
+
+export const timeZoneOffset = () => {
+  const offset = -new Date().getTimezoneOffset();
+  const sign = offset >= 0 ? '+' : '-';
+  const abs = Math.abs(offset);
+  const hours = String(Math.floor(abs / 60)).padStart(2, '0');
+  const minutes = String(abs % 60).padStart(2, '0');
+  return `UTC${sign}${hours}:${minutes}`;
+};


### PR DESCRIPTION
## Summary
- add `timeZoneOffset` util for UTC offset formatting
- show timezone in timeline UI and CSV export
- test that timeline entries include timezone

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a082c424948320af2e5e7c4da42569