### PR TITLE
Use delegated event handling for action cards

### DIFF
--- a/js/actions.test.js
+++ b/js/actions.test.js
@@ -15,13 +15,13 @@ describe('initActions default doses', () => {
     const chk = card.querySelector('.act_chk');
     const dose = card.querySelector('.act_dose');
     chk.checked = true;
-    chk.dispatchEvent(new Event('change'));
+    chk.dispatchEvent(new Event('change', { bubbles: true }));
     expect(dose.value).toBe(DEFAULT_DOSES['Fentanilis']);
     dose.value = '150 mcg';
     chk.checked = false;
-    chk.dispatchEvent(new Event('change'));
+    chk.dispatchEvent(new Event('change', { bubbles: true }));
     chk.checked = true;
-    chk.dispatchEvent(new Event('change'));
+    chk.dispatchEvent(new Event('change', { bubbles: true }));
     expect(dose.value).toBe('150 mcg');
   });
 
@@ -41,7 +41,7 @@ describe('initActions default doses', () => {
       const chk = card.querySelector('.act_chk');
       const dose = card.querySelector('.act_dose');
       chk.checked = true;
-      chk.dispatchEvent(new Event('change'));
+      chk.dispatchEvent(new Event('change', { bubbles: true }));
       expect(dose.value).toBe(DEFAULT_DOSES[med]);
     }
   );


### PR DESCRIPTION
## Summary
- Delegate click and change events from medication/procedure wrappers instead of individual cards
- Auto-fill times and default doses, log events, and toggle details in the delegated handler
- Adjust tests to bubble change events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a091875d208320be5642e38c98e0c8