### PR TITLE
Add responsive four-column grid layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -25,6 +25,7 @@ section.card h2{font-size:16px;margin:0 0 10px}
 section.card .grid{display:grid;gap:10px}
 .cols-2{grid-template-columns:1fr 1fr}
 .cols-3{grid-template-columns:repeat(3,1fr)}
+.cols-4{grid-template-columns:repeat(4,1fr)}
 label{display:block;color:var(--muted);font-size:13px;margin-bottom:4px}
 input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select{
   width:100%;padding:9px 10px;border:1px solid var(--line);border-radius:10px;background:#0f1620;color:var(--ink);font-size:14px;outline:none
@@ -98,7 +99,7 @@ label.chip input{
 .hidden{display:none}
 .detail{overflow:hidden;max-height:200px;opacity:1;transition:max-height .3s ease,opacity .3s ease}
 .collapsed{max-height:0;opacity:0;pointer-events:none}
-@media (max-width:980px){ main{grid-template-columns:1fr} nav{position:static} .cols-3{grid-template-columns:1fr 1fr} .cols-2{grid-template-columns:1fr} }
+@media (max-width:980px){ main{grid-template-columns:1fr} nav{position:static} .cols-3{grid-template-columns:1fr 1fr} .cols-2{grid-template-columns:1fr} .cols-4{grid-template-columns:1fr 1fr} }
 @media print{ header,nav,.toolbar{display:none!important} body{background:#fff;color:#000} section.card{break-inside:avoid} }
 
 /* Interventions compact layout */


### PR DESCRIPTION
## Summary
- support four-column form layouts with new `.cols-4` grid class
- collapse four-column grids to two columns on narrow screens for better responsiveness

## Testing
- `npm test >/tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68a092f93bb883209b18c23022ff3b1c