### PR TITLE
Show patient info on activation page

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,9 +31,10 @@
   <nav id="tabs"></nav>
 
   <div id="views">
-    <!-- Pacientas -->
-    <section class="card view" data-tab="Pacientas">
-      <h2>Pacientas</h2>
+    <!-- Aktyvacija -->
+    <section class="card view" data-tab="Aktyvacija">
+        <h2>Traumos komandos aktyvacija <span class="badge">GMP rodikliai → auto</span></h2>
+      <h3>Pacientas</h3>
       <div class="grid cols-4">
         <div><label>Vardas</label><input id="patient_name" type="text"></div>
         <div><label>Amžius</label><input id="patient_age" type="number" min="0"></div>
@@ -46,10 +47,6 @@
         </div>
         <div><label>Paciento ID</label><input id="patient_id" type="text"></div>
       </div>
-    </section>
-    <!-- Aktyvacija -->
-    <section class="card view" data-tab="Aktyvacija">
-        <h2>Traumos komandos aktyvacija <span class="badge">GMP rodikliai → auto</span></h2>
       <div class="grid cols-3">
           <div><label>GMP ŠSD (k./min)</label><input id="gmp_hr" type="number" min="0" max="250"></div>
           <div><label>GMP KD (k./min)</label><input id="gmp_rr" type="number" min="0" max="80"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -96,6 +96,7 @@ async function initSessions(){
     currentSessionId=id;
     populateSessionSelect(select, sessions);
     select.value=id;
+    localStorage.setItem('v10_activeTab','Aktyvacija');
     location.reload();
   });
   $('#btnRenameSession').addEventListener('click',()=>{
@@ -113,6 +114,7 @@ async function initSessions(){
     saveAll();
     localStorage.setItem('trauma_current_session', id);
     currentSessionId=id;
+    localStorage.setItem('v10_activeTab','Aktyvacija');
     location.reload();
   });
 }


### PR DESCRIPTION
## Summary
- Embed patient data fields into the Aktyvacija view
- Drop the separate Pacientas tab and default sessions to Aktyvacija so patient info is visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a092417c9483208daf481c4a466c99