### PR TITLE
Fix body map missing in printed report

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -705,17 +705,17 @@ document.getElementById('btnPrint').addEventListener('click',()=>{
   const prevTab=localStorage.getItem('v10_activeTab');
   generateReport();
   const text=$('#output').value||'';
-  const svg=$('#bodySvg').cloneNode(true);
-  const front=svg.querySelector('#layer-front');
-  const back=svg.querySelector('#layer-back');
-  if(front) front.classList.remove('hidden');
-  if(back) back.classList.remove('hidden');
   const printWin=window.open('','_blank');
   if(printWin){
     const doc=printWin.document;
     doc.open();
-    doc.write('<!DOCTYPE html><html><head><meta charset="utf-8"><title>Ataskaita</title><link rel="stylesheet" href="css/main.css"><style>body{font-family:sans-serif;padding:20px;} pre{white-space:pre-wrap;}</style></head><body></body></html>');
+    doc.write('<!DOCTYPE html><html><head><meta charset="utf-8"><title>Ataskaita</title><link rel="stylesheet" href="/css/main.css"><style>body{font-family:sans-serif;padding:20px;} pre{white-space:pre-wrap;}</style></head><body></body></html>');
     doc.close();
+    const svg=doc.importNode(document.getElementById('bodySvg'), true);
+    const front=svg.querySelector('#layer-front');
+    const back=svg.querySelector('#layer-back');
+    if(front) front.classList.remove('hidden');
+    if(back) back.classList.remove('hidden');
     const pre=doc.createElement('pre');
     pre.textContent=text;
     doc.body.appendChild(pre);

--- a/js/patient.test.js
+++ b/js/patient.test.js
@@ -136,4 +136,19 @@ describe('patient fields', () => {
     expect(mockJsPDF).toHaveBeenCalled();
     expect(mockSave).toHaveBeenCalledWith('report.pdf');
   });
+
+  test('print window contains body map', () => {
+    const newDoc = document.implementation.createHTMLDocument();
+    const openMock = jest.spyOn(window, 'open').mockReturnValue({
+      document: newDoc,
+      focus: jest.fn(),
+      print: jest.fn(),
+      close: jest.fn()
+    });
+    require('./app.js');
+    document.getElementById('btnPrint').click();
+    const svg = newDoc.querySelector('#bodySvg');
+    expect(svg).not.toBeNull();
+    openMock.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure print window loads body map by importing the existing SVG and using an absolute stylesheet path
- add regression test verifying printed document contains body map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b6376aac83209589d981e05c3700