### PR TITLE
Refine breathing section layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -69,7 +69,9 @@ label.chip input{
 .gcs-calc .grid{margin-bottom:8px}
 .blood-order-box{margin-top:8px;border:1px solid var(--line);border-radius:10px;padding:8px}
 .blood-order-box .row{gap:8px;flex-wrap:wrap;align-items:center}
-.breath-chip{padding:12px 20px;font-size:18px}
+.breath-chip{padding:12px 20px;font-size:24px}
+section[data-tab="B – Kvėpavimas"] h3{margin:12px 0 4px;font-size:14px;color:var(--muted)}
+section[data-tab="B – Kvėpavimas"] h3:first-of-type{margin-top:0}
 .hint{color:var(--muted);font-size:12px}
 .badge{padding:2px 8px;border-radius:8px;font-size:12px;border:1px solid var(--line);background:#152231;color:var(--muted)}
 .activation-dot{width:12px;height:12px;border-radius:50%;display:none;margin-left:8px}

--- a/index.html
+++ b/index.html
@@ -109,18 +109,18 @@
     <!-- B -->
     <section class="card view" data-tab="B – Kvėpavimas">
       <h2>B – Kvėpavimas</h2>
+      <h3>Gyvybiniai rodikliai</h3>
       <div class="grid cols-2">
         <div><label>KD (k./min)</label><input id="b_rr" type="number" min="0" max="80"></div>
         <div><label>SpO₂ (%)</label><input id="b_spo2" type="number" min="0" max="100"></div>
       </div>
-      <div style="margin-top:8px">
-        <label>Alsavimas</label>
-        <div class="row">
-          <div><div class="subtle">Kairė</div><div class="chip-group" id="b_breath_left_group" data-single="true" aria-label="Alsavimas – Kairė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false">+</button><button type="button" class="chip breath-chip" data-value="-" aria-pressed="false">-</button></div></div>
-          <div><div class="subtle">Dešinė</div><div class="chip-group" id="b_breath_right_group" data-single="true" aria-label="Alsavimas – Dešinė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false">+</button><button type="button" class="chip breath-chip" data-value="-" aria-pressed="false">-</button></div></div>
-        </div>
+      <h3>Alsavimas</h3>
+      <div class="row">
+        <div><div class="subtle">Kairė</div><div class="chip-group" id="b_breath_left_group" data-single="true" aria-label="Alsavimas – Kairė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false">+</button><button type="button" class="chip breath-chip" data-value="-" aria-pressed="false">-</button></div></div>
+        <div><div class="subtle">Dešinė</div><div class="chip-group" id="b_breath_right_group" data-single="true" aria-label="Alsavimas – Dešinė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false">+</button><button type="button" class="chip breath-chip" data-value="-" aria-pressed="false">-</button></div></div>
       </div>
-      <div class="row" style="margin-top:8px;flex-wrap:wrap">
+      <h3>Pagalbinė ventiliacija</h3>
+      <div class="row" style="flex-wrap:wrap">
         <div class="row" style="gap:8px;align-items:center;">
           <button type="button" class="btn" id="btnOxygen">O2</button>
           <div id="oxygenFields" class="row" style="display:none;gap:8px;">


### PR DESCRIPTION
## Summary
- highlight separate groups on the breathing page with section headings
- enlarge +/- breathing chips for easier visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b6f87a34832083c4bcb2fe906840