### PR TITLE
feat: add light/dark theme toggle

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,8 +1,16 @@
-:root{
+:root{color-scheme:light dark}
+
+:root.dark{
   --bg:#0c1218;--card:#121a24;--ink:#e9f2fb;
   /* brighten supporting colours for better contrast */
   --muted:#c2d0e0;--line:#2d3b4f;
   --accent:#4ea0f5;--red:#e53935;--yellow:#ffcc00;--green:#00c853;--ink2:#d7ecff;
+}
+
+:root.light{
+  --bg:#ffffff;--card:#f5f7fa;--ink:#0c1218;
+  --muted:#5b6b7c;--line:#d0d7e2;
+  --accent:#0066cc;--red:#e53935;--yellow:#ffcc00;--green:#00c853;--ink2:#0c1218;
 }
 *{box-sizing:border-box}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Traumos forma – Desktop v10 (SVG kūno žemėlapis)</title>
+<script>
+  (function(){
+    const saved=localStorage.getItem('trauma_theme');
+    const prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme=saved|| (prefersDark?'dark':'light');
+    document.documentElement.classList.add(theme);
+  })();
+</script>
 <link rel="stylesheet" href="css/main.css">
 </head>
 <body>
@@ -23,6 +31,7 @@
       <button type="button" class="btn ghost" id="btnClear">Išvalyti</button>
       <button type="button" class="btn" id="btnPdf">PDF</button>
       <button type="button" class="btn warn" id="btnPrint">🖨 Spausdinti</button>
+      <button type="button" class="btn" id="themeToggle">🌓 Tema</button>
     </div>
   </div>
 </header>

--- a/js/app.js
+++ b/js/app.js
@@ -8,6 +8,31 @@ import { logEvent, initTimeline } from './timeline.js';
 let authToken = localStorage.getItem('trauma_token') || null;
 let socket = null;
 
+function applyTheme(t){
+  document.documentElement.classList.remove('light','dark');
+  document.documentElement.classList.add(t);
+}
+
+function initTheme(){
+  let theme = localStorage.getItem('trauma_theme');
+  if(!theme){
+    theme = document.documentElement.classList.contains('light') ? 'light' :
+      document.documentElement.classList.contains('dark') ? 'dark' :
+      ((typeof window.matchMedia==='function' && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light');
+  }
+  applyTheme(theme);
+  const btn = document.getElementById('themeToggle');
+  if(btn){
+    btn.addEventListener('click',()=>{
+      const next = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
+      applyTheme(next);
+      localStorage.setItem('trauma_theme', next);
+    });
+  }
+}
+
+initTheme();
+
 async function ensureLogin(){
   if(authToken || typeof fetch !== 'function' || typeof prompt !== 'function') return;
   try{


### PR DESCRIPTION
## Summary
- add `:root.light` and `:root.dark` theme variables and default script
- provide button to switch themes and persist preference
- initialize theme on load based on saved choice or system preference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1a62d97ac8320a0fc69eee5f5e4c1