### PR TITLE
feat: add arrow key navigation for chip groups

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -93,12 +93,39 @@ export function initChips(saveAll){
     handleChip(chip);
   }, true);
 
+  // Support keyboard interaction:
+  // * Enter/Space toggles the active state of a chip
+  // * Arrow keys move focus within a chip group. For radiogroups the
+  //   newly focused chip is activated automatically to mirror native
+  //   radio behaviour.
   document.addEventListener('keydown', e => {
-    if(e.key !== 'Enter' && e.key !== ' ') return;
     const chip = e.target.closest('.chip');
     if(!chip) return;
-    e.preventDefault();
-    handleChip(chip);
+
+    if(e.key === 'Enter' || e.key === ' '){
+      e.preventDefault();
+      handleChip(chip);
+      return;
+    }
+
+    if(['ArrowLeft','ArrowRight','ArrowUp','ArrowDown'].includes(e.key)){
+      const group = chip.parentElement;
+      if(!group) return;
+      const chips = $$('.chip', group);
+      const activeIndex = chips.findIndex(isChipActive);
+      let index = activeIndex !== -1 ? activeIndex : chips.indexOf(chip);
+      if(e.key === 'ArrowLeft' || e.key === 'ArrowUp'){
+        index = (index - 1 + chips.length) % chips.length;
+      } else {
+        index = (index + 1) % chips.length;
+      }
+      const nextChip = chips[index];
+      e.preventDefault();
+      nextChip.focus();
+      if(group.dataset?.single === 'true'){
+        handleChip(nextChip);
+      }
+    }
   }, true);
 }
 

--- a/js/chips.test.js
+++ b/js/chips.test.js
@@ -66,6 +66,41 @@ describe('chips', () => {
     expect(isChipActive(chip)).toBe(false);
   });
 
+  test('navigates and activates chips with arrow keys in radiogroups', () => {
+    document.body.innerHTML = `
+      <div id="group" data-single="true">
+        <span class="chip" data-value="a"></span>
+        <span class="chip" data-value="b"></span>
+      </div>
+    `;
+    const { initChips, isChipActive } = require('./chips.js');
+    initChips();
+    const [chip1, chip2] = document.querySelectorAll('#group .chip');
+    chip1.focus();
+    chip1.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(document.activeElement).toBe(chip2);
+    expect(isChipActive(chip2)).toBe(true);
+    expect(isChipActive(chip1)).toBe(false);
+  });
+
+  test('moves focus with arrow keys without toggling in multiselect groups', () => {
+    document.body.innerHTML = `
+      <div id="group">
+        <span class="chip" data-value="a"></span>
+        <span class="chip" data-value="b"></span>
+      </div>
+    `;
+    const { initChips, isChipActive } = require('./chips.js');
+    initChips();
+    const [chip1, chip2] = document.querySelectorAll('#group .chip');
+    chip1.click(); // activate first chip
+    chip1.focus();
+    chip1.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(document.activeElement).toBe(chip2);
+    expect(isChipActive(chip1)).toBe(true);
+    expect(isChipActive(chip2)).toBe(false);
+  });
+
   test('shows hospital field when transfer decision selected', () => {
     document.body.innerHTML = `
       <div id="spr_decision_group" data-single="true">


### PR DESCRIPTION
## Summary
- support arrow-key navigation between chips and auto-select in radiogroups
- document keyboard behavior for chip groups
- cover arrow navigation and activation in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a643aa1c8320824dc7ad4b6299d5