### PR TITLE
Add responsive nav toggle with focus trap

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -17,6 +17,7 @@ h1{font-size:20px;margin:4px 0}
 .btn.ghost{background:transparent;color:var(--muted);border-style:dashed}
 main{max-width:1200px;margin:12px auto;padding:0 16px;display:grid;grid-template-columns:220px 1fr;gap:12px}
 nav{position:sticky;top:68px;align-self:start}
+#navToggle{display:none}
 nav .tab{display:block;padding:10px 12px;border:1px solid var(--line);border-radius:10px;margin-bottom:8px;background:#152231;color:var(--ink);cursor:pointer;font-weight:600;text-align:left;text-transform:none;font-size:16px}
 nav .tab.active{background:#1f2e44;border-color:#2b405c}
 nav .tab:focus{outline:2px solid var(--accent)}
@@ -108,7 +109,26 @@ section[data-tab="B – Kvėpavimas"] h3:first-of-type{margin-top:0}
 .hidden{display:none}
 .detail{overflow:hidden;max-height:200px;opacity:1;transition:max-height .3s ease,opacity .3s ease}
 .collapsed{max-height:0;opacity:0;pointer-events:none}
-@media (max-width:980px){ main{grid-template-columns:1fr} nav{position:static} .cols-3{grid-template-columns:1fr 1fr} .cols-2{grid-template-columns:1fr} .cols-4{grid-template-columns:1fr 1fr} }
+@media (max-width:980px){
+  #navToggle{display:inline-block;margin-bottom:8px}
+  main{grid-template-columns:1fr}
+  nav{
+    position:fixed;
+    top:0;left:0;bottom:0;
+    width:220px;
+    background:#0d151f;
+    transform:translateX(-100%);
+    transition:transform .3s ease;
+    padding:14px 16px;
+    overflow:auto;
+    z-index:20;
+    pointer-events:none;
+  }
+  body.nav-open nav{transform:translateX(0);pointer-events:auto}
+  .cols-3{grid-template-columns:1fr 1fr}
+  .cols-2{grid-template-columns:1fr}
+  .cols-4{grid-template-columns:1fr 1fr}
+}
 @media print{ header,nav,.toolbar{display:none!important} body{background:#fff;color:#000} section.card{break-inside:avoid} }
 
 /* Interventions compact layout */

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
 <header>
   <div class="wrap">
+    <button type="button" class="btn" id="navToggle" aria-controls="tabs" aria-expanded="false">☰</button>
     <h1>Traumos forma – Desktop v10</h1>
     <div class="sub">Aktyvacija · ABCDE · LT · SVG kūno žemėlapis <span id="activationIndicator" class="activation-dot"></span></div>
     <div class="toolbar" id="sessionBar">

--- a/js/app.js
+++ b/js/app.js
@@ -5,6 +5,47 @@ import { initAutoActivate } from './autoActivate.js';
 import { initActions } from './actions.js';
 import { logEvent, initTimeline } from './timeline.js';
 
+function initNavToggle(){
+  const toggle = document.getElementById('navToggle');
+  const nav = document.querySelector('nav');
+  if(!toggle || !nav) return;
+  nav.setAttribute('aria-hidden','true');
+  const focusableSel = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+  const trap = e => {
+    if(e.key === 'Tab'){
+      const items = nav.querySelectorAll(focusableSel);
+      if(!items.length) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      if(e.shiftKey){
+        if(document.activeElement === first){ e.preventDefault(); last.focus(); }
+      }else{
+        if(document.activeElement === last){ e.preventDefault(); first.focus(); }
+      }
+    }else if(e.key === 'Escape'){
+      close();
+    }
+  };
+  const open = () => {
+    document.body.classList.add('nav-open');
+    toggle.setAttribute('aria-expanded','true');
+    nav.removeAttribute('aria-hidden');
+    const items = nav.querySelectorAll(focusableSel);
+    if(items.length) items[0].focus();
+    document.addEventListener('keydown', trap);
+  };
+  const close = () => {
+    document.body.classList.remove('nav-open');
+    toggle.setAttribute('aria-expanded','false');
+    nav.setAttribute('aria-hidden','true');
+    document.removeEventListener('keydown', trap);
+    toggle.focus();
+  };
+  toggle.addEventListener('click', () => {
+    document.body.classList.contains('nav-open') ? close() : open();
+  });
+}
+
 let authToken = localStorage.getItem('trauma_token') || null;
 let socket = null;
 
@@ -510,6 +551,7 @@ async function init(){
   connectSocket();
   await initSessions();
   initTabs();
+  initNavToggle();
   initChips(saveAllDebounced);
   initAutoActivate(saveAllDebounced);
   initActions(saveAllDebounced);


### PR DESCRIPTION
## Summary
- Add hamburger button to toggle sidebar navigation
- Hide sidebar off-canvas on small screens and reveal when `nav-open` is applied
- Implement JavaScript toggle with focus trapping and restored focus

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a6523ce88320b2259b27ad3a6fd4