### PR TITLE
feat: add reusable modal and toast components

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -128,3 +128,14 @@ section[data-tab="Intervencijos"] .interv-groups{gap:6px}
 section[data-tab="Intervencijos"] .med-search{margin-bottom:4px}
 section[data-tab="Intervencijos"] h3{margin:0 0 4px;font-size:13px;color:var(--muted);display:flex;align-items:center;gap:4px}
 section[data-tab="Intervencijos"] .cols-3{grid-template-columns:repeat(4,1fr)}
+
+/* Modal and toast components */
+.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;z-index:1000}
+.modal{background:var(--card);color:var(--ink);padding:20px;border-radius:10px;box-shadow:0 2px 10px rgba(0,0,0,0.3);max-width:90%;width:320px}
+.modal p{margin-top:0}
+.modal .actions{display:flex;justify-content:flex-end;gap:8px;margin-top:16px}
+.toast-container{position:fixed;bottom:20px;right:20px;display:flex;flex-direction:column;gap:8px;z-index:1000}
+.toast{background:var(--card);color:var(--ink);border:1px solid var(--line);padding:10px 16px;border-radius:6px;box-shadow:0 2px 6px rgba(0,0,0,0.2);transition:opacity .3s,transform .3s}
+.toast.success{background:var(--green);color:#fff}
+.toast.error{background:var(--red);color:#fff}
+.toast.hide{opacity:0;transform:translateY(10px)}

--- a/js/app.js
+++ b/js/app.js
@@ -4,6 +4,8 @@ import { initChips, listChips, setChipActive, isChipActive } from './chips.js';
 import { initAutoActivate } from './autoActivate.js';
 import { initActions } from './actions.js';
 import { logEvent, initTimeline } from './timeline.js';
+import { promptModal, confirmModal } from './components/modal.js';
+import { showToast } from './components/toast.js';
 
 let authToken = localStorage.getItem('trauma_token') || null;
 let socket = null;
@@ -34,9 +36,9 @@ function initTheme(){
 initTheme();
 
 async function ensureLogin(){
-  if(authToken || typeof fetch !== 'function' || typeof prompt !== 'function') return;
+  if(authToken || typeof fetch !== 'function') return;
   try{
-    const name = prompt('Įveskite vardą dalyvauti bendroje sesijoje');
+    const name = await promptModal('Įveskite vardą dalyvauti bendroje sesijoje');
     if(!name) return;
     const res = await fetch('/api/login', {
       method: 'POST',
@@ -111,8 +113,8 @@ async function initSessions(){
   populateSessionSelect(select, sessions);
   select.value=currentSessionId;
 
-  $('#btnNewSession').addEventListener('click',()=>{
-    const name=prompt('Sesijos pavadinimas');
+  $('#btnNewSession').addEventListener('click',async()=>{
+    const name=await promptModal('Sesijos pavadinimas');
     if(!name) return;
     const id=Date.now().toString(36);
     sessions.push({id,name});
@@ -124,10 +126,10 @@ async function initSessions(){
     localStorage.setItem('v10_activeTab','Aktyvacija');
     location.reload();
   });
-  $('#btnRenameSession').addEventListener('click',()=>{
+  $('#btnRenameSession').addEventListener('click',async()=>{
     const sess=sessions.find(s=>s.id===select.value);
     if(!sess) return;
-    const name=prompt('Naujas pavadinimas', sess.name);
+    const name=await promptModal('Naujas pavadinimas', sess.name);
     if(!name) return;
     sess.name=name;
     saveSessions(sessions);
@@ -231,7 +233,12 @@ const BodySVG=(function(){
     const list=[...marks.querySelectorAll('use')].filter(u=>u.dataset.side===side);
     const last=list.pop(); if(last){ last.remove(); saveAll(); }
   });
-  btnClear.addEventListener('click',()=>{ if(confirm('Išvalyti visas žymas (priekis ir nugara)?')){ marks.innerHTML=''; saveAll(); }});
+  btnClear.addEventListener('click',async()=>{
+    if(await confirmModal('Išvalyti visas žymas (priekis ir nugara)?')){
+      marks.innerHTML='';
+      saveAll();
+    }
+  });
 
   btnExport.addEventListener('click',()=>{
     const clone=svg.cloneNode(true);
@@ -744,9 +751,16 @@ export function generateReport(){
 }
 document.getElementById('btnGen').addEventListener('click',()=>{ if(validateForm()) generateReport(); });
 
-document.getElementById('btnCopy').addEventListener('click',async()=>{ try{ await navigator.clipboard.writeText($('#output').value||''); alert('Nukopijuota.'); }catch(e){ alert('Nepavyko nukopijuoti.'); }});
-document.getElementById('btnSave').addEventListener('click',()=>{ if(validateForm()){ saveAll(); alert('Išsaugota naršyklėje.'); }});
-document.getElementById('btnClear').addEventListener('click',()=>{ if(confirm('Išvalyti viską?')){ localStorage.removeItem(sessionKey()); location.reload(); }});
+document.getElementById('btnCopy').addEventListener('click',async()=>{
+  try{
+    await navigator.clipboard.writeText($('#output').value||'');
+    showToast('Nukopijuota.','success');
+  }catch(e){
+    showToast('Nepavyko nukopijuoti.','error');
+  }
+});
+document.getElementById('btnSave').addEventListener('click',()=>{ if(validateForm()){ saveAll(); showToast('Išsaugota naršyklėje.','success'); }});
+document.getElementById('btnClear').addEventListener('click',async()=>{ if(await confirmModal('Išvalyti viską?')){ localStorage.removeItem(sessionKey()); location.reload(); }});
 document.getElementById('btnPdf').addEventListener('click', async () => {
   if(!validateForm()) return;
   generateReport();
@@ -759,7 +773,7 @@ document.getElementById('btnPdf').addEventListener('click', async () => {
     doc.text(lines, 10, 10);
     doc.save('report.pdf');
   } catch (e) {
-    alert('Nepavyko sugeneruoti PDF.');
+    showToast('Nepavyko sugeneruoti PDF.','error');
     console.error('PDF generation failed', e);
   }
 });

--- a/js/components/modal.js
+++ b/js/components/modal.js
@@ -1,0 +1,102 @@
+export function promptModal(message, defaultValue = '') {
+  return new Promise(resolve => {
+    const prev = document.activeElement;
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    const box = document.createElement('div');
+    box.className = 'modal';
+    box.setAttribute('role', 'dialog');
+    box.setAttribute('aria-modal', 'true');
+    const p = document.createElement('p');
+    p.textContent = message;
+    box.appendChild(p);
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = defaultValue;
+    box.appendChild(input);
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+    const btnOk = document.createElement('button');
+    btnOk.textContent = 'OK';
+    btnOk.className = 'btn primary';
+    const btnCancel = document.createElement('button');
+    btnCancel.textContent = 'Cancel';
+    btnCancel.className = 'btn';
+    actions.appendChild(btnCancel);
+    actions.appendChild(btnOk);
+    box.appendChild(actions);
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+
+    const focusable = box.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    function trap(e){
+      if(e.key === 'Tab'){
+        if(e.shiftKey && document.activeElement === first){ e.preventDefault(); last.focus(); }
+        else if(!e.shiftKey && document.activeElement === last){ e.preventDefault(); first.focus(); }
+      } else if(e.key === 'Escape'){ e.preventDefault(); close(null); }
+    }
+    function close(val){
+      overlay.remove();
+      document.removeEventListener('keydown', trap, true);
+      prev?.focus();
+      resolve(val);
+    }
+    btnOk.addEventListener('click',()=>close(input.value.trim()||null));
+    btnCancel.addEventListener('click',()=>close(null));
+    overlay.addEventListener('click',e=>{ if(e.target===overlay) close(null); });
+    document.addEventListener('keydown', trap, true);
+    input.addEventListener('keydown',e=>{ if(e.key==='Enter') btnOk.click(); });
+    first.focus();
+  });
+}
+
+export function confirmModal(message){
+  return new Promise(resolve => {
+    const prev = document.activeElement;
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    const box = document.createElement('div');
+    box.className = 'modal';
+    box.setAttribute('role', 'dialog');
+    box.setAttribute('aria-modal', 'true');
+    const p = document.createElement('p');
+    p.textContent = message;
+    box.appendChild(p);
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+    const btnOk = document.createElement('button');
+    btnOk.textContent = 'OK';
+    btnOk.className = 'btn primary';
+    const btnCancel = document.createElement('button');
+    btnCancel.textContent = 'Cancel';
+    btnCancel.className = 'btn';
+    actions.appendChild(btnCancel);
+    actions.appendChild(btnOk);
+    box.appendChild(actions);
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+
+    const focusable = box.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    function trap(e){
+      if(e.key==='Tab'){
+        if(e.shiftKey && document.activeElement===first){e.preventDefault();last.focus();}
+        else if(!e.shiftKey && document.activeElement===last){e.preventDefault();first.focus();}
+      }else if(e.key==='Escape'){e.preventDefault();close(false);}
+    }
+    function close(val){
+      overlay.remove();
+      document.removeEventListener('keydown',trap,true);
+      prev?.focus();
+      resolve(val);
+    }
+    btnOk.addEventListener('click',()=>close(true));
+    btnCancel.addEventListener('click',()=>close(false));
+    overlay.addEventListener('click',e=>{ if(e.target===overlay) close(false); });
+    document.addEventListener('keydown',trap,true);
+    first.focus();
+  });
+}

--- a/js/components/toast.js
+++ b/js/components/toast.js
@@ -1,0 +1,19 @@
+let container;
+
+export function showToast(message, type = 'info', duration = 3000) {
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'toast-container';
+    container.setAttribute('role', 'status');
+    container.setAttribute('aria-live', 'polite');
+    document.body.appendChild(container);
+  }
+  const toast = document.createElement('div');
+  toast.className = 'toast ' + type;
+  toast.textContent = message;
+  container.appendChild(toast);
+  setTimeout(() => {
+    toast.classList.add('hide');
+    setTimeout(() => toast.remove(), 300);
+  }, duration);
+}


### PR DESCRIPTION
## Summary
- add accessible modal and toast utilities with focus trapping
- replace blocking prompts and alerts with modals and toasts
- style modal and toast components for consistent theming

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a8c74ddc83208a683f8f9271f402