### PR TITLE
Add labels to breath sound controls for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,8 +139,8 @@
       </div>
       <h3>Alsavimas</h3>
       <div class="row">
-        <div><div class="subtle">Kairė</div><div class="chip-group" id="b_breath_left_group" data-single="true" aria-label="Alsavimas – Kairė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false">+</button><button type="button" class="chip breath-chip red" data-value="-" aria-pressed="false">-</button></div></div>
-        <div><div class="subtle">Dešinė</div><div class="chip-group" id="b_breath_right_group" data-single="true" aria-label="Alsavimas – Dešinė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false">+</button><button type="button" class="chip breath-chip red" data-value="-" aria-pressed="false">-</button></div></div>
+        <div><div class="subtle">Kairė</div><div class="chip-group" id="b_breath_left_group" data-single="true" aria-label="Alsavimas – Kairė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false" aria-label="Girdimi kvėpavimo garsai" title="Girdimi kvėpavimo garsai">+</button><button type="button" class="chip breath-chip red" data-value="-" aria-pressed="false" aria-label="Kvėpavimo garsai negirdimi" title="Kvėpavimo garsai negirdimi">-</button></div></div>
+        <div><div class="subtle">Dešinė</div><div class="chip-group" id="b_breath_right_group" data-single="true" aria-label="Alsavimas – Dešinė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false" aria-label="Girdimi kvėpavimo garsai" title="Girdimi kvėpavimo garsai">+</button><button type="button" class="chip breath-chip red" data-value="-" aria-pressed="false" aria-label="Kvėpavimo garsai negirdimi" title="Kvėpavimo garsai negirdimi">-</button></div></div>
       </div>
       <h3>Pagalbinė ventiliacija</h3>
       <div class="row" style="flex-wrap:wrap">


### PR DESCRIPTION
## Summary
- add descriptive aria-label and title attributes to breath sound buttons

## Testing
- `npm test`
- `node - <<'NODE'...` (axe-core button-name check)


------
https://chatgpt.com/codex/tasks/task_e_68a1a8da53b4832091f9e24bd281ee53