### PR TITLE
Add save status indicator with offline feedback

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -94,6 +94,9 @@ input.invalid,select.invalid{border-color:var(--red)}
 .activation-dot{width:12px;height:12px;border-radius:50%;display:none;margin-left:8px}
 .activation-dot.red{background:var(--red);display:inline-block}
 .activation-dot.yellow{background:var(--yellow);display:inline-block}
+#saveStatus{color:var(--muted);font-size:13px;margin-top:4px}
+#saveStatus.offline{color:var(--yellow)}
+#saveStatus.offline::before{content:'⚠ ';}
 .split{display:flex;gap:12px;flex-wrap:wrap}
 .split>div{flex:1}
 .interv-groups{display:flex;gap:8px;flex-wrap:wrap}

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
       <button type="button" class="btn warn" id="btnPrint">🖨 Spausdinti</button>
       <button type="button" class="btn" id="themeToggle">🌓 Tema</button>
     </div>
+    <div id="saveStatus" aria-live="polite"></div>
   </div>
 </header>
 

--- a/js/app.js
+++ b/js/app.js
@@ -351,12 +351,29 @@ export function saveAll(){
   data['pain_meds']=pack($('#pain_meds')); data['bleeding_meds']=pack($('#bleeding_meds')); data['other_meds']=pack($('#other_meds')); data['procs']=pack($('#procedures'));
   data['bodymap_svg']=BodySVG.serialize();
   localStorage.setItem(sessionKey(), JSON.stringify(data));
+  const statusEl = $('#saveStatus');
+  if(statusEl){
+    statusEl.textContent='Saving...';
+    statusEl.classList.remove('offline');
+  }
   if(authToken && typeof fetch === 'function'){
     fetch(`/api/sessions/${currentSessionId}/data`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json', 'Authorization': authToken },
       body: JSON.stringify(data)
-    }).catch(()=>{});
+    }).then(()=>{
+      if(statusEl){
+        statusEl.textContent='Saved';
+        statusEl.classList.remove('offline');
+      }
+    }).catch(()=>{
+      if(statusEl){
+        statusEl.textContent='Save failed';
+        statusEl.classList.add('offline');
+      }
+    });
+  } else if(statusEl){
+    statusEl.textContent='Saved';
   }
 }
 export function loadAll(){


### PR DESCRIPTION
## Summary
- Add a live-updating save status area in the header
- Show saving progress, success, and failure (with offline icon) in saveAll
- Style status text and provide offline icon indicator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a8e963c08320bbc7d3eb5becd918