### PR TITLE
Add input validation module and tests

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,8 @@ import { initActions } from './actions.js';
 import { logEvent, initTimeline } from './timeline.js';
 import { promptModal, confirmModal } from './components/modal.js';
 import { showToast } from './components/toast.js';
+import { initValidation, validateVitals } from './validation.js';
+export { validateVitals };
 
 function initNavToggle(){
   const toggle = document.getElementById('navToggle');
@@ -540,40 +542,6 @@ function clampNumberInputs(){
   });
 }
 
-function showInlineError(el,msg){
-  let err = el.nextElementSibling;
-  if(!err || !err.classList.contains('input-error')){
-    err = document.createElement('span');
-    err.className = 'input-error';
-    err.style.color = 'var(--danger)';
-    err.style.fontSize = '12px';
-    err.style.marginLeft = '4px';
-    el.insertAdjacentElement('afterend', err);
-  }
-  err.textContent = msg;
-  err.style.display = msg ? 'inline' : 'none';
-}
-
-export function validateVitals(){
-  const fields=['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm'];
-  fields.forEach(sel=>{
-    const el=$(sel);
-    if(!el) return;
-    const val=el.value.trim();
-    let msg='';
-    if(val!==''){
-      const num=parseFloat(val);
-      const min=el.getAttribute('min');
-      const max=el.getAttribute('max');
-      if((min!==null && num<parseFloat(min)) || (max!==null && num>parseFloat(max))){
-        msg=`Leistina ${min}–${max}`;
-      }
-    }
-    showInlineError(el,msg);
-  });
-  return true;
-}
-window.validateVitals=validateVitals;
 
 /* ===== Init modules ===== */
 async function init(){
@@ -642,10 +610,9 @@ async function init(){
       saveAll();
     });
     $('#output').addEventListener('input', expandOutput);
-    const vitalSelectors=['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm'];
-    vitalSelectors.forEach(sel=>{ const el=$(sel); if(el) el.addEventListener('input', validateVitals); });
     loadAll();
     clampNumberInputs();
+    initValidation();
     validateVitals();
     updateDGksTotal();
     updateGmpGksTotal();

--- a/js/patient.test.js
+++ b/js/patient.test.js
@@ -159,4 +159,18 @@ describe('patient fields', () => {
     expect(svg).not.toBeNull();
     openMock.mockRestore();
   });
+
+  test('validation flags out-of-range values', () => {
+    const { initValidation } = require('./validation.js');
+    initValidation();
+    const age = document.getElementById('patient_age');
+    age.setAttribute('min','0');
+    age.setAttribute('max','120');
+    age.value = '130';
+    age.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(age.classList.contains('invalid')).toBe(true);
+    const err = age.nextElementSibling;
+    expect(err).not.toBeNull();
+    expect(err.textContent).toContain('Leistina');
+  });
 });

--- a/js/validation.js
+++ b/js/validation.js
@@ -1,0 +1,57 @@
+import { $ } from './utils.js';
+
+function showInlineError(el, msg) {
+  let err = el.nextElementSibling;
+  if (!err || !err.classList.contains('input-error')) {
+    err = document.createElement('span');
+    err.className = 'input-error';
+    err.style.color = 'var(--danger)';
+    err.style.fontSize = '12px';
+    err.style.marginLeft = '4px';
+    el.insertAdjacentElement('afterend', err);
+  }
+  err.textContent = msg;
+  err.style.display = msg ? 'inline' : 'none';
+  if (msg) {
+    el.classList.add('invalid');
+  } else {
+    el.classList.remove('invalid');
+  }
+}
+
+export function validateField(el) {
+  const val = el.value.trim();
+  let msg = '';
+  if (val !== '') {
+    const num = parseFloat(val);
+    const min = el.getAttribute('min');
+    const max = el.getAttribute('max');
+    if ((min !== null && num < parseFloat(min)) || (max !== null && num > parseFloat(max))) {
+      msg = `Leistina ${min}–${max}`;
+    }
+  }
+  showInlineError(el, msg);
+}
+
+export function validateVitals() {
+  const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm','#patient_age'];
+  fields.forEach(sel => {
+    const el = $(sel);
+    if (el) validateField(el);
+  });
+  return true;
+}
+
+export function initValidation() {
+  const selectors = ['#patient_age','#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm'];
+  selectors.forEach(sel => {
+    const el = $(sel);
+    if (!el) return;
+    ['input','change'].forEach(evt => el.addEventListener(evt, () => validateField(el)));
+    validateField(el);
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.validateVitals = validateVitals;
+}


### PR DESCRIPTION
## Summary
- create reusable validation module for numeric inputs
- wire validation into app initialization to flag out-of-range values
- test validation for patient age field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1bc8024408320925e56dff524dbfc