### PR TITLE
feat: add reference points to body map

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -111,6 +111,7 @@ input.invalid,select.invalid{border-color:var(--red)}
 .tool.active{background:var(--accent);color:#fff;border-color:#2d74b8}
 #bodySvg{width:100%;max-width:400px;height:auto;border:1px solid var(--line);border-radius:12px;background:#0b141e}
 .silhouette{fill:#0f1822;stroke:#36506a;stroke-width:2}
+.body-point{fill:#748ba1;pointer-events:none}
 .label{fill:#a9b6c5;font:bold 16px system-ui}
 .mark-w{stroke:#ef5350;stroke-width:3;fill:none}
 .mark-b{fill:#64b5f6}

--- a/index.html
+++ b/index.html
@@ -290,6 +290,17 @@
             <path d="M212,458 C218,540 222,620 224,730 L202,730 C200,620 196,540 194,458 Z"/>
             <path d="M176,730 C150,748 160,760 180,762 C190,764 198,756 198,730 Z"/>
             <path d="M224,730 C250,748 240,760 220,762 C210,764 202,756 202,730 Z"/>
+            <g class="body-points">
+              <circle class="body-point" cx="200" cy="90" r="4"/>
+              <circle class="body-point" cx="140" cy="160" r="4"/>
+              <circle class="body-point" cx="260" cy="160" r="4"/>
+              <circle class="body-point" cx="160" cy="360" r="4"/>
+              <circle class="body-point" cx="240" cy="360" r="4"/>
+              <circle class="body-point" cx="170" cy="460" r="4"/>
+              <circle class="body-point" cx="230" cy="460" r="4"/>
+              <circle class="body-point" cx="180" cy="730" r="4"/>
+              <circle class="body-point" cx="220" cy="730" r="4"/>
+            </g>
           </g>
         </g>
 
@@ -307,6 +318,17 @@
             <path d="M212,460 C218,545 222,625 224,730 L200,730 C198,625 194,545 194,460 Z"/>
             <path d="M176,730 C150,748 160,760 185,762 C195,764 200,756 200,730 Z"/>
             <path d="M224,730 C250,748 240,760 215,762 C205,764 200,756 200,730 Z"/>
+            <g class="body-points">
+              <circle class="body-point" cx="200" cy="90" r="4"/>
+              <circle class="body-point" cx="140" cy="160" r="4"/>
+              <circle class="body-point" cx="260" cy="160" r="4"/>
+              <circle class="body-point" cx="160" cy="360" r="4"/>
+              <circle class="body-point" cx="240" cy="360" r="4"/>
+              <circle class="body-point" cx="170" cy="460" r="4"/>
+              <circle class="body-point" cx="230" cy="460" r="4"/>
+              <circle class="body-point" cx="180" cy="730" r="4"/>
+              <circle class="body-point" cx="220" cy="730" r="4"/>
+            </g>
           </g>
         </g>
 


### PR DESCRIPTION
## Summary
- add body-point markers to front and back silhouettes for clearer supine layout
- style the new markers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1bd39adcc8320aca712e3598c9b8c