### PR TITLE
Add aria-label to navigation toggle button

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <body>
 <header>
   <div class="wrap">
-    <button type="button" class="btn" id="navToggle" aria-controls="tabs" aria-expanded="false">☰</button>
+    <button type="button" class="btn" id="navToggle" aria-controls="tabs" aria-expanded="false" aria-label="Navigation menu">☰</button>
     <h1>Traumos forma – Desktop v10</h1>
     <div class="sub">Aktyvacija · ABCDE · LT · SVG kūno žemėlapis <span id="activationIndicator" class="activation-dot"></span></div>
     <div class="toolbar" id="sessionBar">


### PR DESCRIPTION
## Summary
- add accessible `aria-label` to navigation menu toggle button
- retain `aria-expanded` toggling in `initNavToggle`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1bd0695908320b03e6eed01ba5f6a