### PR TITLE
Add ARIA labeling to modal dialogs

### DIFF
--- a/js/components/modal.js
+++ b/js/components/modal.js
@@ -8,7 +8,9 @@ export function promptModal(message, defaultValue = '') {
     box.setAttribute('role', 'dialog');
     box.setAttribute('aria-modal', 'true');
     const p = document.createElement('p');
+    p.id = 'modalMsg';
     p.textContent = message;
+    box.setAttribute('aria-labelledby', p.id);
     box.appendChild(p);
     const input = document.createElement('input');
     input.type = 'text';
@@ -62,7 +64,9 @@ export function confirmModal(message){
     box.setAttribute('role', 'dialog');
     box.setAttribute('aria-modal', 'true');
     const p = document.createElement('p');
+    p.id = 'modalMsg';
     p.textContent = message;
+    box.setAttribute('aria-labelledby', p.id);
     box.appendChild(p);
     const actions = document.createElement('div');
     actions.className = 'actions';


### PR DESCRIPTION
## Summary
- assign ids to modal message `<p>` elements
- reference message elements with `aria-labelledby` on modal containers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1c524dd38832090666489a3dc1e16