### PR TITLE
refactor: use rem units for spacing

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -7,54 +7,55 @@
   --accent:#4ea0f5;--red:#e53935;--yellow:#ffcc00;--green:#00c853;--ink2:#d7ecff;
 }
 
+html{font-size:16px}
 *{box-sizing:border-box}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif}
-header{position:sticky;top:0;z-index:10;background:#0d151fdd;backdrop-filter:blur(6px);border-bottom:1px solid var(--line)}
-.wrap{max-width:1200px;margin:0 auto;padding:14px 16px}
-h1{font-size:20px;margin:4px 0}
-.sub{color:var(--muted);font-size:13px}
-.toolbar{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
-.btn{border:1px solid var(--line);background:#152231;color:var(--ink);padding:8px 12px;border-radius:10px;cursor:pointer;font-weight:600}
+header{position:sticky;top:0;z-index:10;background:#0d151fdd;backdrop-filter:blur(0.375rem);border-bottom:0.0625rem solid var(--line)}
+.wrap{max-width:75rem;margin:0 auto;padding:0.875rem 1rem}
+h1{font-size:1.25rem;margin:0.25rem 0}
+.sub{color:var(--muted);font-size:0.8125rem}
+.toolbar{display:flex;gap:0.5rem;flex-wrap:wrap;margin-top:0.5rem}
+.btn{border:0.0625rem solid var(--line);background:#152231;color:var(--ink);padding:0.5rem 0.75rem;border-radius:0.625rem;cursor:pointer;font-weight:600}
 .btn.primary{background:var(--accent);color:#fff;border-color:#2d74b8}
 .btn.warn{background:#ffb74d;color:#271400;border-color:#bf7d19}
 .btn.ghost{background:transparent;color:var(--muted);border-style:dashed}
-main{max-width:1200px;margin:12px auto;padding:0 16px;display:grid;grid-template-columns:220px 1fr;gap:12px}
-nav{position:sticky;top:68px;align-self:start}
+main{max-width:75rem;margin:0.75rem auto;padding:0 1rem;display:grid;grid-template-columns:13.75rem 1fr;gap:0.75rem}
+nav{position:sticky;top:4.25rem;align-self:start}
 #navToggle{display:none}
-nav .tab{display:block;padding:10px 12px;border:1px solid var(--line);border-radius:10px;margin-bottom:8px;background:#152231;color:var(--ink);cursor:pointer;font-weight:600;text-align:left;text-transform:none;font-size:16px}
+nav .tab{display:block;padding:0.625rem 0.75rem;border:0.0625rem solid var(--line);border-radius:0.625rem;margin-bottom:0.5rem;background:#152231;color:var(--ink);cursor:pointer;font-weight:600;text-align:left;text-transform:none;font-size:1rem}
 nav .tab.active{background:#1f2e44;border-color:#2b405c}
-nav .tab:focus{outline:2px solid var(--accent)}
-section.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px}
-section.card h2{font-size:16px;margin:0 0 10px}
-section.card .grid{display:grid;gap:10px}
+nav .tab:focus{outline:0.125rem solid var(--accent)}
+section.card{background:var(--card);border:0.0625rem solid var(--line);border-radius:0.875rem;padding:0.875rem}
+section.card h2{font-size:1rem;margin:0 0 0.625rem}
+section.card .grid{display:grid;gap:0.625rem}
 .cols-2{grid-template-columns:1fr 1fr}
 .cols-3{grid-template-columns:repeat(3,1fr)}
 .cols-4{grid-template-columns:repeat(4,1fr)}
-label{display:block;color:var(--muted);font-size:13px;margin-bottom:4px}
+label{display:block;color:var(--muted);font-size:0.8125rem;margin-bottom:0.25rem}
 input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select{
-  width:100%;padding:9px 10px;border:1px solid var(--line);border-radius:10px;background:#0f1620;color:var(--ink);font-size:14px;outline:none
+  width:100%;padding:0.5625rem 0.625rem;border:0.0625rem solid var(--line);border-radius:0.625rem;background:#0f1620;color:var(--ink);font-size:0.875rem;outline:none
 }
 input::placeholder,
 textarea::placeholder{color:var(--muted)}
-textarea{min-height:80px;resize:vertical}
-.row{display:flex;gap:8px;align-items:center}
+textarea{min-height:5rem;resize:vertical}
+.row{display:flex;gap:0.5rem;align-items:center}
 #d_gks_total{margin-left:auto;font-weight:700}
-.gcs-input{width:60px;flex:0 0 60px}
-.pill{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid var(--line);border-radius:999px;background:#152231;color:#fff;font-weight:700}
+.gcs-input{width:3.75rem;flex:0 0 3.75rem}
+.pill{display:inline-flex;align-items:center;gap:0.5rem;padding:0.375rem 0.625rem;border:0.0625rem solid var(--line);border-radius:62.4375rem;background:#152231;color:#fff;font-weight:700}
 .pill:has(input:checked){background:var(--accent);border-color:#2d74b8}
 .pill.red:has(input:checked){background:var(--red);border-color:#a52623}
 #fastGrid .pill{
-  padding:10px 16px;
-  font-size:16px;
+  padding:0.625rem 1rem;
+  font-size:1rem;
 }
 select option.red{color:var(--red)}
 .chip{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  padding:8px 10px;
-  border:1px solid var(--line);
-  border-radius:999px;
+  padding:0.5rem 0.625rem;
+  border:0.0625rem solid var(--line);
+  border-radius:62.4375rem;
   background:#152231;
   color:var(--ink);
   cursor:pointer;
@@ -69,79 +70,79 @@ label.chip input{
 }
 .chip:focus-visible,
 .chip:focus-within{
-  outline:2px solid var(--accent);
-  outline-offset:2px;
+  outline:0.125rem solid var(--accent);
+  outline-offset:0.125rem;
 }
 .chip.active{background:var(--accent);color:#fff;border-color:#2d74b8}
 .chip.red.active{background:var(--red);color:#fff;border-color:#a52623}
 .chip.yellow.active{background:var(--yellow);color:#231b00;border-color:#8a7400}
-.chip-group{display:flex;flex-wrap:wrap;gap:8px}
-.gcs-calc{margin-top:8px;border:1px solid var(--line);border-radius:10px;padding:8px;background:#152231}
-.gcs-calc .grid{margin-bottom:8px}
-.blood-order-box{margin-top:8px;border:1px solid var(--line);border-radius:10px;padding:8px}
-.blood-order-box .row{gap:8px;flex-wrap:wrap;align-items:center}
-.breath-chip{padding:12px 20px;font-size:24px}
-section[data-tab="B – Kvėpavimas"] h3{margin:12px 0 4px;font-size:14px;color:var(--muted)}
+.chip-group{display:flex;flex-wrap:wrap;gap:0.5rem}
+.gcs-calc{margin-top:0.5rem;border:0.0625rem solid var(--line);border-radius:0.625rem;padding:0.5rem;background:#152231}
+.gcs-calc .grid{margin-bottom:0.5rem}
+.blood-order-box{margin-top:0.5rem;border:0.0625rem solid var(--line);border-radius:0.625rem;padding:0.5rem}
+.blood-order-box .row{gap:0.5rem;flex-wrap:wrap;align-items:center}
+.breath-chip{padding:0.75rem 1.25rem;font-size:1.5rem}
+section[data-tab="B – Kvėpavimas"] h3{margin:0.75rem 0 0.25rem;font-size:0.875rem;color:var(--muted)}
 section[data-tab="B – Kvėpavimas"] h3:first-of-type{margin-top:0}
-.hint{color:var(--muted);font-size:12px}
-.error-msg{color:var(--red);font-size:12px}
+.hint{color:var(--muted);font-size:0.75rem}
+.error-msg{color:var(--red);font-size:0.75rem}
 input.invalid,select.invalid{border-color:var(--red)}
-.badge{padding:2px 8px;border-radius:8px;font-size:12px;border:1px solid var(--line);background:#152231;color:var(--muted)}
-.activation-dot{width:12px;height:12px;border-radius:50%;display:none;margin-left:8px}
+.badge{padding:0.125rem 0.5rem;border-radius:0.5rem;font-size:0.75rem;border:0.0625rem solid var(--line);background:#152231;color:var(--muted)}
+.activation-dot{width:0.75rem;height:0.75rem;border-radius:50%;display:none;margin-left:0.5rem}
 .activation-dot.red{background:var(--red);display:inline-block}
 .activation-dot.yellow{background:var(--yellow);display:inline-block}
-#saveStatus{color:var(--muted);font-size:13px;margin-top:4px}
+#saveStatus{color:var(--muted);font-size:0.8125rem;margin-top:0.25rem}
 #saveStatus.offline{color:var(--yellow)}
 #saveStatus.offline::before{content:'⚠ ';}
-.split{display:flex;gap:12px;flex-wrap:wrap}
+.split{display:flex;gap:0.75rem;flex-wrap:wrap}
 .split>div{flex:1}
-.interv-groups{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
-.interv-group{display:flex;flex-direction:column;gap:8px;background:var(--bg);border:1px solid var(--line);border-radius:10px;padding:8px}
-.interv-group>.grid{grid-template-columns:repeat(auto-fill,minmax(120px,1fr))}
-.med-search{margin-bottom:8px;width:100%}
-.subtle{font-size:12px;color:var(--muted)}
-.divider{height:1px;background:var(--line);margin:10px 0}
-.mt-4{margin-top:4px}
-.mt-6{margin-top:6px}
-.mt-8{margin-top:8px}
-.mt-12{margin-top:12px}
-.mb-6{margin-bottom:6px}
-.mb-8{margin-bottom:8px}
+.interv-groups{display:grid;gap:0.75rem;grid-template-columns:repeat(auto-fit,minmax(16.25rem,1fr))}
+.interv-group{display:flex;flex-direction:column;gap:0.5rem;background:var(--bg);border:0.0625rem solid var(--line);border-radius:0.625rem;padding:0.5rem}
+.interv-group>.grid{grid-template-columns:repeat(auto-fill,minmax(7.5rem,1fr))}
+.med-search{margin-bottom:0.5rem;width:100%}
+.subtle{font-size:0.75rem;color:var(--muted)}
+.divider{height:0.0625rem;background:var(--line);margin:0.625rem 0}
+.mt-4{margin-top:0.25rem}
+.mt-6{margin-top:0.375rem}
+.mt-8{margin-top:0.5rem}
+.mt-12{margin-top:0.75rem}
+.mb-6{margin-bottom:0.375rem}
+.mb-8{margin-bottom:0.5rem}
 .m-0{margin:0}
 .flex-1{flex:1}
 .flex-wrap{flex-wrap:wrap}
-.w-80{width:80px}
+.w-80{width:5rem}
 .w-auto{width:auto}
-.h3-muted{font-size:14px;color:var(--muted)}
+.h3-muted{font-size:0.875rem;color:var(--muted)}
 
-.timeline-list{border:1px solid var(--line);border-radius:10px;padding:8px;max-height:300px;overflow-y:auto}
-.timeline-entry{padding:4px 0;border-bottom:1px solid var(--line)}
+.timeline-list{border:0.0625rem solid var(--line);border-radius:0.625rem;padding:0.5rem;max-height:18.75rem;overflow-y:auto}
+.timeline-entry{padding:0.25rem 0;border-bottom:0.0625rem solid var(--line)}
 .timeline-entry:last-child{border-bottom:none}
 /* SVG body map */
-.map-toolbar{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin:6px 0}
-.tool{padding:8px 10px;border-radius:10px;border:1px solid var(--line);background:#152231;color:var(--ink);min-height:36px;cursor:pointer;font-weight:700}
+.map-toolbar{display:flex;gap:0.5rem;flex-wrap:wrap;align-items:center;margin:0.375rem 0}
+.tool{padding:0.5rem 0.625rem;border-radius:0.625rem;border:0.0625rem solid var(--line);background:#152231;color:var(--ink);min-height:2.25rem;cursor:pointer;font-weight:700}
 .tool.active{background:var(--accent);color:#fff;border-color:#2d74b8}
-#bodySvg{width:100%;max-width:400px;height:auto;border:1px solid var(--line);border-radius:12px;background:#0b141e}
+#bodySvg{width:100%;max-width:25rem;height:auto;border:0.0625rem solid var(--line);border-radius:0.75rem;background:#0b141e}
 .silhouette{fill:#0f1822;stroke:#36506a;stroke-width:2}
 .body-point{fill:#748ba1;pointer-events:none}
-.label{fill:#a9b6c5;font:bold 16px system-ui}
+.label{fill:#a9b6c5;font:bold 1rem system-ui}
 .mark-w{stroke:#ef5350;stroke-width:3;fill:none}
 .mark-b{fill:#64b5f6}
 .mark-n{fill:#ffd54f;stroke:#6b540e;stroke-width:2}
 .hidden{display:none}
-.detail{overflow:hidden;max-height:200px;opacity:1;transition:max-height .3s ease,opacity .3s ease}
+.detail{overflow:hidden;max-height:12.5rem;opacity:1;transition:max-height .3s ease,opacity .3s ease}
 .collapsed{max-height:0;opacity:0;pointer-events:none}
-@media (max-width:980px){
-  #navToggle{display:inline-block;margin-bottom:8px}
+@media (max-width:61.25rem){
+  #navToggle{display:inline-block;margin-bottom:0.5rem}
   main{grid-template-columns:1fr}
   nav{
     position:fixed;
     top:0;left:0;bottom:0;
-    width:220px;
+    width:13.75rem;
     background:#0d151f;
     transform:translateX(-100%);
     transition:transform .3s ease;
-    padding:14px 16px;
+    padding:0.875rem 1rem;
     overflow:auto;
     z-index:20;
     pointer-events:none;
@@ -154,18 +155,18 @@ input.invalid,select.invalid{border-color:var(--red)}
 @media print{ header,nav,.toolbar{display:none!important} body{background:#fff;color:#000} section.card{break-inside:avoid} }
 
 /* Interventions compact layout */
-section[data-tab="Intervencijos"] .card{padding:8px}
-section[data-tab="Intervencijos"] .card .detail .grid{gap:4px}
-section[data-tab="Intervencijos"] .med-search{margin-bottom:8px}
-section[data-tab="Intervencijos"] h3{margin:0 0 8px;font-size:13px;color:var(--muted);display:flex;align-items:center;gap:4px}
+section[data-tab="Intervencijos"] .card{padding:0.5rem}
+section[data-tab="Intervencijos"] .card .detail .grid{gap:0.25rem}
+section[data-tab="Intervencijos"] .med-search{margin-bottom:0.5rem}
+section[data-tab="Intervencijos"] h3{margin:0 0 0.5rem;font-size:0.8125rem;color:var(--muted);display:flex;align-items:center;gap:0.25rem}
 
 /* Modal and toast components */
 .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;z-index:1000}
-.modal{background:var(--card);color:var(--ink);padding:20px;border-radius:10px;box-shadow:0 2px 10px rgba(0,0,0,0.3);max-width:90%;width:320px}
+.modal{background:var(--card);color:var(--ink);padding:1.25rem;border-radius:0.625rem;box-shadow:0 0.125rem 0.625rem rgba(0,0,0,0.3);max-width:90%;width:20rem}
 .modal p{margin-top:0}
-.modal .actions{display:flex;justify-content:flex-end;gap:8px;margin-top:16px}
-.toast-container{position:fixed;bottom:20px;right:20px;display:flex;flex-direction:column;gap:8px;z-index:1000}
-.toast{background:var(--card);color:var(--ink);border:1px solid var(--line);padding:10px 16px;border-radius:6px;box-shadow:0 2px 6px rgba(0,0,0,0.2);transition:opacity .3s,transform .3s}
+.modal .actions{display:flex;justify-content:flex-end;gap:0.5rem;margin-top:1rem}
+.toast-container{position:fixed;bottom:1.25rem;right:1.25rem;display:flex;flex-direction:column;gap:0.5rem;z-index:1000}
+.toast{background:var(--card);color:var(--ink);border:0.0625rem solid var(--line);padding:0.625rem 1rem;border-radius:0.375rem;box-shadow:0 0.125rem 0.375rem rgba(0,0,0,0.2);transition:opacity .3s,transform .3s}
 .toast.success{background:var(--green);color:#fff}
 .toast.error{background:var(--red);color:#fff}
-.toast.hide{opacity:0;transform:translateY(10px)}
+.toast.hide{opacity:0;transform:translateY(0.625rem)}


### PR DESCRIPTION
## Summary
- convert pixel measurements in CSS to rem units and set root font size
- adjust spacing utilities to scale with the base font size

## Testing
- `node - <<'NODE'
const puppeteer = require('puppeteer');
(async () => {
  const browser = await puppeteer.launch({args:['--no-sandbox']});
  const page = await browser.newPage();
  const widths = [320, 768, 1024];
  for (const w of widths) {
    await page.setViewport({width: w, height: 800});
    await page.goto('file://' + process.cwd() + '/index.html');
    const height = await page.evaluate(() => document.body.scrollHeight);
    console.log(`Viewport ${w}x800 => body height ${height}`);
  }
  await browser.close();
})();
NODE`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1c649fab08320b45840b332937824