### PR TITLE
feat: add hover and focus indicators to buttons

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -15,6 +15,8 @@ h1{font-size:20px;margin:4px 0}
 .sub{color:var(--muted);font-size:13px}
 .toolbar{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
 .btn{border:1px solid var(--line);background:#152231;color:var(--ink);padding:8px 12px;border-radius:10px;cursor:pointer;font-weight:600}
+.btn:hover{filter:brightness(1.1)}
+.btn:focus-visible{outline:3px solid var(--accent);outline-offset:2px}
 .btn.primary{background:var(--accent);color:#fff;border-color:#2d74b8}
 .btn.warn{background:#ffb74d;color:#271400;border-color:#bf7d19}
 .btn.ghost{background:transparent;color:var(--muted);border-style:dashed}


### PR DESCRIPTION
## Summary
- add hover styling for buttons
- provide high-contrast focus-visible outline for buttons

## Testing
- `node <<'NODE'...` *(keyboard navigation via Puppeteer)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1c66f76b4832090d1d986d583fcae