### PR TITLE
Close mobile navigation after selecting tab

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -48,6 +48,9 @@ function initNavToggle(){
   toggle.addEventListener('click', () => {
     document.body.classList.contains('nav-open') ? close() : open();
   });
+  nav.addEventListener('click', e => {
+    if(e.target.closest('.tab')) close();
+  });
 }
 
 let authToken = localStorage.getItem('trauma_token') || null;


### PR DESCRIPTION
## Summary
- close navigation drawer when a tab is selected to allow collapsing on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d45eeed4832080abd6c97f8b9f5f