### PR TITLE
Use async fs operations for server DB

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -8,30 +8,36 @@ const crypto = require('crypto');
 const PORT = process.env.PORT || 3000;
 const DB_FILE = path.join(__dirname, 'db.json');
 
-function loadDB(){
+async function loadDB(){
   try {
-    return JSON.parse(fs.readFileSync(DB_FILE, 'utf8'));
+    const data = await fs.promises.readFile(DB_FILE, 'utf8');
+    return JSON.parse(data);
   } catch (e) {
+    console.error('Failed to load DB', e);
     return { sessions: [], data: {}, users: [] };
   }
 }
 
-function saveDB(){
-  fs.writeFileSync(DB_FILE, JSON.stringify(db, null, 2));
+async function saveDB(){
+  try {
+    await fs.promises.writeFile(DB_FILE, JSON.stringify(db, null, 2));
+  } catch (e) {
+    console.error('Failed to save DB', e);
+  }
 }
 
-let db = loadDB();
+let db;
 
 const app = express();
 app.use(express.json());
 app.use(express.static(path.join(__dirname, '..')));
 
 /* ===== Auth ===== */
-app.post('/api/login', (req, res) => {
+app.post('/api/login', async (req, res) => {
   const name = (req.body && req.body.name) || 'anonymous';
   const token = crypto.randomBytes(8).toString('hex');
   db.users.push({ token, name });
-  saveDB();
+  await saveDB();
   res.json({ token });
 });
 
@@ -47,32 +53,32 @@ app.get('/api/sessions', (req, res) => {
   res.json(db.sessions);
 });
 
-app.put('/api/sessions', auth, (req, res) => {
+app.put('/api/sessions', auth, async (req, res) => {
   if(Array.isArray(req.body)){
     db.sessions = req.body;
-    saveDB();
+    await saveDB();
     io.emit('sessions', db.sessions);
   }
   res.json({ ok: true });
 });
 
-app.post('/api/sessions', auth, (req, res) => {
+app.post('/api/sessions', auth, async (req, res) => {
   const name = req.body && req.body.name;
   if(!name) return res.status(400).json({ error: 'Name required' });
   const id = crypto.randomBytes(6).toString('hex');
   const session = { id, name };
   db.sessions.push(session);
-  saveDB();
+  await saveDB();
   io.emit('sessions', db.sessions);
   res.json(session);
 });
 
-app.put('/api/sessions/:id', auth, (req, res) => {
+app.put('/api/sessions/:id', auth, async (req, res) => {
   const id = req.params.id;
   const session = db.sessions.find(s => s.id === id);
   if(!session) return res.status(404).json({ error: 'Not found' });
   if(req.body && req.body.name) session.name = req.body.name;
-  saveDB();
+  await saveDB();
   io.emit('sessions', db.sessions);
   res.json({ ok: true });
 });
@@ -83,10 +89,10 @@ app.get('/api/sessions/:id/data', auth, (req, res) => {
   res.json(db.data[id] || {});
 });
 
-app.put('/api/sessions/:id/data', auth, (req, res) => {
+app.put('/api/sessions/:id/data', auth, async (req, res) => {
   const id = req.params.id;
   db.data[id] = req.body || {};
-  saveDB();
+  await saveDB();
   io.emit('sessionData', { id, data: db.data[id] });
   res.json({ ok: true });
 });
@@ -100,6 +106,11 @@ io.use((socket, next) => {
   next(new Error('unauthorized'));
 });
 
-server.listen(PORT, () => {
-  console.log('Server listening on', PORT);
+(async () => {
+  db = await loadDB();
+  server.listen(PORT, () => {
+    console.log('Server listening on', PORT);
+  });
+})().catch(err => {
+  console.error('Failed to start server', err);
 });


### PR DESCRIPTION
## Summary
- refactor DB load/save to async fs.promises with error logging
- await saveDB across routes and load DB before starting server
- log startup errors without crashing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a30d66d1248320a73d98ca3c6ff050