### PR TITLE
Handle missing document in DOM utilities

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1,5 +1,11 @@
-export const $ = (selector, scope = document) => scope.querySelector(selector);
-export const $$ = (selector, scope = document) => Array.from(scope.querySelectorAll(selector));
+export const $ = (
+  selector,
+  scope = typeof document !== 'undefined' ? document : null,
+) => (scope ? scope.querySelector(selector) : null);
+export const $$ = (
+  selector,
+  scope = typeof document !== 'undefined' ? document : null,
+) => (scope ? Array.from(scope.querySelectorAll(selector)) : []);
 export const nowHM = () => {
   const d = new Date();
   const p = n => String(n).padStart(2, '0');

--- a/js/utils.test.js
+++ b/js/utils.test.js
@@ -1,0 +1,21 @@
+describe('$ and $$ when document is undefined', () => {
+  const originalDocument = global.document;
+  beforeEach(() => {
+    global.document = undefined;
+    jest.resetModules();
+  });
+  afterEach(() => {
+    global.document = originalDocument;
+    jest.resetModules();
+  });
+
+  test('$ returns null when document is undefined', () => {
+    const { $ } = require('./utils.js');
+    expect($('div')).toBeNull();
+  });
+
+  test('$$ returns [] when document is undefined', () => {
+    const { $$ } = require('./utils.js');
+    expect($$('div')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- guard DOM query helpers against missing `document`
- add tests for `$` and `$$` when no `document`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a31b8984b083208971bffc7e97ae7b