### PR TITLE
Refactor header into topbar component

### DIFF
--- a/assets/partials/topbar.html
+++ b/assets/partials/topbar.html
@@ -1,0 +1,29 @@
+<div class="wrap">
+  <div class="header-left">
+    <button type="button" class="btn" id="navToggle" aria-controls="tabs" aria-expanded="false" aria-label="Navigation menu">☰</button>
+    <div>
+      <h1>Traumos forma – Desktop v10</h1>
+      <div class="sub">Aktyvacija · ABCDE · LT · SVG kūno žemėlapis <span id="activationIndicator" class="activation-dot"></span></div>
+    </div>
+  </div>
+  <div class="header-actions">
+    <div class="toolbar" id="arrivalBar">
+      <button type="button" class="btn primary" id="btnAtvyko">ATVYKO</button>
+      <div id="arrivalTimer" class="btn primary arrival-timer" aria-live="polite"></div>
+    </div>
+    <div class="toolbar" id="sessionBar">
+      <select id="sessionSelect" class="w-auto"></select>
+      <button type="button" class="btn" id="btnNewSession">Nauja sesija</button>
+      <button type="button" class="btn" id="btnRenameSession">Pervadinti</button>
+    </div>
+    <div class="toolbar">
+      <button type="button" class="btn primary" id="btnGen">Sugeneruoti ataskaitą</button>
+      <button type="button" class="btn" id="btnCopy">Kopijuoti</button>
+      <button type="button" class="btn" id="btnSave">Išsaugoti</button>
+      <button type="button" class="btn ghost" id="btnClear">Išvalyti</button>
+      <button type="button" class="btn" id="btnPdf">PDF</button>
+      <button type="button" class="btn warn" id="btnPrint">🖨 Spausdinti</button>
+    </div>
+    <div id="saveStatus" aria-live="polite"></div>
+  </div>
+</div>

--- a/index.html
+++ b/index.html
@@ -11,37 +11,7 @@
 <link rel="stylesheet" href="css/main.css">
 </head>
 <body>
-<header>
-  <div class="wrap">
-    <div class="header-left">
-      <button type="button" class="btn" id="navToggle" aria-controls="tabs" aria-expanded="false" aria-label="Navigation menu">☰</button>
-      <div>
-        <h1>Traumos forma – Desktop v10</h1>
-        <div class="sub">Aktyvacija · ABCDE · LT · SVG kūno žemėlapis <span id="activationIndicator" class="activation-dot"></span></div>
-      </div>
-    </div>
-    <div class="header-actions">
-      <div class="toolbar" id="arrivalBar">
-        <button type="button" class="btn primary" id="btnAtvyko">ATVYKO</button>
-        <div id="arrivalTimer" class="btn primary arrival-timer" aria-live="polite"></div>
-      </div>
-      <div class="toolbar" id="sessionBar">
-        <select id="sessionSelect" class="w-auto"></select>
-        <button type="button" class="btn" id="btnNewSession">Nauja sesija</button>
-        <button type="button" class="btn" id="btnRenameSession">Pervadinti</button>
-      </div>
-      <div class="toolbar">
-        <button type="button" class="btn primary" id="btnGen">Sugeneruoti ataskaitą</button>
-        <button type="button" class="btn" id="btnCopy">Kopijuoti</button>
-        <button type="button" class="btn" id="btnSave">Išsaugoti</button>
-        <button type="button" class="btn ghost" id="btnClear">Išvalyti</button>
-        <button type="button" class="btn" id="btnPdf">PDF</button>
-        <button type="button" class="btn warn" id="btnPrint">🖨 Spausdinti</button>
-      </div>
-      <div id="saveStatus" aria-live="polite"></div>
-    </div>
-  </div>
-</header>
+<header id="appHeader"></header>
 
 <main>
   <nav id="tabs"></nav>

--- a/js/components/topbar.js
+++ b/js/components/topbar.js
@@ -1,0 +1,53 @@
+export async function initTopbar(){
+  const header=document.getElementById('appHeader');
+  if(!header || typeof fetch !== 'function') return;
+  try{
+    const res=await fetch('assets/partials/topbar.html');
+    if(res.ok){
+      header.innerHTML=await res.text();
+    }
+  }catch(e){
+    console.error('Failed to load topbar', e);
+  }
+  const toggle=document.getElementById('navToggle');
+  const nav=document.querySelector('nav');
+  if(!toggle || !nav) return;
+  nav.setAttribute('aria-hidden','true');
+  const focusableSel='a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+  function close(){
+    document.body.classList.remove('nav-open');
+    toggle.setAttribute('aria-expanded','false');
+    nav.setAttribute('aria-hidden','true');
+    document.removeEventListener('keydown', trap);
+    toggle.focus();
+  }
+  function trap(e){
+    if(e.key==='Tab'){
+      const items=nav.querySelectorAll(focusableSel);
+      if(!items.length) return;
+      const first=items[0];
+      const last=items[items.length-1];
+      if(e.shiftKey){
+        if(document.activeElement===first){ e.preventDefault(); last.focus(); }
+      }else{
+        if(document.activeElement===last){ e.preventDefault(); first.focus(); }
+      }
+    }else if(e.key==='Escape'){
+      close();
+    }
+  }
+  function open(){
+    document.body.classList.add('nav-open');
+    toggle.setAttribute('aria-expanded','true');
+    nav.removeAttribute('aria-hidden');
+    const items=nav.querySelectorAll(focusableSel);
+    if(items.length) items[0].focus();
+    document.addEventListener('keydown', trap);
+  }
+  toggle.addEventListener('click',()=>{
+    document.body.classList.contains('nav-open') ? close() : open();
+  });
+  nav.addEventListener('click',e=>{
+    if(e.target.closest('.tab')) close();
+  });
+}


### PR DESCRIPTION
## Summary
- Move static header markup into reusable `topbar.html` partial and load it dynamically via new `initTopbar` component
- Initialize topbar and bind navigation/session/actions through `setupHeaderActions`
- Replace inline header in `index.html` with `<header id="appHeader"></header>` placeholder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a32f73e0848320b89c24089d0905e6