### PR TITLE
Require auth for session listing

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -49,7 +49,7 @@ function auth(req, res, next){
 }
 
 /* ===== Sessions ===== */
-app.get('/api/sessions', (req, res) => {
+app.get('/api/sessions', auth, (req, res) => {
   res.json(db.sessions);
 });
 


### PR DESCRIPTION
## Summary
- secure session listing by enforcing auth middleware on `GET /api/sessions`

## Testing
- `npm test`
- `curl -i http://localhost:3000/api/sessions` (fails with 401)
- `curl -i -H 'Authorization: <token>' http://localhost:3000/api/sessions`

------
https://chatgpt.com/codex/tasks/task_e_68a350c8858c8320af6a6617f9db6995