### PR TITLE
Return validity from vitals validator

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -613,6 +613,7 @@ function validateForm(){
       if(hintId) el.setAttribute('aria-describedby', hintId); else el.removeAttribute('aria-describedby');
     }
   });
+  if(!validateVitals()) ok=false;
   return ok;
 }
 

--- a/js/validation.js
+++ b/js/validation.js
@@ -35,11 +35,15 @@ export function validateField(el) {
 
 export function validateVitals() {
   const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm','#patient_age'];
+  let ok = true;
   fields.forEach(sel => {
     const el = $(sel);
-    if (el) validateField(el);
+    if (el) {
+      validateField(el);
+      if (el.classList.contains('invalid')) ok = false;
+    }
   });
-  return true;
+  return ok;
 }
 
 export function initValidation() {


### PR DESCRIPTION
## Summary
- Track invalid fields in `validateVitals` and return a boolean
- Ensure `validateForm` checks vital sign validity before proceeding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a35496a8608320830cc5e66dfa96bd