### PR TITLE
Simplify patient info and auto-generate reports

### DIFF
--- a/assets/partials/topbar.html
+++ b/assets/partials/topbar.html
@@ -17,7 +17,6 @@
       <button type="button" class="btn" id="btnRenameSession">Pervadinti</button>
     </div>
     <div class="toolbar">
-      <button type="button" class="btn primary" id="btnGen">Sugeneruoti ataskaitą</button>
       <details class="more-actions">
         <summary class="btn">More ▾</summary>
         <div class="menu">

--- a/index.html
+++ b/index.html
@@ -22,12 +22,7 @@
     <section class="card view" id="view-aktivacija" data-tab="Aktyvacija">
         <h2>Traumos komandos aktyvacija <span class="badge">GMP rodikliai → auto</span></h2>
       <h3>Pacientas</h3>
-      <div class="grid cols-4 cols-auto">
-        <div>
-          <label for="patient_name">Vardas</label>
-          <input id="patient_name" type="text" required aria-describedby="patient_name_hint" title="Būtinas laukas">
-          <div class="hint" id="patient_name_hint">Privalomas laukas</div>
-        </div>
+      <div class="grid cols-3 cols-auto">
         <div>
           <label for="patient_age">Amžius</label>
           <input id="patient_age" type="number" min="0" max="120" required aria-describedby="patient_age_hint" title="Amžius 0-120">
@@ -39,13 +34,14 @@
             <option value=""></option>
             <option value="M">Vyras</option>
             <option value="F">Moteris</option>
+            <option value="O">Kita / nenurodyta</option>
           </select>
           <div class="hint" id="patient_sex_hint">Pasirinkite lytį</div>
         </div>
         <div>
-          <label for="patient_id">Paciento ID</label>
-          <input id="patient_id" type="text" required aria-describedby="patient_id_hint" title="Įveskite paciento ID">
-          <div class="hint" id="patient_id_hint">Privalomas laukas</div>
+          <label for="patient_history">Ligos istorijos nr.</label>
+          <input id="patient_history" type="text" required aria-describedby="patient_history_hint" title="Įveskite ligos istorijos numerį">
+          <div class="hint" id="patient_history_hint">Privalomas laukas</div>
         </div>
       </div>
       <div class="grid cols-3 cols-auto">
@@ -436,7 +432,7 @@
       </div>
       <div id="timelineList" class="timeline-list"></div>
     </section>
-    <section class="card view" id="view-ataskaita" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Spauskite „Sugeneruoti ataskaitą“..."></textarea><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
+    <section class="card view" id="view-ataskaita" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Ataskaita sugeneruojama automatiškai"></textarea><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
   </div>
 </main>
 

--- a/js/app.js
+++ b/js/app.js
@@ -309,7 +309,7 @@ window.updateActivationIndicator=updateActivationIndicator;
 window.ensureSingleTeam=ensureSingleTeam;
 
 /* ===== Save / Load ===== */
-const FIELD_SELECTORS='input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select,#patient_name,#patient_age,#patient_sex,#patient_id';
+const FIELD_SELECTORS='input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select';
 let fields=[];
 const getFields=()=>fields.length?fields:(fields=$$(FIELD_SELECTORS));
 
@@ -583,10 +583,9 @@ async function init(){
 
 function validateForm(){
   const fields=[
-    {el:$('#patient_name'),check:e=>e.value.trim()!=='',msg:'Vardas privalomas'},
     {el:$('#patient_age'),check:e=>e.value!=='' && +e.value>=0 && +e.value<=120,msg:'Amžius 0-120'},
     {el:$('#patient_sex'),check:e=>e.value!=='',msg:'Pasirinkite lytį'},
-    {el:$('#patient_id'),check:e=>e.value.trim()!=='',msg:'ID privalomas'}
+    {el:$('#patient_history'),check:e=>e.value.trim()!=='',msg:'Ligos istorijos nr. privalomas'}
   ];
   let ok=true;
   fields.forEach(({el,check,msg})=>{
@@ -634,8 +633,8 @@ function bodymapSummary(){
 
 export function generateReport(){
   const out=[];
-  const patient={ name:$('#patient_name').value, age:$('#patient_age').value, sex:$('#patient_sex').value, id:$('#patient_id').value };
-  const patientLine=[patient.name?`Vardas: ${patient.name}`:null, patient.age?`Amžius ${patient.age}`:null, patient.sex?`Lytis ${patient.sex}`:null, patient.id?`ID ${patient.id}`:null].filter(Boolean).join('; ');
+  const patient={ age:$('#patient_age').value, sex:$('#patient_sex').value, history:$('#patient_history').value };
+  const patientLine=[patient.age?`Amžius ${patient.age}`:null, patient.sex?`Lytis ${patient.sex}`:null, patient.history?`Ligos istorijos nr. ${patient.history}`:null].filter(Boolean).join('; ');
   if(patientLine){ out.push('--- Pacientas ---'); out.push(patientLine); }
   const red=listChips('#chips_red'), yellow=listChips('#chips_yellow');
   const gmp={ hr:$('#gmp_hr').value, rr:$('#gmp_rr').value, spo2:$('#gmp_spo2').value, sbp:$('#gmp_sbp').value, dbp:$('#gmp_dbp').value, gksa:$('#gmp_gksa').value, gksk:$('#gmp_gksk').value, gksm:$('#gmp_gksm').value, time:$('#gmp_time').value, mechanism:$('#gmp_mechanism').value, notes:$('#gmp_notes').value };
@@ -714,17 +713,13 @@ export function generateReport(){
       if(sprVitals) out.push(sprVitals);
     }
 
-    $('#output').value=out.filter(Boolean).join('\n');
+  $('#output').value=out.filter(Boolean).join('\n');
   expandOutput();
-  showTab('Ataskaita');
   saveAll();
 }
 function setupHeaderActions(){
   const btnAtvyko=document.getElementById('btnAtvyko');
   if(btnAtvyko) btnAtvyko.addEventListener('click', startArrivalTimer);
-
-  const btnGen=document.getElementById('btnGen');
-  if(btnGen) btnGen.addEventListener('click',()=>{ if(validateForm()) generateReport(); });
 
   const btnCopy=document.getElementById('btnCopy');
   if(btnCopy) btnCopy.addEventListener('click',async()=>{
@@ -745,7 +740,7 @@ function setupHeaderActions(){
   const btnPdf=document.getElementById('btnPdf');
   if(btnPdf) btnPdf.addEventListener('click', async () => {
     if(!validateForm()) return;
-    generateReport();
+    showTab('Ataskaita');
     const text = $('#output').value || '';
     try {
       const module = await import('./lib/jspdf.umd.min.js');
@@ -764,7 +759,7 @@ function setupHeaderActions(){
   if(btnPrint) btnPrint.addEventListener('click',()=>{
     if(!validateForm()) return;
     const prevTab=localStorage.getItem('v10_activeTab');
-    generateReport();
+    showTab('Ataskaita');
     const text=$('#output').value||'';
     const printWin=window.open('','_blank');
     if(printWin){
@@ -792,3 +787,9 @@ function setupHeaderActions(){
 }
 
 setupHeaderActions();
+
+document.addEventListener('tabShown',e=>{
+  if(e.detail==='Ataskaita'){
+    if(validateForm()) generateReport();
+  }
+});

--- a/js/patient.test.js
+++ b/js/patient.test.js
@@ -24,7 +24,6 @@ const setupDom = () => {
       <span id="d_gcs_calc_total"></span>
     </div>
     <input type="checkbox" id="e_back_ny" />
-    <button id="btnGen"></button>
     <textarea id="output"></textarea>
     <svg id="bodySvg"><g id="layer-front"></g><g id="layer-back"></g><g id="marks"></g></svg>
     <div id="front-shape"></div>
@@ -42,7 +41,7 @@ const setupDom = () => {
     'spr_skyrius_container','spr_ligonine_container','imaging_other'
   ];
   divIds.forEach(id=>{ const d=document.createElement('div'); d.id=id; document.body.appendChild(d); });
-  const textInputs=['a_notes','gmp_mechanism','gmp_notes','b_oxygen_type','b_dpv_fio2','d_pupil_left_note','d_pupil_right_note','d_notes','e_back_notes','e_other','spr_skyrius_kita','spr_ligonine','patient_name','patient_id'];
+  const textInputs=['a_notes','gmp_mechanism','gmp_notes','b_oxygen_type','b_dpv_fio2','d_pupil_left_note','d_pupil_right_note','d_notes','e_back_notes','e_other','spr_skyrius_kita','spr_ligonine','patient_history'];
   textInputs.forEach(id=>{ const i=document.createElement('input'); i.id=id; i.type='text'; document.body.appendChild(i); });
   const numberInputs=['b_rr','b_spo2','b_oxygen_liters','c_hr','c_sbp','c_dbp','c_caprefill','d_gksa','d_gksk','d_gksm','e_temp',
     'spr_hr','spr_rr','spr_spo2','spr_sbp','spr_dbp','spr_gksa','spr_gksk','spr_gksm','patient_age','gmp_hr','gmp_rr','gmp_spo2',
@@ -50,7 +49,7 @@ const setupDom = () => {
   numberInputs.forEach(id=>{ const i=document.createElement('input'); i.id=id; i.type='number'; document.body.appendChild(i); });
   const timeInputs=['gmp_time','spr_time'];
   timeInputs.forEach(id=>{ const i=document.createElement('input'); i.id=id; i.type='time'; document.body.appendChild(i); });
-  const patientSex=document.createElement('select'); patientSex.id='patient_sex'; ['','M','F'].forEach(v=>{ const o=document.createElement('option'); o.value=v; o.textContent=v; patientSex.appendChild(o); }); document.body.appendChild(patientSex);
+  const patientSex=document.createElement('select'); patientSex.id='patient_sex'; ['','M','F','O'].forEach(v=>{ const o=document.createElement('option'); o.value=v; o.textContent=v; patientSex.appendChild(o); }); document.body.appendChild(patientSex);
   const sprSkyrius=document.createElement('select'); sprSkyrius.id='spr_skyrius'; sprSkyrius.appendChild(document.createElement('option')); document.body.appendChild(sprSkyrius);
 };
 
@@ -66,40 +65,34 @@ describe('patient fields', () => {
 
   test('persist with saveAll/loadAll', () => {
     const { saveAll, loadAll } = require('./app.js');
-    document.getElementById('patient_name').value='Jonas';
     document.getElementById('patient_age').value='25';
     document.getElementById('patient_sex').value='M';
-    document.getElementById('patient_id').value='ID123';
+    document.getElementById('patient_history').value='H123';
     saveAll();
     const stored = JSON.parse(localStorage.getItem('trauma_v10_test'));
-    expect(stored.patient_name).toBe('Jonas');
     expect(stored.patient_age).toBe('25');
     expect(stored.patient_sex).toBe('M');
-    expect(stored.patient_id).toBe('ID123');
-    document.getElementById('patient_name').value='';
+    expect(stored.patient_history).toBe('H123');
     document.getElementById('patient_age').value='';
     document.getElementById('patient_sex').value='';
-    document.getElementById('patient_id').value='';
+    document.getElementById('patient_history').value='';
     loadAll();
-    expect(document.getElementById('patient_name').value).toBe('Jonas');
     expect(document.getElementById('patient_age').value).toBe('25');
     expect(document.getElementById('patient_sex').value).toBe('M');
-    expect(document.getElementById('patient_id').value).toBe('ID123');
+    expect(document.getElementById('patient_history').value).toBe('H123');
   });
 
   test('report includes patient info', () => {
     const { generateReport } = require('./app.js');
-    document.getElementById('patient_name').value='Jonas';
     document.getElementById('patient_age').value='25';
     document.getElementById('patient_sex').value='M';
-    document.getElementById('patient_id').value='ID123';
+    document.getElementById('patient_history').value='H123';
     generateReport();
     const report=document.getElementById('output').value;
     expect(report.startsWith('--- Pacientas ---')).toBe(true);
-    expect(report).toContain('Jonas');
     expect(report).toContain('25');
     expect(report).toContain('M');
-    expect(report).toContain('ID123');
+    expect(report).toContain('H123');
   });
 
   test('GCS panel focuses first select and closes on Escape', () => {
@@ -132,10 +125,9 @@ describe('patient fields', () => {
 
   test('PDF button generates file via jsPDF', async () => {
     require('./app.js');
-    document.getElementById('patient_name').value='Jonas';
     document.getElementById('patient_age').value='25';
     document.getElementById('patient_sex').value='M';
-    document.getElementById('patient_id').value='ID123';
+    document.getElementById('patient_history').value='H123';
     document.getElementById('btnPdf').click();
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(mockJsPDF).toHaveBeenCalled();
@@ -151,10 +143,9 @@ describe('patient fields', () => {
       close: jest.fn()
     });
     require('./app.js');
-    document.getElementById('patient_name').value='Jonas';
     document.getElementById('patient_age').value='25';
     document.getElementById('patient_sex').value='M';
-    document.getElementById('patient_id').value='ID123';
+    document.getElementById('patient_history').value='H123';
     document.getElementById('btnPrint').click();
     const svg = newDoc.querySelector('#bodySvg');
     expect(svg).not.toBeNull();

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -25,6 +25,7 @@ export function showTab(name){
   });
   document.querySelectorAll('.view').forEach(v=>v.style.display = (v.dataset.tab===name)?'block':'none');
   localStorage.setItem('v10_activeTab', name);
+  document.dispatchEvent(new CustomEvent('tabShown',{detail:name}));
 }
 
 export function initTabs(){


### PR DESCRIPTION
## Summary
- remove patient name field and switch to medical history number
- add other/unspecified gender option and automatically generate reports when opening the report tab
- drop manual report button and update PDF/print actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f747d7788320afd0aee241eda4f1