### PR TITLE
Add session deletion API and UI

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -83,6 +83,17 @@ app.put('/api/sessions/:id', auth, async (req, res) => {
   res.json({ ok: true });
 });
 
+app.delete('/api/sessions/:id', auth, async (req, res) => {
+  const id = req.params.id;
+  const index = db.sessions.findIndex(s => s.id === id);
+  if(index === -1) return res.status(404).json({ error: 'Not found' });
+  db.sessions.splice(index, 1);
+  delete db.data[id];
+  await saveDB();
+  io.emit('sessions', db.sessions);
+  res.json({ ok: true });
+});
+
 /* ===== Session data ===== */
 app.get('/api/sessions/:id/data', auth, (req, res) => {
   const id = req.params.id;


### PR DESCRIPTION
## Summary
- Add backend endpoint to delete sessions and associated data
- Render per-session delete buttons on the frontend and sync with server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a406b5c3c88320ae33f7444b73665b