### PR TITLE
Add logout endpoint and front-end control

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -33,6 +33,7 @@ async function ensureLogin(){
     const data = await res.json();
     authToken = data.token;
     localStorage.setItem('trauma_token', authToken);
+    setupHeaderActions();
   }catch(e){
     // ignore
   }
@@ -830,6 +831,24 @@ function setupHeaderActions(){
     }
     if(prevTab) showTab(prevTab);
   });
+
+  const menu=document.querySelector('.more-actions .menu');
+  if(menu && authToken && !document.getElementById('btnLogout')){
+    const btn=document.createElement('button');
+    btn.type='button';
+    btn.className='btn';
+    btn.id='btnLogout';
+    btn.textContent='Logout';
+    btn.addEventListener('click',async()=>{
+      if(authToken && typeof fetch==='function'){
+        try{ await fetch('/api/logout',{ method:'POST', headers:{ 'Authorization':authToken } }); }catch(e){ /* ignore */ }
+      }
+      authToken=null;
+      localStorage.removeItem('trauma_token');
+      location.reload();
+    });
+    menu.appendChild(btn);
+  }
 }
 
 setupHeaderActions();

--- a/server/index.js
+++ b/server/index.js
@@ -41,6 +41,16 @@ app.post('/api/login', async (req, res) => {
   res.json({ token });
 });
 
+app.post('/api/logout', auth, async (req, res) => {
+  const token = req.headers['authorization'];
+  const index = db.users.findIndex(u => u.token === token);
+  if(index !== -1){
+    db.users.splice(index, 1);
+    await saveDB();
+  }
+  res.json({ ok: true });
+});
+
 function auth(req, res, next){
   const token = req.headers['authorization'];
   if(!token) return res.status(401).json({ error: 'No token' });


### PR DESCRIPTION
## Summary
- add backend route to invalidate user token on logout
- add topbar logout button that clears token and reloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4084532848320bca6c1a4e6c34dca