### PR TITLE
refactor: centralize font size variables

### DIFF
--- a/css/scss/_base.scss
+++ b/css/scss/_base.scss
@@ -1,3 +1,5 @@
+@use 'variables' as *;
+
 :root{color-scheme:dark}
 
 :root.dark{
@@ -8,7 +10,7 @@
 }
 
 *{box-sizing:border-box}
-body{margin:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;font-size:100%;line-height:1.5}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;font-size:$font-base;line-height:1.5}
 header{--header-height:68px;position:sticky;top:0;z-index:10;background:#0d151fdd;backdrop-filter:blur(6px);border-bottom:1px solid var(--line)}
 .wrap{max-width:1200px;margin:0 auto;padding:14px 16px;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between}
 .header-left{display:flex;align-items:center;gap:8px}
@@ -31,8 +33,8 @@ header{--header-height:68px;position:sticky;top:0;z-index:10;background:#0d151fd
   }
 }
 #saveStatus{width:100%}
-h1{font-size:1.25rem;margin:4px 0}
-.sub{color:var(--muted);font-size:0.8125rem}
+h1{font-size:$font-xl;margin:4px 0}
+.sub{color:var(--muted);font-size:$font-sm}
 .btn{min-width:4rem}
 .toolbar{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
 .toolbar--scroll{flex-wrap:nowrap;overflow-x:auto}
@@ -40,18 +42,18 @@ h1{font-size:1.25rem;margin:4px 0}
 main{max-width:1200px;margin:12px auto;padding:0 16px;display:grid;grid-template-columns:220px 1fr;gap:12px}
 nav{position:sticky;top:var(--header-height);align-self:start}
 #navToggle{display:none}
-nav .tab{display:flex;align-items:center;gap:8px;width:100%;white-space:nowrap;padding:10px 12px;border:1px solid var(--line);border-radius:10px;margin-bottom:8px;background:#152231;color:var(--ink);cursor:pointer;font-weight:600;text-align:left;text-transform:none;font-size:1rem;transition:background-color .2s,color .2s}
+nav .tab{display:flex;align-items:center;gap:8px;width:100%;white-space:nowrap;padding:10px 12px;border:1px solid var(--line);border-radius:10px;margin-bottom:8px;background:#152231;color:var(--ink);cursor:pointer;font-weight:600;text-align:left;text-transform:none;font-size:$font-lg;transition:background-color .2s,color .2s}
 nav .tab:hover{background:color-mix(in srgb,#152231,white 10%);color:color-mix(in srgb,var(--ink),white 10%)}
 nav .tab.active{background:#1f2e44;border-color:#2b405c}
 nav .tab:focus{outline:none}
 nav .tab:focus-visible{outline:2px solid var(--accent)}
 .tab-icon{width:1.5rem}
 section.card{background:rgba(18,26,36,.6);backdrop-filter:blur(10px);border:1px solid color-mix(in srgb,var(--line),white 20%);border-radius:14px;padding:14px;color:var(--ink)}
-section.card h2{font-size:1rem;margin:0 0 10px}
+section.card h2{font-size:$font-lg;margin:0 0 10px}
 section.card .grid{display:grid;gap:10px}
-label{display:block;color:var(--muted);font-size:0.8125rem;margin-bottom:4px}
+label{display:block;color:var(--muted);font-size:$font-sm;margin-bottom:4px}
 input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select{
-  width:100%;padding:9px 10px;border:1px solid var(--line);border-radius:10px;background:#0f1620;color:var(--ink);font-size:0.875rem
+  width:100%;padding:9px 10px;border:1px solid var(--line);border-radius:10px;background:#0f1620;color:var(--ink);font-size:$font-md
 }
 input[type="text"]:focus-visible,input[type="number"]:focus-visible,input[type="time"]:focus-visible,input[type="date"]:focus-visible,textarea:focus-visible,select:focus-visible{outline:2px solid var(--accent)}
 input::placeholder,

--- a/css/scss/_components.scss
+++ b/css/scss/_components.scss
@@ -1,3 +1,5 @@
+@use 'variables' as *;
+
 .btn{border:1px solid var(--line);background:#152231;color:var(--ink);padding:8px 12px;border-radius:10px;cursor:pointer;font-weight:600;transition:background-color .2s,color .2s}
 .btn:hover{filter:brightness(1.1)}
 .btn:active{filter:brightness(.9)}
@@ -11,7 +13,7 @@
 .pill.red:has(input:checked){background:var(--red);border-color:#a52623}
   #fastGrid .pill{
     padding:10px 16px;
-    font-size:1rem;
+    font-size:$font-lg;
   }
 select option.red{color:var(--red)}
 .chip{
@@ -46,17 +48,17 @@ label.chip input{
 .gcs-calc .grid{margin-bottom:8px}
 .blood-order-box{margin-top:8px;border:1px solid var(--line);border-radius:10px;padding:8px}
 .blood-order-box .row{gap:8px;flex-wrap:wrap;align-items:center}
-  .breath-chip{padding:12px 20px;font-size:1.5rem}
-  section[data-tab="B – Kvėpavimas"] h3{margin:12px 0 4px;font-size:0.875rem;color:var(--muted)}
+    .breath-chip{padding:12px 20px;font-size:$font-xxl}
+    section[data-tab="B – Kvėpavimas"] h3{margin:12px 0 4px;font-size:$font-md;color:var(--muted)}
 section[data-tab="B – Kvėpavimas"] h3:first-of-type{margin-top:0}
-  .hint{color:var(--muted);font-size:0.75rem}
-  .error-msg{color:var(--red);font-size:0.75rem}
+    .hint{color:var(--muted);font-size:$font-xs}
+    .error-msg{color:var(--red);font-size:$font-xs}
 input.invalid,select.invalid{border-color:var(--red)}
-  .badge{padding:2px 8px;border-radius:8px;font-size:0.75rem;border:1px solid var(--line);background:#152231;color:var(--muted)}
+    .badge{padding:2px 8px;border-radius:8px;font-size:$font-xs;border:1px solid var(--line);background:#152231;color:var(--muted)}
 .activation-dot{width:12px;height:12px;border-radius:50%;display:none;margin-left:8px}
 .activation-dot.red{background:var(--red);display:inline-block}
 .activation-dot.yellow{background:var(--yellow);display:inline-block}
-  #saveStatus{color:var(--muted);font-size:0.8125rem;margin-top:4px}
+    #saveStatus{color:var(--muted);font-size:$font-sm;margin-top:4px}
 #saveStatus.offline{color:var(--yellow)}
 #saveStatus.offline::before{content:'⚠ ';}
 .split{display:flex;gap:12px;flex-wrap:wrap}
@@ -74,7 +76,7 @@ input.invalid,select.invalid{border-color:var(--red)}
 .tool.active{background:var(--accent);color:#fff;border-color:#2d74b8}
 #bodySvg{width:100%;max-width:300px;max-height:80vh;height:auto;border:1px solid var(--line);border-radius:12px;background:#0b141e}
 .silhouette{fill:#0f1822;stroke:#36506a;stroke-width:2}
-  .label{fill:#a9b6c5;font:bold 1rem system-ui}
+    .label{fill:#a9b6c5;font:bold $font-lg system-ui}
 .mark-w{stroke:#ef5350;stroke-width:3;fill:none}
 .mark-b{fill:#64b5f6}
 .mark-n{fill:#ffd54f;stroke:#6b540e;stroke-width:2}
@@ -103,7 +105,7 @@ body.nav-open{overflow:hidden}
 section[data-tab="Intervencijos"] .card{padding:8px}
 section[data-tab="Intervencijos"] .card .detail .grid{gap:4px}
 section[data-tab="Intervencijos"] .med-search{margin-bottom:8px}
-  section[data-tab="Intervencijos"] h3{margin:0 0 8px;font-size:0.8125rem;color:var(--muted);display:flex;align-items:center;gap:4px}
+    section[data-tab="Intervencijos"] h3{margin:0 0 8px;font-size:$font-sm;color:var(--muted);display:flex;align-items:center;gap:4px}
 /* Pain meds list layout */
 #pain_meds{grid-template-columns:1fr;gap:4px}
 #pain_meds .chip{width:100%;justify-content:flex-start;text-align:left;padding:4px 8px;white-space:normal}

--- a/css/scss/_utilities.scss
+++ b/css/scss/_utilities.scss
@@ -1,10 +1,12 @@
+@use 'variables' as *;
+
 .cols-2{grid-template-columns:repeat(2,1fr)}
 .cols-3{grid-template-columns:repeat(3,1fr)}
 .cols-4{grid-template-columns:repeat(4,1fr)}
 .cols-auto{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
 .row{display:flex;gap:8px;align-items:center}
 .gcs-input{width:60px;flex:0 0 60px}
-.subtle{font-size:0.75rem;color:var(--muted)}
+.subtle{font-size:$font-xs;color:var(--muted)}
 .divider{height:1px;background:var(--line);margin:10px 0}
 .mt-4{margin-top:4px}
 .mt-6{margin-top:6px}
@@ -17,7 +19,7 @@
 .flex-wrap{flex-wrap:wrap}
 .w-80{width:80px}
 .w-auto{width:auto}
-.h3-muted{font-size:0.875rem;color:var(--muted)}
+.h3-muted{font-size:$font-md;color:var(--muted)}
 .hidden{display:none}
 .detail{overflow:hidden;max-height:200px;opacity:1;transition:max-height .3s ease,opacity .3s ease}
 .collapsed{max-height:0;opacity:0;pointer-events:none}

--- a/css/scss/_variables.scss
+++ b/css/scss/_variables.scss
@@ -1,0 +1,7 @@
+$font-base: 100%;
+$font-xs: 0.75rem;
+$font-sm: 0.8125rem;
+$font-md: 0.875rem;
+$font-lg: 1rem;
+$font-xl: 1.25rem;
+$font-xxl: 1.5rem;


### PR DESCRIPTION
## Summary
- define shared font-scale variables and consume them across base, component, and utility styles
- compile refreshed main.css from updated SCSS

## Testing
- `npm run build:css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4149272e08320af2b66f0b819da6a