### PR TITLE
Replace nav toggle icon with inline SVG

### DIFF
--- a/assets/partials/topbar.html
+++ b/assets/partials/topbar.html
@@ -1,6 +1,10 @@
 <div class="wrap">
   <div class="header-left">
-    <button type="button" class="btn" id="navToggle" aria-controls="tabs" aria-expanded="false" aria-label="Navigation menu">☰</button>
+    <button type="button" class="btn" id="navToggle" aria-controls="tabs" aria-expanded="false" aria-label="Navigation menu">
+      <svg viewBox="0 0 24 24" width="1.5em" height="1.5em" aria-hidden="true">
+        <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
     <div>
       <h1>Sunkios traumos forma</h1>
       <div class="sub">Aktyvacija · ABCE · Santrauka <span id="activationIndicator" class="activation-dot"></span></div>


### PR DESCRIPTION
## Summary
- Replace nav toggle text character with an inline SVG hamburger icon that inherits current color

## Testing
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68a43a64f66c8320af77b469ec17c468