### PR TITLE
Reorder FAST to top of imaging tests view

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,15 +306,15 @@
     <!-- Vaizdai / Laboratorija / Komanda / Sprendimas / Ataskaita -->
     <section class="card view" id="view-vaizdiniai-tyrimai" data-tab="Vaizdiniai tyrimai">
       <h2>Vaizdiniai tyrimai</h2>
-      <h3 class="h3-muted">KT</h3>
+      <h3 class="h3-muted">FAST</h3>
+      <div class="grid cols-3 cols-auto" id="fastGrid"></div>
+      <h3 class="h3-muted mt-8">KT</h3>
       <div class="chip-group" id="imaging_ct" aria-label="KT"></div>
       <h3 class="h3-muted mt-8">Rentgenogramos</h3>
       <div class="chip-group" id="imaging_xray" aria-label="Rentgenogramos"></div>
       <h3 class="h3-muted mt-8">Kiti</h3>
       <div class="chip-group" id="imaging_other_group" aria-label="Kiti vaizdiniai tyrimai"></div>
       <input id="imaging_other" type="text" placeholder="Įvesti kitą tyrimą" class="hidden mt-8">
-      <h3 class="h3-muted mt-12">FAST</h3>
-      <div class="grid cols-3 cols-auto" id="fastGrid"></div>
     </section>
     <section class="card view" id="view-laboratorija" data-tab="Laboratorija">
       <h2>Laboratoriniai tyrimai</h2>


### PR DESCRIPTION
## Summary
- Move FAST section to the top of the imaging tests window

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a453072c208320bc6cffd9490a5444