### PR TITLE
Improve breathing section with detailed auscultation options

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,8 +113,26 @@
       </div>
       <h3>Alsavimas</h3>
       <div class="row">
-        <div><div class="subtle">Kairė</div><div class="chip-group" id="b_breath_left_group" data-single="true" aria-label="Alsavimas – Kairė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false" aria-label="Girdimi kvėpavimo garsai" title="Girdimi kvėpavimo garsai">+</button><button type="button" class="chip breath-chip red" data-value="-" aria-pressed="false" aria-label="Kvėpavimo garsai negirdimi" title="Kvėpavimo garsai negirdimi">-</button></div></div>
-        <div><div class="subtle">Dešinė</div><div class="chip-group" id="b_breath_right_group" data-single="true" aria-label="Alsavimas – Dešinė"><button type="button" class="chip breath-chip" data-value="+" aria-pressed="false" aria-label="Girdimi kvėpavimo garsai" title="Girdimi kvėpavimo garsai">+</button><button type="button" class="chip breath-chip red" data-value="-" aria-pressed="false" aria-label="Kvėpavimo garsai negirdimi" title="Kvėpavimo garsai negirdimi">-</button></div></div>
+        <div>
+          <div class="subtle">Kairė</div>
+          <div class="chip-group" id="b_breath_left_group" data-single="true" aria-label="Alsavimas – Kairė">
+            <button type="button" class="chip breath-chip" data-value="Normalus" aria-label="Normalus" title="Normalus">Normalus</button>
+            <button type="button" class="chip breath-chip red breath-toggle" data-value="_kita" aria-label="Kita" title="Kita">Kita</button>
+            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Neišklausomas">Neišklausomas</button>
+            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Susilpnėjęs">Susilpnėjęs</button>
+            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Kita">Kita</button>
+          </div>
+        </div>
+        <div>
+          <div class="subtle">Dešinė</div>
+          <div class="chip-group" id="b_breath_right_group" data-single="true" aria-label="Alsavimas – Dešinė">
+            <button type="button" class="chip breath-chip" data-value="Normalus" aria-label="Normalus" title="Normalus">Normalus</button>
+            <button type="button" class="chip breath-chip red breath-toggle" data-value="_kita" aria-label="Kita" title="Kita">Kita</button>
+            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Neišklausomas">Neišklausomas</button>
+            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Susilpnėjęs">Susilpnėjęs</button>
+            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Kita">Kita</button>
+          </div>
+        </div>
       </div>
       <h3>Pagalbinė ventiliacija</h3>
       <div class="row flex-wrap">

--- a/js/chips.js
+++ b/js/chips.js
@@ -30,6 +30,20 @@ function togglePupilNote(side, chip){
   if(!show) note.value='';
 }
 
+function updateBreathGroups(){
+  ['b_breath_left_group','b_breath_right_group'].forEach(id=>{
+    const group = $('#'+id);
+    if(!group) return;
+    const toggle = group.querySelector('.breath-toggle');
+    const options = $$('.breath-option', group);
+    const show = (toggle && isChipActive(toggle)) || options.some(isChipActive);
+    options.forEach(opt=>{
+      opt.classList.toggle('hidden', !show);
+      if(!show) setChipActive(opt,false);
+    });
+  });
+}
+
 export function initChips(saveAll){
   $$('.chip').forEach(chip => {
     const group = chip.parentElement;
@@ -45,6 +59,7 @@ export function initChips(saveAll){
     }
     setChipActive(chip, isChipActive(chip));
   });
+  updateBreathGroups();
   if(listenersAdded) return;
   listenersAdded = true;
 
@@ -83,6 +98,7 @@ export function initChips(saveAll){
         $('#spr_ligonine').value='';
       }
     }
+    updateBreathGroups();
     delete chip.dataset.auto;
     if(typeof saveAll === 'function') saveAll();
   }


### PR DESCRIPTION
## Summary
- Replace breathing auscultation plus/minus with explicit "Normalus" and expandable "Kita" options
- Add JS logic to toggle additional auscultation choices when "Kita" is selected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4646200a88320bddd908dd3845517