### PR TITLE
Add development script for concurrent server and Sass watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ node server/index.js
 
 You can also create an `npm start` script for convenience.
 
+## Development Server
+
+Run the backend with automatic restarts and watch Sass files for changes:
+
+```bash
+npm run dev
+```
+
+This uses `nodemon` and `sass` via `concurrently` to streamline development.
+
 ## Testing
 
 Execute the test suite:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest --passWithNoTests",
     "build:css": "sass --no-source-map --style=compressed css/scss/main.scss css/main.css",
-    "start": "node server/index.js"
+    "start": "node server/index.js",
+    "dev": "concurrently \"sass --watch css/scss/main.scss:css/main.css\" \"nodemon server/index.js\""
   },
   "keywords": [],
   "author": "",
@@ -18,6 +19,8 @@
     "socket.io": "^4.7.5"
   },
   "devDependencies": {
+    "concurrently": "^8.2.0",
+    "nodemon": "^3.1.0",
     "@babel/preset-env": "^7.28.3",
     "jest": "^27.5.1",
     "jsdom": "^26.1.0",


### PR DESCRIPTION
## Summary
- add `npm run dev` script to run nodemon and Sass watcher concurrently
- document development workflow in README
- include nodemon and concurrently in dev dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a46eaa49488320a4fe918f8e4a3f27