### PR TITLE
Add required field validation for vitals

### DIFF
--- a/js/validation.js
+++ b/js/validation.js
@@ -22,7 +22,9 @@ function showInlineError(el, msg) {
 export function validateField(el) {
   const val = el.value.trim();
   let msg = '';
-  if (val !== '') {
+  if (el.hasAttribute('required') && val === '') {
+    msg = 'Privalomas laukas';
+  } else if (val !== '') {
     const num = parseFloat(val);
     const min = el.getAttribute('min');
     const max = el.getAttribute('max');
@@ -34,7 +36,7 @@ export function validateField(el) {
 }
 
 export function validateVitals() {
-  const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm','#patient_age'];
+  const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm','#patient_age','#patient_sex','#patient_history'];
   let ok = true;
   fields.forEach(sel => {
     const el = $(sel);
@@ -47,7 +49,7 @@ export function validateVitals() {
 }
 
 export function initValidation() {
-  const selectors = ['#patient_age','#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm'];
+  const selectors = ['#patient_age','#patient_sex','#patient_history','#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm'];
   selectors.forEach(sel => {
     const el = $(sel);
     if (!el) return;

--- a/js/validation.test.js
+++ b/js/validation.test.js
@@ -1,0 +1,37 @@
+import { validateField, validateVitals } from './validation.js';
+
+describe('validateField', () => {
+  test('returns error for required empty field', () => {
+    document.body.innerHTML = '<input id="test" required />';
+    const input = document.getElementById('test');
+    validateField(input);
+    const err = input.nextElementSibling;
+    expect(err).not.toBeNull();
+    expect(err.textContent).toBe('Privalomas laukas');
+    expect(input.classList.contains('invalid')).toBe(true);
+  });
+});
+
+describe('validateVitals', () => {
+  test('checks required text and select fields', () => {
+    document.body.innerHTML = `
+      <input id="patient_age" type="number" value="25" required />
+      <select id="patient_sex" required>
+        <option value=""></option>
+        <option value="M">M</option>
+      </select>
+      <input id="patient_history" required />
+    `;
+    expect(validateVitals()).toBe(false);
+    const sexErr = document.querySelector('#patient_sex').nextElementSibling;
+    const histErr = document.querySelector('#patient_history').nextElementSibling;
+    expect(sexErr.textContent).toBe('Privalomas laukas');
+    expect(histErr.textContent).toBe('Privalomas laukas');
+
+    document.getElementById('patient_sex').value = 'M';
+    document.getElementById('patient_history').value = 'H123';
+    expect(validateVitals()).toBe(true);
+    expect(document.getElementById('patient_sex').classList.contains('invalid')).toBe(false);
+    expect(document.getElementById('patient_history').classList.contains('invalid')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- handle required fields in `validateField`
- include `patient_sex` and `patient_history` in vitals validation
- add tests for required field checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a487fac5cc8320b53d5c185c29d206