### PR TITLE
feat: add timeline clear button

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,12 +444,13 @@
           <option value="">Visi</option>
           <option value="med">Vaistai</option>
           <option value="proc">Procedūros</option>
-          <option value="vital">Gyvybiniai rodikliai</option>
-        </select>
-        <button type="button" class="btn" id="timelineExport">Eksportuoti</button>
-      </div>
-      <div id="timelineList" class="timeline-list"></div>
-    </section>
+        <option value="vital">Gyvybiniai rodikliai</option>
+      </select>
+      <button type="button" class="btn" id="timelineExport">Eksportuoti</button>
+      <button type="button" class="btn" id="timelineClear">Išvalyti</button>
+    </div>
+    <div id="timelineList" class="timeline-list"></div>
+  </section>
     <section class="card view" id="view-ataskaita" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Ataskaita sugeneruojama automatiškai"></textarea><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
   </div>
 </main>

--- a/js/timeline.js
+++ b/js/timeline.js
@@ -42,6 +42,9 @@ export function initTimeline() {
     a.click();
     URL.revokeObjectURL(url);
   });
+  $('#timelineClear')?.addEventListener('click', () => {
+    if (confirm('Ar tikrai ištrinti visus įrašus?')) clearTimeline();
+  });
   renderTimeline();
 }
 


### PR DESCRIPTION
## Summary
- add "Išvalyti" button next to timeline export
- confirm before clearing timeline entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48cf77c588320a1a79ffdc2ff0944