### PR TITLE
Validate sessions PUT payload

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -71,11 +71,12 @@ app.get('/api/sessions', auth, (req, res) => {
 });
 
 app.put('/api/sessions', auth, async (req, res) => {
-  if(Array.isArray(req.body)){
-    db.sessions = req.body;
-    await saveDB();
-    io.emit('sessions', db.sessions);
+  if(!Array.isArray(req.body)){
+    return res.status(400).json({ error: 'Invalid session list' });
   }
+  db.sessions = req.body;
+  await saveDB();
+  io.emit('sessions', db.sessions);
   res.json({ ok: true });
 });
 
@@ -127,6 +128,8 @@ app.put('/api/sessions/:id/data', auth, async (req, res) => {
 
 const server = http.createServer(app);
 const io = new Server(server, { cors: { origin: '*' } });
+
+module.exports = { app, server };
 
 io.use((socket, next) => {
   const token = socket.handshake.auth && socket.handshake.auth.token;

--- a/server/sessions.test.js
+++ b/server/sessions.test.js
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment node
+ */
+const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
+
+describe('PUT /api/sessions validation', () => {
+  const dbPath = path.join(__dirname, 'db.json');
+  let originalDB;
+  let server;
+
+  beforeAll(async () => {
+    originalDB = await fs.promises.readFile(dbPath, 'utf8');
+    process.env.PORT = 0; // use ephemeral port
+    server = require('./index.js').server;
+    await new Promise(resolve => {
+      if (server.listening) return resolve();
+      server.on('listening', resolve);
+    });
+  });
+
+  afterAll(async () => {
+    await fs.promises.writeFile(dbPath, originalDB);
+    await new Promise(resolve => server.close(resolve));
+  });
+
+  test('returns 400 when body is not an array', async () => {
+    const loginRes = await request(server).post('/api/login').send({ name: 'tester' });
+    const token = loginRes.body.token;
+
+    const res = await request(server)
+      .put('/api/sessions')
+      .set('Authorization', token)
+      .send({ invalid: true });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid session list' });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure PUT /api/sessions rejects non-array bodies
- export server to facilitate tests
- add unit test covering invalid session payload

## Testing
- `npm test` *(fails: Cannot find module 'supertest')*


------
https://chatgpt.com/codex/tasks/task_e_68a4a81c32848320b2ccc9bb0adadbf7