### PR TITLE
Use Bearer tokens for API authorization

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -22,7 +22,7 @@ function updateUserList(users){
 async function fetchUsers(){
   if(authToken && typeof fetch==='function'){
     try{
-      const res=await fetch('/api/users',{ headers:{ 'Authorization':authToken } });
+      const res=await fetch('/api/users',{ headers:{ 'Authorization':'Bearer '+authToken } });
       if(res.ok){
         const data=await res.json();
         updateUserList(data);
@@ -68,7 +68,7 @@ async function ensureLogin(){
 
 function connectSocket(){
   if(typeof io === 'undefined' || socket || !authToken) return;
-  socket = io({ auth: { token: authToken } });
+  socket = io({ auth: { token: 'Bearer '+authToken } });
   socket.on('sessions', list => {
     const sel = $('#sessionSelect');
     if(sel) populateSessionSelect(sel, list);
@@ -86,7 +86,7 @@ const sessionKey = () => 'trauma_v10_' + currentSessionId;
 async function getSessions(){
   if(authToken && typeof fetch === 'function'){
     try{
-      const res = await fetch('/api/sessions', { headers: { 'Authorization': authToken } });
+      const res = await fetch('/api/sessions', { headers: { 'Authorization': 'Bearer ' + authToken } });
       if(res.ok){
         const data = await res.json();
         localStorage.setItem('trauma_sessions', JSON.stringify(data));
@@ -101,7 +101,7 @@ function saveSessions(list){
   if(authToken && typeof fetch === 'function'){
     fetch('/api/sessions', {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json', 'Authorization': authToken },
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + authToken },
       body: JSON.stringify(list)
     }).catch(()=>{});
   }
@@ -143,7 +143,7 @@ async function initSessions(){
           try{
             await fetch(`/api/sessions/${s.id}`, {
               method:'PUT',
-              headers:{ 'Content-Type':'application/json','Authorization':authToken },
+              headers:{ 'Content-Type':'application/json','Authorization':'Bearer '+authToken },
               body:JSON.stringify({name})
             });
           }catch(e){ /* ignore */ }
@@ -156,7 +156,7 @@ async function initSessions(){
       btn.setAttribute('aria-label','Delete session');
       btn.addEventListener('click',async()=>{
         if(authToken && typeof fetch==='function'){
-          try{ await fetch(`/api/sessions/${s.id}`, { method:'DELETE', headers:{ 'Authorization': authToken } }); }catch(e){ /* ignore */ }
+          try{ await fetch(`/api/sessions/${s.id}`, { method:'DELETE', headers:{ 'Authorization': 'Bearer ' + authToken } }); }catch(e){ /* ignore */ }
         }
         const wasCurrent=currentSessionId===s.id;
         sessions=sessions.filter(x=>x.id!==s.id);
@@ -451,7 +451,7 @@ export function saveAll(){
   if(authToken && typeof fetch === 'function'){
     fetch(`/api/sessions/${currentSessionId}/data`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json', 'Authorization': authToken },
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + authToken },
       body: JSON.stringify(data)
     }).then(()=>{
       if(statusEl){
@@ -510,7 +510,7 @@ export function loadAll(){
     const raw=localStorage.getItem(sessionKey()); if(!raw) return; try{ apply(JSON.parse(raw)); }catch(e){}
   };
   if(authToken && typeof fetch === 'function'){
-    fetch(`/api/sessions/${currentSessionId}/data`, { headers:{ 'Authorization': authToken }})
+    fetch(`/api/sessions/${currentSessionId}/data`, { headers:{ 'Authorization': 'Bearer ' + authToken }})
       .then(r=>r.json()).then(d=>{ localStorage.setItem(sessionKey(), JSON.stringify(d)); apply(d); })
       .catch(fallback);
   } else {
@@ -898,7 +898,7 @@ function setupHeaderActions(){
     btn.textContent='Logout';
     btn.addEventListener('click',async()=>{
       if(authToken && typeof fetch==='function'){
-        try{ await fetch('/api/logout',{ method:'POST', headers:{ 'Authorization':authToken } }); }catch(e){ /* ignore */ }
+        try{ await fetch('/api/logout',{ method:'POST', headers:{ 'Authorization':'Bearer '+authToken } }); }catch(e){ /* ignore */ }
       }
       authToken=null;
       localStorage.removeItem('trauma_token');

--- a/server/sessions.test.js
+++ b/server/sessions.test.js
@@ -1,23 +1,26 @@
 /**
  * @jest-environment node
  */
-const request = require('supertest');
 const fs = require('fs');
 const path = require('path');
+const http = require('http');
 
-describe('PUT /api/sessions validation', () => {
+describe('auth middleware', () => {
   const dbPath = path.join(__dirname, 'db.json');
   let originalDB;
   let server;
+  let base;
 
   beforeAll(async () => {
     originalDB = await fs.promises.readFile(dbPath, 'utf8');
-    process.env.PORT = 0; // use ephemeral port
+    process.env.PORT = 0;
     server = require('./index.js').server;
     await new Promise(resolve => {
       if (server.listening) return resolve();
       server.on('listening', resolve);
     });
+    const address = server.address();
+    base = `http://localhost:${address.port}`;
   });
 
   afterAll(async () => {
@@ -25,16 +28,61 @@ describe('PUT /api/sessions validation', () => {
     await new Promise(resolve => server.close(resolve));
   });
 
+  function httpRequest(method, path, { headers = {}, body } = {}) {
+    return new Promise((resolve, reject) => {
+      const req = http.request(base + path, { method, headers }, res => {
+        let data = '';
+        res.on('data', chunk => { data += chunk; });
+        res.on('end', () => resolve({ status: res.statusCode, data }));
+      });
+      req.on('error', reject);
+      if(body) req.write(body);
+      req.end();
+    });
+  }
+
   test('returns 400 when body is not an array', async () => {
-    const loginRes = await request(server).post('/api/login').send({ name: 'tester' });
-    const token = loginRes.body.token;
-
-    const res = await request(server)
-      .put('/api/sessions')
-      .set('Authorization', token)
-      .send({ invalid: true });
-
+    const loginRes = await httpRequest('POST', '/api/login', {
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'tester' })
+    });
+    const token = JSON.parse(loginRes.data).token;
+    const res = await httpRequest('PUT', '/api/sessions', {
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ invalid: true })
+    });
     expect(res.status).toBe(400);
-    expect(res.body).toEqual({ error: 'Invalid session list' });
+    const body = JSON.parse(res.data);
+    expect(body).toEqual({ error: 'Invalid session list' });
+  });
+
+  test('rejects requests without authorization header', async () => {
+    const res = await httpRequest('GET', '/api/sessions');
+    expect(res.status).toBe(401);
+    const body = JSON.parse(res.data);
+    expect(body).toEqual({ error: 'No token' });
+  });
+
+  test('rejects requests with malformed token', async () => {
+    const loginRes = await httpRequest('POST', '/api/login', {
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'tester2' })
+    });
+    const token = JSON.parse(loginRes.data).token;
+    const res = await httpRequest('GET', '/api/sessions', {
+      headers: { Authorization: token }
+    });
+    expect(res.status).toBe(401);
+    const body = JSON.parse(res.data);
+    expect(body).toEqual({ error: 'No token' });
+  });
+
+  test('rejects requests with invalid bearer token', async () => {
+    const res = await httpRequest('GET', '/api/sessions', {
+      headers: { Authorization: 'Bearer invalid' }
+    });
+    expect(res.status).toBe(401);
+    const body = JSON.parse(res.data);
+    expect(body).toEqual({ error: 'Invalid token' });
   });
 });


### PR DESCRIPTION
## Summary
- prefix all client API calls with `Authorization: Bearer <token>`
- parse bearer tokens in server auth middleware and socket handshake
- add integration tests for missing or invalid bearer tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a9ed8dec8320a67428f0547a5997