### PR TITLE
Refactor forms into collapsible fieldsets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,72 +21,82 @@
     <!-- Aktyvacija -->
     <section class="card view" id="view-aktivacija" data-tab="Aktyvacija">
         <h2>Traumos komandos aktyvacija <span class="badge">GMP rodikliai → auto</span></h2>
-      <h3>Pacientas</h3>
-      <div class="grid cols-3 cols-auto">
-        <div>
-          <label for="patient_age">Amžius</label>
-          <input id="patient_age" type="number" min="0" max="120" required aria-describedby="patient_age_hint" title="Amžius 0-120">
-          <div class="hint" id="patient_age_hint">0–120 metų</div>
-        </div>
-        <div>
-          <label for="patient_sex">Lytis</label>
-          <select id="patient_sex" required aria-describedby="patient_sex_hint" title="Pasirinkite lytį">
-            <option value=""></option>
-            <option value="M">Vyras</option>
-            <option value="F">Moteris</option>
-            <option value="O">Kita / nenurodyta</option>
-          </select>
-          <div class="hint" id="patient_sex_hint">Pasirinkite lytį</div>
-        </div>
-        <div>
-          <label for="patient_history">Ligos istorijos nr.</label>
-          <input id="patient_history" type="text" required aria-describedby="patient_history_hint" title="Įveskite ligos istorijos numerį">
-          <div class="hint" id="patient_history_hint">Privalomas laukas</div>
-        </div>
-      </div>
-      <div class="grid cols-3 cols-auto">
-          <div><label for="gmp_hr">GMP ŠSD (k./min)</label><input id="gmp_hr" type="number" min="0" max="250"></div>
-          <div><label for="gmp_rr">GMP KD (k./min)</label><input id="gmp_rr" type="number" min="0" max="80"></div>
-          <div><label for="gmp_spo2">GMP SpO₂ (%)</label><input id="gmp_spo2" type="number" min="0" max="100"></div>
-      </div>
-      <div class="grid cols-3 cols-auto mt-8">
-          <div class="row"><div class="flex-1"><label for="gmp_sbp">GMP AKS s</label><input id="gmp_sbp" type="number" min="0" max="300"></div><div class="flex-1"><label for="gmp_dbp">GMP AKS d</label><input id="gmp_dbp" type="number" min="0" max="200"></div></div>
-          <div><label>GMP GKS (A-K-M)</label><div class="row"><input id="gmp_gksa" type="number" min="1" max="4" placeholder="A"><input id="gmp_gksk" type="number" min="1" max="5" placeholder="K"><input id="gmp_gksm" type="number" min="1" max="6" placeholder="M"><span id="gmp_gks_total"></span></div></div>
-          <div><label for="gmp_time">GMP pranešimo laikas</label><div class="row"><input id="gmp_time" type="time"><button type="button" class="btn ghost" id="btnGmpNow">Dabar</button></div></div>
-      </div>
-      <div class="grid cols-2 cols-auto mt-8">
-          <div><label for="gmp_mechanism">Traumos mechanizmas</label><input id="gmp_mechanism" type="text"></div>
-          <div><label for="gmp_notes">Pastabos</label><input id="gmp_notes" type="text" placeholder="Trumpai..."></div>
-      </div>
-      <div class="split mt-12">
-        <div>
-          <label><strong>RAUDONA</strong></label>
-          <div class="chip-group" id="chips_red" aria-label="RAUDONA">
-            <button type="button" class="chip red" data-value="GKS &lt; 9" aria-pressed="false">GKS &lt; 9</button>
-            <button type="button" class="chip red" data-value="KD &lt; 8 ar &gt; 30/min" aria-pressed="false">KD &lt; 8 ar &gt; 30/min</button>
-            <button type="button" class="chip red" data-value="AKS &lt; 90 mmHg" aria-pressed="false">AKS &lt; 90 mmHg</button>
-            <button type="button" class="chip red" data-value="SpO₂ &lt; 90%" aria-pressed="false">SpO₂ &lt; 90%</button>
-            <button type="button" class="chip red" data-value="ŠSD &gt; 120/min" aria-pressed="false">ŠSD &gt; 120/min</button>
-            <button type="button" class="chip red" data-value="Stridoras" aria-pressed="false">Stridoras</button>
-            <button type="button" class="chip red" data-value="Lūžę 2 ilgieji kaulai/dubuo" aria-pressed="false">Lūžę 2 ilgieji kaulai/dubuo</button>
-            <button type="button" class="chip red" data-value="Kiauriniai suž. kakle/krūtinėje/juosmenyje" aria-pressed="false">Kiauriniai suž. kakle/krūtinėje/juosmenyje</button>
-            <button type="button" class="chip red" data-value="Įtariamas vidinis kraujavimas" aria-pressed="false">Įtariamas vidinis kraujavimas</button>
-            <button type="button" class="chip red" data-value="Nestabili krūtinės ląsta" aria-pressed="false">Nestabili krūtinės ląsta</button>
-            <button type="button" class="chip red" data-value="Nudegimas &gt;18% ar KT nudegimas" aria-pressed="false">Nudegimas &gt;18% ar KT nudegimas</button>
-            <button type="button" class="chip red" data-value="Amputacijos aukščiau plašt./pėdų" aria-pressed="false">Amputacijos aukščiau plašt./pėdų</button>
+        <fieldset class="collapsible" id="activation-patient">
+          <legend>Pacientas</legend>
+          <div class="grid cols-3 cols-auto">
+            <div>
+              <label for="patient_age">Amžius</label>
+              <input id="patient_age" type="number" min="0" max="120" required aria-describedby="patient_age_hint" title="Amžius 0-120">
+              <div class="hint" id="patient_age_hint">0–120 metų</div>
+            </div>
+            <div>
+              <label for="patient_sex">Lytis</label>
+              <select id="patient_sex" required aria-describedby="patient_sex_hint" title="Pasirinkite lytį">
+                <option value=""></option>
+                <option value="M">Vyras</option>
+                <option value="F">Moteris</option>
+                <option value="O">Kita / nenurodyta</option>
+              </select>
+              <div class="hint" id="patient_sex_hint">Pasirinkite lytį</div>
+            </div>
+            <div>
+              <label for="patient_history">Ligos istorijos nr.</label>
+              <input id="patient_history" type="text" required aria-describedby="patient_history_hint" title="Įveskite ligos istorijos numerį">
+              <div class="hint" id="patient_history_hint">Privalomas laukas</div>
+            </div>
           </div>
-        </div>
-        <div>
-          <label><strong>GELTONA</strong></label>
-          <div class="chip-group" id="chips_yellow" aria-label="GELTONA">
-            <button type="button" class="chip yellow" data-value="Pėst./dvir./motociklo trauma" aria-pressed="false">Pėst./dvir./motociklo trauma</button>
-            <button type="button" class="chip yellow" data-value="Sprogimas/susišaudymas" aria-pressed="false">Sprogimas/susišaudymas</button>
-            <button type="button" class="chip yellow" data-value="Kritimas &gt;3 m ar nardymas" aria-pressed="false">Kritimas &gt;3 m ar nardymas</button>
-            <button type="button" class="chip yellow" data-value="Reikėjo gelbėtojų pagalbos" aria-pressed="false">Reikėjo gelbėtojų pagalbos</button>
+        </fieldset>
+
+        <fieldset class="collapsible" id="activation-gmp">
+          <legend>GMP rodikliai</legend>
+          <div class="grid cols-3 cols-auto">
+              <div><label for="gmp_hr">GMP ŠSD (k./min)</label><input id="gmp_hr" type="number" min="0" max="250"></div>
+              <div><label for="gmp_rr">GMP KD (k./min)</label><input id="gmp_rr" type="number" min="0" max="80"></div>
+              <div><label for="gmp_spo2">GMP SpO₂ (%)</label><input id="gmp_spo2" type="number" min="0" max="100"></div>
           </div>
-        </div>
-      </div>
-        <div class="hint mt-6">Auto-aktyvacija – tik iš GMP rodiklių; rankiniai pakeitimai išlieka.</div>
+          <div class="grid cols-3 cols-auto mt-8">
+              <div class="row"><div class="flex-1"><label for="gmp_sbp">GMP AKS s</label><input id="gmp_sbp" type="number" min="0" max="300"></div><div class="flex-1"><label for="gmp_dbp">GMP AKS d</label><input id="gmp_dbp" type="number" min="0" max="200"></div></div>
+              <div><label>GMP GKS (A-K-M)</label><div class="row"><input id="gmp_gksa" type="number" min="1" max="4" placeholder="A"><input id="gmp_gksk" type="number" min="1" max="5" placeholder="K"><input id="gmp_gksm" type="number" min="1" max="6" placeholder="M"><span id="gmp_gks_total"></span></div></div>
+              <div><label for="gmp_time">GMP pranešimo laikas</label><div class="row"><input id="gmp_time" type="time"><button type="button" class="btn ghost" id="btnGmpNow">Dabar</button></div></div>
+          </div>
+          <div class="grid cols-2 cols-auto mt-8">
+              <div><label for="gmp_mechanism">Traumos mechanizmas</label><input id="gmp_mechanism" type="text"></div>
+              <div><label for="gmp_notes">Pastabos</label><input id="gmp_notes" type="text" placeholder="Trumpai..."></div>
+          </div>
+        </fieldset>
+
+        <fieldset class="collapsible" id="activation-criteria">
+          <legend>Aktyvacijos kriterijai</legend>
+          <div class="split mt-12">
+            <div>
+              <label><strong>RAUDONA</strong></label>
+              <div class="chip-group" id="chips_red" aria-label="RAUDONA">
+                <button type="button" class="chip red" data-value="GKS &lt; 9" aria-pressed="false">GKS &lt; 9</button>
+                <button type="button" class="chip red" data-value="KD &lt; 8 ar &gt; 30/min" aria-pressed="false">KD &lt; 8 ar &gt; 30/min</button>
+                <button type="button" class="chip red" data-value="AKS &lt; 90 mmHg" aria-pressed="false">AKS &lt; 90 mmHg</button>
+                <button type="button" class="chip red" data-value="SpO₂ &lt; 90%" aria-pressed="false">SpO₂ &lt; 90%</button>
+                <button type="button" class="chip red" data-value="ŠSD &gt; 120/min" aria-pressed="false">ŠSD &gt; 120/min</button>
+                <button type="button" class="chip red" data-value="Stridoras" aria-pressed="false">Stridoras</button>
+                <button type="button" class="chip red" data-value="Lūžę 2 ilgieji kaulai/dubuo" aria-pressed="false">Lūžę 2 ilgieji kaulai/dubuo</button>
+                <button type="button" class="chip red" data-value="Kiauriniai suž. kakle/krūtinėje/juosmenyje" aria-pressed="false">Kiauriniai suž. kakle/krūtinėje/juosmenyje</button>
+                <button type="button" class="chip red" data-value="Įtariamas vidinis kraujavimas" aria-pressed="false">Įtariamas vidinis kraujavimas</button>
+                <button type="button" class="chip red" data-value="Nestabili krūtinės ląsta" aria-pressed="false">Nestabili krūtinės ląsta</button>
+                <button type="button" class="chip red" data-value="Nudegimas &gt;18% ar KT nudegimas" aria-pressed="false">Nudegimas &gt;18% ar KT nudegimas</button>
+                <button type="button" class="chip red" data-value="Amputacijos aukščiau plašt./pėdų" aria-pressed="false">Amputacijos aukščiau plašt./pėdų</button>
+              </div>
+            </div>
+            <div>
+              <label><strong>GELTONA</strong></label>
+              <div class="chip-group" id="chips_yellow" aria-label="GELTONA">
+                <button type="button" class="chip yellow" data-value="Pėst./dvir./motociklo trauma" aria-pressed="false">Pėst./dvir./motociklo trauma</button>
+                <button type="button" class="chip yellow" data-value="Sprogimas/susišaudymas" aria-pressed="false">Sprogimas/susišaudymas</button>
+                <button type="button" class="chip yellow" data-value="Kritimas &gt;3 m ar nardymas" aria-pressed="false">Kritimas &gt;3 m ar nardymas</button>
+                <button type="button" class="chip yellow" data-value="Reikėjo gelbėtojų pagalbos" aria-pressed="false">Reikėjo gelbėtojų pagalbos</button>
+              </div>
+            </div>
+          </div>
+          <div class="hint mt-6">Auto-aktyvacija – tik iš GMP rodiklių; rankiniai pakeitimai išlieka.</div>
+        </fieldset>
     </section>
 
     <!-- A -->
@@ -106,54 +116,60 @@
     <!-- B -->
     <section class="card view" id="view-b" data-tab="B – Kvėpavimas">
       <h2>B – Kvėpavimas</h2>
-      <h3>Gyvybiniai rodikliai</h3>
-      <div class="grid cols-2 cols-auto">
-        <div><label for="b_rr">KD (k./min)</label><input id="b_rr" type="number" min="0" max="80"></div>
-        <div><label for="b_spo2">SpO₂ (%)</label><input id="b_spo2" type="number" min="0" max="100"></div>
-      </div>
-      <h3>Alsavimas</h3>
-      <div class="row">
-        <div>
-          <div class="subtle">Kairė</div>
-          <div class="chip-group" id="b_breath_left_group" data-single="true" aria-label="Alsavimas – Kairė">
-            <button type="button" class="chip breath-chip" data-value="Normalus" aria-label="Normalus" title="Normalus">Normalus</button>
-            <button type="button" class="chip breath-chip red breath-toggle" data-value="_kita" aria-label="Kita" title="Kita">Kita</button>
-            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Neišklausomas">Neišklausomas</button>
-            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Susilpnėjęs">Susilpnėjęs</button>
-            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Kita">Kita</button>
+        <fieldset class="collapsible" id="breathing-vitals">
+          <legend>Gyvybiniai rodikliai</legend>
+          <div class="grid cols-2 cols-auto">
+            <div><label for="b_rr">KD (k./min)</label><input id="b_rr" type="number" min="0" max="80"></div>
+            <div><label for="b_spo2">SpO₂ (%)</label><input id="b_spo2" type="number" min="0" max="100"></div>
           </div>
-        </div>
-        <div>
-          <div class="subtle">Dešinė</div>
-          <div class="chip-group" id="b_breath_right_group" data-single="true" aria-label="Alsavimas – Dešinė">
-            <button type="button" class="chip breath-chip" data-value="Normalus" aria-label="Normalus" title="Normalus">Normalus</button>
-            <button type="button" class="chip breath-chip red breath-toggle" data-value="_kita" aria-label="Kita" title="Kita">Kita</button>
-            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Neišklausomas">Neišklausomas</button>
-            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Susilpnėjęs">Susilpnėjęs</button>
-            <button type="button" class="chip breath-chip red breath-option hidden" data-value="Kita">Kita</button>
+        </fieldset>
+        <fieldset class="collapsible" id="breathing-breath">
+          <legend>Alsavimas</legend>
+          <div class="row">
+            <div>
+              <div class="subtle">Kairė</div>
+              <div class="chip-group" id="b_breath_left_group" data-single="true" aria-label="Alsavimas – Kairė">
+                <button type="button" class="chip breath-chip" data-value="Normalus" aria-label="Normalus" title="Normalus">Normalus</button>
+                <button type="button" class="chip breath-chip red breath-toggle" data-value="_kita" aria-label="Kita" title="Kita">Kita</button>
+                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Neišklausomas">Neišklausomas</button>
+                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Susilpnėjęs">Susilpnėjęs</button>
+                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Kita">Kita</button>
+              </div>
+            </div>
+            <div>
+              <div class="subtle">Dešinė</div>
+              <div class="chip-group" id="b_breath_right_group" data-single="true" aria-label="Alsavimas – Dešinė">
+                <button type="button" class="chip breath-chip" data-value="Normalus" aria-label="Normalus" title="Normalus">Normalus</button>
+                <button type="button" class="chip breath-chip red breath-toggle" data-value="_kita" aria-label="Kita" title="Kita">Kita</button>
+                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Neišklausomas">Neišklausomas</button>
+                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Susilpnėjęs">Susilpnėjęs</button>
+                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Kita">Kita</button>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
-      <h3>Pagalbinė ventiliacija</h3>
-      <div class="row flex-wrap">
-        <div class="row">
-          <button type="button" class="btn" id="btnOxygen">O2</button>
-          <div id="oxygenFields" class="row hidden">
-            <input id="b_oxygen_liters" type="number" min="0" max="25" placeholder="L/min" class="w-80">
-            <select id="b_oxygen_type">
-              <option value="Kaukė su rez.">Kaukė su rez.</option>
-              <option value="Kaukė">Kaukė</option>
-              <option value="Nosinės kaniulės">Nosinės kaniulės</option>
-            </select>
+        </fieldset>
+        <fieldset class="collapsible" id="breathing-vent">
+          <legend>Pagalbinė ventiliacija</legend>
+          <div class="row flex-wrap">
+            <div class="row">
+              <button type="button" class="btn" id="btnOxygen">O2</button>
+              <div id="oxygenFields" class="row hidden">
+                <input id="b_oxygen_liters" type="number" min="0" max="25" placeholder="L/min" class="w-80">
+                <select id="b_oxygen_type">
+                  <option value="Kaukė su rez.">Kaukė su rez.</option>
+                  <option value="Kaukė">Kaukė</option>
+                  <option value="Nosinės kaniulės">Nosinės kaniulės</option>
+                </select>
+              </div>
+            </div>
+            <div class="row">
+              <button type="button" class="btn" id="btnDPV">DPV</button>
+              <div id="dpvFields" class="row hidden">
+                <input id="b_dpv_fio2" type="number" step="0.01" min="0" max="1" placeholder="FiO₂">
+              </div>
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <button type="button" class="btn" id="btnDPV">DPV</button>
-          <div id="dpvFields" class="row hidden">
-            <input id="b_dpv_fio2" type="number" step="0.01" min="0" max="1" placeholder="FiO₂">
-          </div>
-        </div>
-      </div>
+        </fieldset>
     </section>
 
     <!-- C -->

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,6 +9,7 @@ import { showToast } from './components/toast.js';
 import { initValidation, validateVitals } from './validation.js';
 import { startArrivalTimer } from './arrival.js';
 import { initTopbar } from './components/topbar.js';
+import { initCollapsibles } from './sections.js';
 export { validateVitals };
 
 let authToken = localStorage.getItem('trauma_token') || null;
@@ -613,6 +614,7 @@ async function init(){
   await fetchUsers();
   await initSessions();
   initTabs();
+  initCollapsibles();
   initChips(saveAllDebounced);
   initAutoActivate(saveAllDebounced);
   initActions(saveAllDebounced);

--- a/public/js/sections.js
+++ b/public/js/sections.js
@@ -1,0 +1,38 @@
+import { $$ } from './utils.js';
+
+export function initCollapsibles(){
+  $$( 'fieldset.collapsible').forEach((fs, i) => {
+    const legend = fs.querySelector('legend');
+    if(!legend) return;
+    const content = document.createElement('div');
+    content.className = 'fieldset-content';
+    while(legend.nextSibling){
+      content.appendChild(legend.nextSibling);
+    }
+    fs.appendChild(content);
+    legend.style.cursor = 'pointer';
+    legend.setAttribute('role','button');
+    legend.setAttribute('tabindex','0');
+    const collapsed = i > 0;
+    if(collapsed){
+      fs.classList.add('collapsed');
+      content.style.display = 'none';
+      legend.setAttribute('aria-expanded','false');
+    } else {
+      legend.setAttribute('aria-expanded','true');
+    }
+    const toggle = () => {
+      fs.classList.toggle('collapsed');
+      const isCollapsed = fs.classList.contains('collapsed');
+      content.style.display = isCollapsed ? 'none' : '';
+      legend.setAttribute('aria-expanded', (!isCollapsed).toString());
+    };
+    legend.addEventListener('click', toggle);
+    legend.addEventListener('keydown', e => {
+      if(e.key === 'Enter' || e.key === ' '){
+        e.preventDefault();
+        toggle();
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Split activation and breathing views into `<fieldset>` groups with legends for step-wise form navigation.
- Introduced `initCollapsibles` helper and wired it into app initialization to toggle fieldset visibility.

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching supertest)*

------
https://chatgpt.com/codex/tasks/task_e_68a56e29f65083209bb6065384ccb433