### PR TITLE
feat: add unified alert manager

### DIFF
--- a/docs/js/alerts.js
+++ b/docs/js/alerts.js
@@ -1,0 +1,39 @@
+const handlers = {};
+const queue = [];
+let processing = false;
+
+export function register(type, handler){
+  handlers[type] = handler;
+}
+
+export function notify(options){
+  return new Promise(resolve => {
+    queue.push({ ...options, resolve });
+    processQueue();
+  });
+}
+
+async function processQueue(){
+  if(processing) return;
+  processing = true;
+  while(queue.length){
+    const item = queue.shift();
+    const handler = handlers[item.type] || handlers.toast;
+    if(typeof handler === 'function'){
+      try{
+        const result = handler(item);
+        if(result && typeof result.then === 'function'){
+          item.resolve(await result);
+        }else{
+          item.resolve(result);
+        }
+      }catch(e){
+        console.error(e);
+        item.resolve();
+      }
+    }else{
+      item.resolve();
+    }
+  }
+  processing = false;
+}

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -4,8 +4,9 @@ import { initChips, listChips, setChipActive, isChipActive, addChipIndicators } 
 import { initAutoActivate } from './autoActivate.js';
 import { initActions } from './actions.js';
 import { logEvent, initTimeline } from './timeline.js';
-import { promptModal, confirmModal } from './components/modal.js';
-import { showToast } from './components/toast.js';
+import { notify } from './alerts.js';
+import './components/toast.js';
+import './components/modal.js';
 import { initValidation, validateVitals } from './validation.js';
 import { startArrivalTimer } from './arrival.js';
 import { initTopbar } from './components/topbar.js';
@@ -41,7 +42,7 @@ async function ensureLogin(){
   if(authToken || typeof fetch !== 'function') return;
   while(true){
     try{
-      const name=await promptModal('Įveskite vardą dalyvauti bendroje sesijoje');
+      const name=await notify({type:'prompt', message:'Įveskite vardą dalyvauti bendroje sesijoje'});
       if(!name) return;
       const res=await fetch('/api/login',{
         method:'POST',
@@ -49,8 +50,8 @@ async function ensureLogin(){
         body:JSON.stringify({ name })
       });
       if(!res.ok){
-        showToast('Prisijungti nepavyko: '+res.status,'error');
-        if(await confirmModal('Bandysite dar kartą?')) continue;
+        notify({message:'Prisijungti nepavyko: '+res.status,type:'error'});
+        if(await notify({type:'confirm',message:'Bandysite dar kartą?'})) continue;
         return;
       }
       const data=await res.json();
@@ -59,8 +60,8 @@ async function ensureLogin(){
       setupHeaderActions();
       break;
     }catch(e){
-      showToast('Prisijungti nepavyko: '+(e&&e.message||e),'error');
-      if(await confirmModal('Bandysite dar kartą?')) continue;
+      notify({message:'Prisijungti nepavyko: '+(e&&e.message||e),type:'error'});
+      if(await notify({type:'confirm',message:'Bandysite dar kartą?'})) continue;
       return;
     }
   }
@@ -132,7 +133,7 @@ async function initSessions(){
       rename.className='btn ghost';
       rename.setAttribute('aria-label','Rename session');
       rename.addEventListener('click',async()=>{
-        const name=await promptModal('Naujas pavadinimas', s.name);
+        const name=await notify({type:'prompt', message:'Naujas pavadinimas', defaultValue:s.name});
         if(!name) return;
         s.name=name;
         localStorage.setItem('trauma_sessions', JSON.stringify(sessions));
@@ -197,7 +198,7 @@ async function initSessions(){
   renderDeleteButtons();
 
   $('#btnNewSession').addEventListener('click',async()=>{
-    const name=await promptModal('Sesijos pavadinimas');
+    const name=await notify({type:'prompt', message:'Sesijos pavadinimas'});
     if(!name) return;
     const id=Date.now().toString(36);
     sessions.push({id,name});
@@ -213,7 +214,7 @@ async function initSessions(){
   $('#btnRenameSession').addEventListener('click',async()=>{
     const sess=sessions.find(s=>s.id===select.value);
     if(!sess) return;
-    const name=await promptModal('Naujas pavadinimas', sess.name);
+    const name=await notify({type:'prompt', message:'Naujas pavadinimas', defaultValue:sess.name});
     if(!name) return;
     sess.name=name;
     saveSessions(sessions);
@@ -320,7 +321,7 @@ const BodySVG=(function(){
     const last=list.pop(); if(last){ last.remove(); saveAll(); }
   });
   btnClear.addEventListener('click',async()=>{
-    if(await confirmModal('Išvalyti visas žymas (priekis ir nugara)?')){
+    if(await notify({type:'confirm', message:'Išvalyti visas žymas (priekis ir nugara)?'})){
       marks.innerHTML='';
       saveAll();
     }
@@ -830,17 +831,17 @@ function setupHeaderActions(){
   if(btnCopy) btnCopy.addEventListener('click',async()=>{
     try{
       await navigator.clipboard.writeText($('#output').value||'');
-      showToast('Nukopijuota.','success');
+      notify({message:'Nukopijuota.', type:'success'});
     }catch(e){
-      showToast('Nepavyko nukopijuoti.','error');
+      notify({message:'Nepavyko nukopijuoti.', type:'error'});
     }
   });
 
   const btnSave=document.getElementById('btnSave');
-  if(btnSave) btnSave.addEventListener('click',()=>{ if(validateForm()){ saveAll(); showToast('Išsaugota naršyklėje.','success'); }});
+  if(btnSave) btnSave.addEventListener('click',()=>{ if(validateForm()){ saveAll(); notify({message:'Išsaugota naršyklėje.', type:'success'}); }});
 
   const btnClear=document.getElementById('btnClear');
-  if(btnClear) btnClear.addEventListener('click',async()=>{ if(await confirmModal('Išvalyti viską?')){ localStorage.removeItem(sessionKey()); location.reload(); }});
+  if(btnClear) btnClear.addEventListener('click',async()=>{ if(await notify({type:'confirm', message:'Išvalyti viską?'})){ localStorage.removeItem(sessionKey()); location.reload(); }});
 
   const btnPdf=document.getElementById('btnPdf');
   if(btnPdf) btnPdf.addEventListener('click', async () => {
@@ -855,7 +856,7 @@ function setupHeaderActions(){
       doc.text(lines, 10, 10);
       doc.save('report.pdf');
     } catch (e) {
-      showToast('Nepavyko sugeneruoti PDF.','error');
+      notify({message:'Nepavyko sugeneruoti PDF.', type:'error'});
       console.error('PDF generation failed', e);
     }
   });

--- a/docs/js/components/modal.js
+++ b/docs/js/components/modal.js
@@ -1,4 +1,6 @@
-export function promptModal(message, defaultValue = '') {
+import { register } from '../alerts.js';
+
+function promptHandler({ message, defaultValue = '' }) {
   return new Promise(resolve => {
     const prev = document.activeElement;
     const overlay = document.createElement('div');
@@ -54,7 +56,7 @@ export function promptModal(message, defaultValue = '') {
   });
 }
 
-export function confirmModal(message){
+function confirmHandler({ message }){
   return new Promise(resolve => {
     const prev = document.activeElement;
     const overlay = document.createElement('div');
@@ -104,3 +106,6 @@ export function confirmModal(message){
     first.focus();
   });
 }
+
+register('prompt', promptHandler);
+register('confirm', confirmHandler);

--- a/docs/js/components/toast.js
+++ b/docs/js/components/toast.js
@@ -1,15 +1,17 @@
+import { register } from '../alerts.js';
+
 let container;
 
-export function showToast(message, type = 'info', duration = 3000) {
+function toastHandler({ message, type = 'info', duration = 3000 }) {
   if (!container) {
     container = document.createElement('div');
     container.className = 'toast-container';
-    container.setAttribute('role', 'status');
-    container.setAttribute('aria-live', 'polite');
     document.body.appendChild(container);
   }
   const toast = document.createElement('div');
   toast.className = 'toast ' + type;
+  toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
+  toast.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
   toast.textContent = message;
   container.appendChild(toast);
   setTimeout(() => {
@@ -17,3 +19,5 @@ export function showToast(message, type = 'info', duration = 3000) {
     setTimeout(() => toast.remove(), 300);
   }, duration);
 }
+
+register('toast', toastHandler);

--- a/public/js/alerts.js
+++ b/public/js/alerts.js
@@ -1,0 +1,39 @@
+const handlers = {};
+const queue = [];
+let processing = false;
+
+export function register(type, handler){
+  handlers[type] = handler;
+}
+
+export function notify(options){
+  return new Promise(resolve => {
+    queue.push({ ...options, resolve });
+    processQueue();
+  });
+}
+
+async function processQueue(){
+  if(processing) return;
+  processing = true;
+  while(queue.length){
+    const item = queue.shift();
+    const handler = handlers[item.type] || handlers.toast;
+    if(typeof handler === 'function'){
+      try{
+        const result = handler(item);
+        if(result && typeof result.then === 'function'){
+          item.resolve(await result);
+        }else{
+          item.resolve(result);
+        }
+      }catch(e){
+        console.error(e);
+        item.resolve();
+      }
+    }else{
+      item.resolve();
+    }
+  }
+  processing = false;
+}

--- a/public/js/components/modal.js
+++ b/public/js/components/modal.js
@@ -1,4 +1,6 @@
-export function promptModal(message, defaultValue = '') {
+import { register } from '../alerts.js';
+
+function promptHandler({ message, defaultValue = '' }) {
   return new Promise(resolve => {
     const prev = document.activeElement;
     const overlay = document.createElement('div');
@@ -54,7 +56,7 @@ export function promptModal(message, defaultValue = '') {
   });
 }
 
-export function confirmModal(message){
+function confirmHandler({ message }){
   return new Promise(resolve => {
     const prev = document.activeElement;
     const overlay = document.createElement('div');
@@ -104,3 +106,6 @@ export function confirmModal(message){
     first.focus();
   });
 }
+
+register('prompt', promptHandler);
+register('confirm', confirmHandler);

--- a/public/js/components/toast.js
+++ b/public/js/components/toast.js
@@ -1,15 +1,17 @@
+import { register } from '../alerts.js';
+
 let container;
 
-export function showToast(message, type = 'info', duration = 3000) {
+function toastHandler({ message, type = 'info', duration = 3000 }) {
   if (!container) {
     container = document.createElement('div');
     container.className = 'toast-container';
-    container.setAttribute('role', 'status');
-    container.setAttribute('aria-live', 'polite');
     document.body.appendChild(container);
   }
   const toast = document.createElement('div');
   toast.className = 'toast ' + type;
+  toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
+  toast.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
   toast.textContent = message;
   container.appendChild(toast);
   setTimeout(() => {
@@ -17,3 +19,5 @@ export function showToast(message, type = 'info', duration = 3000) {
     setTimeout(() => toast.remove(), 300);
   }, duration);
 }
+
+register('toast', toastHandler);


### PR DESCRIPTION
## Summary
- introduce queue-based `notify` API for all alerts
- register toast and modal components with the alert manager
- refactor app to use `notify` instead of direct UI helpers

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5854a044c832084ec48cef2bf7323