### PR TITLE
Use numeric timestamps for timeline entries

### DIFF
--- a/docs/js/timeline.js
+++ b/docs/js/timeline.js
@@ -1,16 +1,32 @@
-import { $, nowHM, timeZoneOffset } from './utils.js';
+import { $, timeZoneOffset } from './utils.js';
 
 const entries = [];
 
-export function logEvent(type, label, value = '', time = nowHM()) {
-  entries.push({ time, type, label, value });
+function parseTime(value) {
+  if (typeof value === 'number') return value;
+  const [h, m] = String(value).split(':').map(Number);
+  if (isNaN(h) || isNaN(m)) return Date.now();
+  const d = new Date();
+  d.setHours(h, m, 0, 0);
+  return d.getTime();
+}
+
+function formatTime(ts) {
+  const d = new Date(ts);
+  const p = n => String(n).padStart(2, '0');
+  return `${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
+export function logEvent(type, label, value = '', time = Date.now()) {
+  const timestamp = parseTime(time);
+  entries.push({ time: timestamp, type, label, value });
   renderTimeline();
 }
 
 export function getEntries(filter = '') {
   return entries
     .filter(e => !filter || e.type === filter)
-    .sort((a, b) => a.time.localeCompare(b.time));
+    .sort((a, b) => a.time - b.time);
 }
 
 export function renderTimeline() {
@@ -22,7 +38,8 @@ export function renderTimeline() {
   getEntries(filter).forEach(e => {
     const div = document.createElement('div');
     div.className = 'timeline-entry';
-    div.textContent = `${e.time} ${tz} – ${e.label}${e.value ? ': ' + e.value : ''}`;
+    const t = formatTime(e.time);
+    div.textContent = `${t} ${tz} – ${e.label}${e.value ? ': ' + e.value : ''}`;
     list.appendChild(div);
   });
 }
@@ -32,7 +49,7 @@ export function initTimeline() {
   $('#timelineExport')?.addEventListener('click', () => {
     const tz = timeZoneOffset();
     const csv = entries
-      .map(e => `${e.time} ${tz},${e.type},${e.label},${e.value}`)
+      .map(e => `${formatTime(e.time)} ${tz},${e.type},${e.label},${e.value}`)
       .join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);

--- a/public/js/timeline.js
+++ b/public/js/timeline.js
@@ -1,16 +1,32 @@
-import { $, nowHM, timeZoneOffset } from './utils.js';
+import { $, timeZoneOffset } from './utils.js';
 
 const entries = [];
 
-export function logEvent(type, label, value = '', time = nowHM()) {
-  entries.push({ time, type, label, value });
+function parseTime(value) {
+  if (typeof value === 'number') return value;
+  const [h, m] = String(value).split(':').map(Number);
+  if (isNaN(h) || isNaN(m)) return Date.now();
+  const d = new Date();
+  d.setHours(h, m, 0, 0);
+  return d.getTime();
+}
+
+function formatTime(ts) {
+  const d = new Date(ts);
+  const p = n => String(n).padStart(2, '0');
+  return `${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
+export function logEvent(type, label, value = '', time = Date.now()) {
+  const timestamp = parseTime(time);
+  entries.push({ time: timestamp, type, label, value });
   renderTimeline();
 }
 
 export function getEntries(filter = '') {
   return entries
     .filter(e => !filter || e.type === filter)
-    .sort((a, b) => a.time.localeCompare(b.time));
+    .sort((a, b) => a.time - b.time);
 }
 
 export function renderTimeline() {
@@ -22,7 +38,8 @@ export function renderTimeline() {
   getEntries(filter).forEach(e => {
     const div = document.createElement('div');
     div.className = 'timeline-entry';
-    div.textContent = `${e.time} ${tz} – ${e.label}${e.value ? ': ' + e.value : ''}`;
+    const t = formatTime(e.time);
+    div.textContent = `${t} ${tz} – ${e.label}${e.value ? ': ' + e.value : ''}`;
     list.appendChild(div);
   });
 }
@@ -32,7 +49,7 @@ export function initTimeline() {
   $('#timelineExport')?.addEventListener('click', () => {
     const tz = timeZoneOffset();
     const csv = entries
-      .map(e => `${e.time} ${tz},${e.type},${e.label},${e.value}`)
+      .map(e => `${formatTime(e.time)} ${tz},${e.type},${e.label},${e.value}`)
       .join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- store timeline events with numeric timestamps
- sort timeline entries numerically and format time for display
- export CSV with formatted timestamps

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npx jest --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68a5962e43788320a04eb303a99119d4