### PR TITLE
Add timeline tab to navigation

### DIFF
--- a/docs/js/tabs.js
+++ b/docs/js/tabs.js
@@ -12,6 +12,7 @@ export const TABS = [
   { name: 'Laboratorija', icon: '🧪' },
   { name: 'Komanda', icon: '👥' },
   { name: 'Sprendimas', icon: '⚖️' },
+  { name: 'Laiko juosta', icon: '🕒' },
   { name: 'Ataskaita', icon: '📝' }
 ];
 

--- a/public/js/__tests__/tabs.test.js
+++ b/public/js/__tests__/tabs.test.js
@@ -29,8 +29,8 @@ describe('tabs', () => {
     expect(setSpy).toHaveBeenCalledWith('v10_activeTab', tabs.TABS[1].name);
   });
 
-  test('showTab saves active tab and initTabs restores it', () => {
-    const store = {};
+    test('showTab saves active tab and initTabs restores it', () => {
+      const store = {};
     Object.defineProperty(window, 'localStorage', {
       value: {
         setItem: jest.fn((k, v) => { store[k] = v; }),
@@ -60,6 +60,15 @@ describe('tabs', () => {
     tabs.initTabs();
     expect(window.localStorage.getItem).toHaveBeenCalledWith('v10_activeTab');
     const active = document.querySelector('nav .tab.active');
-    expect(active.dataset.tab).toBe('A – Kvėpavimo takai');
+      expect(active.dataset.tab).toBe('A – Kvėpavimo takai');
+    });
+
+    test('includes timeline tab before report', () => {
+      const tabs = require('../tabs.js');
+      const timelineIndex = tabs.TABS.findIndex(t => t.name === 'Laiko juosta');
+      const reportIndex = tabs.TABS.findIndex(t => t.name === 'Ataskaita');
+      expect(timelineIndex).toBeGreaterThan(-1);
+      expect(reportIndex).toBeGreaterThan(-1);
+      expect(timelineIndex).toBeLessThan(reportIndex);
+    });
   });
-});

--- a/public/js/tabs.js
+++ b/public/js/tabs.js
@@ -12,6 +12,7 @@ export const TABS = [
   { name: 'Laboratorija', icon: '🧪' },
   { name: 'Komanda', icon: '👥' },
   { name: 'Sprendimas', icon: '⚖️' },
+  { name: 'Laiko juosta', icon: '🕒' },
   { name: 'Ataskaita', icon: '📝' }
 ];
 


### PR DESCRIPTION
## Summary
- Insert "Laiko juosta" timeline tab before the report tab and include an icon.
- Ensure tab array exports to public build and add regression test verifying order.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5a837f2a88320a059e9df801087b4