### PR TITLE
Add copy button to report view

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -455,7 +455,7 @@
     </div>
     <div id="timelineList" class="timeline-list"></div>
   </section>
-    <section class="card view" id="view-ataskaita" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Ataskaita sugeneruojama automatiškai"></textarea><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
+    <section class="card view" id="view-ataskaita" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Ataskaita sugeneruojama automatiškai"></textarea><div class="row mb-8"><button type="button" class="btn" id="btnCopyReport">Kopijuoti</button></div><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
   </div>
 </main>
 

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -828,15 +828,18 @@ function setupHeaderActions(){
   const arrivalTimer=document.getElementById('arrivalTimer');
   if(arrivalTimer) arrivalTimer.addEventListener('dblclick',()=>startArrivalTimer(true));
 
-  const btnCopy=document.getElementById('btnCopy');
-  if(btnCopy) btnCopy.addEventListener('click',async()=>{
+  const handleCopy=async()=>{
     try{
       await navigator.clipboard.writeText($('#output').value||'');
       notify({message:'Nukopijuota.', type:'success'});
     }catch(e){
       notify({message:'Nepavyko nukopijuoti.', type:'error'});
     }
-  });
+  };
+  const btnCopy=document.getElementById('btnCopy');
+  if(btnCopy) btnCopy.addEventListener('click',handleCopy);
+  const btnCopyReport=document.getElementById('btnCopyReport');
+  if(btnCopyReport) btnCopyReport.addEventListener('click',handleCopy);
 
   const btnSave=document.getElementById('btnSave');
   if(btnSave) btnSave.addEventListener('click',()=>{ if(validateForm()){ saveAll(); notify({message:'Išsaugota naršyklėje.', type:'success'}); }});

--- a/public/index.html
+++ b/public/index.html
@@ -471,7 +471,7 @@
     </div>
     <div id="timelineList" class="timeline-list"></div>
   </section>
-    <section class="card view" id="view-ataskaita" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Ataskaita sugeneruojama automatiškai"></textarea><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
+    <section class="card view" id="view-ataskaita" data-tab="Ataskaita"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Ataskaita sugeneruojama automatiškai"></textarea><div class="row mb-8"><button type="button" class="btn" id="btnCopyReport">Kopijuoti</button></div><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
   </div>
 </main>
 

--- a/public/js/headerActions.js
+++ b/public/js/headerActions.js
@@ -11,15 +11,15 @@ export function setupHeaderActions({ validateForm, saveAll }){
   const arrivalTimer=document.getElementById('arrivalTimer');
   if(arrivalTimer) arrivalTimer.addEventListener('dblclick',()=>startArrivalTimer(true));
 
-  const btnCopy=$('#btnCopy');
-  if(btnCopy) btnCopy.addEventListener('click',async()=>{
+  const copyButtons=[$('#btnCopy'), $('#btnCopyReport')].filter(Boolean);
+  copyButtons.forEach(btn=>btn.addEventListener('click',async()=>{
     try{
       await navigator.clipboard.writeText($('#output').value||'');
       notify({message:'Nukopijuota.', type:'success'});
     }catch(e){
       notify({message:'Nepavyko nukopijuoti.', type:'error'});
     }
-  });
+  }));
 
   const btnSave=$('#btnSave');
   if(btnSave) btnSave.addEventListener('click',()=>{ if(validateForm()){ saveAll(); notify({message:'Išsaugota naršyklėje.', type:'success'}); }});


### PR DESCRIPTION
## Summary
- add a copy button to the "Ataskaita" report section
- handle copy from both header and report buttons
- update docs build

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6bdf8ab9c8320a27a5c89d3fd35ce