### PR TITLE
Remove session login prompt and rename session label

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -9,7 +9,7 @@ import './components/modal.js';
 import { initValidation, validateVitals } from './validation.js';
 import { initTopbar } from './components/topbar.js';
 import { initCollapsibles } from './sections.js';
-import { ensureLogin, connectSocket, initSessions, fetchUsers, initTheme, saveAll, loadAll } from './sessionManager.js';
+import { connectSocket, initSessions, fetchUsers, initTheme, saveAll, loadAll } from './sessionManager.js';
 import { initBodyMap } from './bodyMap.js';
 import { generateReport, gksSum } from './report.js';
 import { setupHeaderActions } from './headerActions.js';
@@ -219,8 +219,7 @@ function clampNumberInputs(){
 async function init(){
   initTheme();
   await initTopbar();
-  await ensureLogin();
-  setupHeaderActions({ validateForm, saveAll });
+    setupHeaderActions({ validateForm, saveAll });
   connectSocket();
   await fetchUsers();
   await initSessions();

--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -29,34 +29,6 @@ export function initTheme(){
   document.documentElement.classList.add('dark');
 }
 
-export async function ensureLogin(){
-  if(authToken || typeof fetch !== 'function') return;
-  for(;;){
-    try{
-      const name=await notify({type:'prompt', message:'Įveskite vardą dalyvauti bendroje sesijoje'});
-      if(!name) return;
-      const res=await fetch('/api/login',{
-        method:'POST',
-        headers:{ 'Content-Type':'application/json' },
-        body:JSON.stringify({ name })
-      });
-      if(!res.ok){
-        notify({message:'Prisijungti nepavyko: '+res.status,type:'error'});
-        if(await notify({type:'confirm',message:'Bandysite dar kartą?'})) continue;
-        return;
-      }
-      const data=await res.json();
-      authToken=data.token;
-      localStorage.setItem('trauma_token',authToken);
-      break;
-    }catch(e){
-      notify({message:'Prisijungti nepavyko: '+(e&&e.message||e),type:'error'});
-      if(await notify({type:'confirm',message:'Bandysite dar kartą?'})) continue;
-      return;
-    }
-  }
-}
-
 export function connectSocket(){
   if(typeof io === 'undefined' || socket || !authToken) return;
   socket = io({ auth: { token: 'Bearer '+authToken } });
@@ -198,7 +170,7 @@ export async function initSessions(){
   renderDeleteButtons();
 
   $('#btnNewSession').addEventListener('click',async()=>{
-    const name=await notify({type:'prompt', message:'Sesijos pavadinimas'});
+    const name=await notify({type:'prompt', message:'Paciento ID'});
     if(!name) return;
     const id=Date.now().toString(36);
     sessions.push({id,name});

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,7 +9,7 @@ import './components/modal.js';
 import { initValidation, validateVitals } from './validation.js';
 import { initTopbar } from './components/topbar.js';
 import { initCollapsibles } from './sections.js';
-import { ensureLogin, connectSocket, initSessions, fetchUsers, initTheme, saveAll, loadAll } from './sessionManager.js';
+import { connectSocket, initSessions, fetchUsers, initTheme, saveAll, loadAll } from './sessionManager.js';
 import { initBodyMap } from './bodyMap.js';
 import { generateReport, gksSum } from './report.js';
 import { setupHeaderActions } from './headerActions.js';
@@ -219,8 +219,7 @@ function clampNumberInputs(){
 async function init(){
   initTheme();
   await initTopbar();
-  await ensureLogin();
-  setupHeaderActions({ validateForm, saveAll });
+    setupHeaderActions({ validateForm, saveAll });
   connectSocket();
   await fetchUsers();
   await initSessions();

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -29,34 +29,6 @@ export function initTheme(){
   document.documentElement.classList.add('dark');
 }
 
-export async function ensureLogin(){
-  if(authToken || typeof fetch !== 'function') return;
-  for(;;){
-    try{
-      const name=await notify({type:'prompt', message:'Įveskite vardą dalyvauti bendroje sesijoje'});
-      if(!name) return;
-      const res=await fetch('/api/login',{
-        method:'POST',
-        headers:{ 'Content-Type':'application/json' },
-        body:JSON.stringify({ name })
-      });
-      if(!res.ok){
-        notify({message:'Prisijungti nepavyko: '+res.status,type:'error'});
-        if(await notify({type:'confirm',message:'Bandysite dar kartą?'})) continue;
-        return;
-      }
-      const data=await res.json();
-      authToken=data.token;
-      localStorage.setItem('trauma_token',authToken);
-      break;
-    }catch(e){
-      notify({message:'Prisijungti nepavyko: '+(e&&e.message||e),type:'error'});
-      if(await notify({type:'confirm',message:'Bandysite dar kartą?'})) continue;
-      return;
-    }
-  }
-}
-
 export function connectSocket(){
   if(typeof io === 'undefined' || socket || !authToken) return;
   socket = io({ auth: { token: 'Bearer '+authToken } });
@@ -198,7 +170,7 @@ export async function initSessions(){
   renderDeleteButtons();
 
   $('#btnNewSession').addEventListener('click',async()=>{
-    const name=await notify({type:'prompt', message:'Sesijos pavadinimas'});
+    const name=await notify({type:'prompt', message:'Paciento ID'});
     if(!name) return;
     const id=Date.now().toString(36);
     sessions.push({id,name});


### PR DESCRIPTION
## Summary
- Remove prompt for entering a name before joining a session
- Rename session creation label to "Paciento ID"

## Testing
- `npm run test:client`
- `npm run test:server`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6e65b1ab88320a8f7529cbdee7359