### PR TITLE
Remove unused getState export from body map

### DIFF
--- a/docs/js/bodyMap.js
+++ b/docs/js/bodyMap.js
@@ -143,7 +143,3 @@ export function counts(){
   cnt.burned=burnArea();
   return cnt;
 }
-
-export function getState(){
-  return { tool: activeTool };
-}

--- a/public/js/bodyMap.js
+++ b/public/js/bodyMap.js
@@ -143,7 +143,3 @@ export function counts(){
   cnt.burned=burnArea();
   return cnt;
 }
-
-export function getState(){
-  return { tool: activeTool };
-}


### PR DESCRIPTION
## Summary
- drop unused getState export from bodyMap modules in public and docs
- retain counts() for report summaries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a708d5d3a883209d1e57ab26e872c5