### PR TITLE
Enable deep links for tab views

### DIFF
--- a/docs/js/tabs.js
+++ b/docs/js/tabs.js
@@ -1,17 +1,17 @@
 export const TABS = [
-  { name: 'Aktyvacija', icon: '🚨' },
-  { name: 'A – Kvėpavimo takai' },
-  { name: 'B – Kvėpavimas' },
-  { name: 'C – Kraujotaka' },
-  { name: 'D – Sąmonė' },
-  { name: 'E – Kita' },
-  { name: 'Intervencijos', icon: '💉' },
-  { name: 'Vaizdiniai tyrimai', icon: '☢️' },
-  { name: 'Laboratorija', icon: '🧪' },
-  { name: 'Komanda', icon: '👥' },
-  { name: 'Sprendimas', icon: '⚖️' },
-  { name: 'Laiko juosta', icon: '🕒' },
-  { name: 'Ataskaita', icon: '📝' }
+  { name: 'Aktyvacija', icon: '🚨', path: '/' },
+  { name: 'A – Kvėpavimo takai', path: '/airway' },
+  { name: 'B – Kvėpavimas', path: '/breathing' },
+  { name: 'C – Kraujotaka', path: '/circulation' },
+  { name: 'D – Sąmonė', path: '/consciousness' },
+  { name: 'E – Kita', path: '/other' },
+  { name: 'Intervencijos', icon: '💉', path: '/interventions' },
+  { name: 'Vaizdiniai tyrimai', icon: '☢️', path: '/imaging' },
+  { name: 'Laboratorija', icon: '🧪', path: '/labs' },
+  { name: 'Komanda', icon: '👥', path: '/team' },
+  { name: 'Sprendimas', icon: '⚖️', path: '/decision' },
+  { name: 'Laiko juosta', icon: '🕒', path: '/timeline' },
+  { name: 'Ataskaita', icon: '📝', path: '/report' }
 ];
 
 export const TAB_NAMES = TABS.map(t => t.name);
@@ -24,6 +24,10 @@ export function showTab(name){
   });
   document.querySelectorAll('.view').forEach(v=>v.style.display = (v.dataset.tab===name)?'block':'none');
   localStorage.setItem('v10_activeTab', name);
+  const tab=TABS.find(t=>t.name===name);
+  if(tab&&tab.path){
+    history.replaceState(null,'',tab.path);
+  }
   document.dispatchEvent(new CustomEvent('tabShown',{detail:name}));
 }
 
@@ -69,6 +73,9 @@ export function initTabs(){
     }
   });
 
+  const pathSeg=window.location.pathname.split('/').filter(Boolean).pop()||'';
+  const pathTab=TABS.find(t=>t.path.replace(/^\//,'')===pathSeg);
   const savedTab = localStorage.getItem('v10_activeTab');
-  if(savedTab && TAB_NAMES.includes(savedTab)) showTab(savedTab);
+  if(pathTab) showTab(pathTab.name);
+  else if(savedTab && TAB_NAMES.includes(savedTab)) showTab(savedTab);
 }

--- a/public/js/__tests__/tabs.test.js
+++ b/public/js/__tests__/tabs.test.js
@@ -2,6 +2,7 @@ describe('tabs', () => {
   beforeEach(() => {
     jest.resetModules();
     document.body.innerHTML = '';
+    window.history.pushState({}, '', '/');
   });
 
   test('moves focus with arrow keys and activates tab on Enter', () => {
@@ -29,8 +30,8 @@ describe('tabs', () => {
     expect(setSpy).toHaveBeenCalledWith('v10_activeTab', tabs.TABS[1].name);
   });
 
-    test('showTab saves active tab and initTabs restores it', () => {
-      const store = {};
+  test('showTab saves active tab and initTabs restores it', () => {
+    const store = {};
     Object.defineProperty(window, 'localStorage', {
       value: {
         setItem: jest.fn((k, v) => { store[k] = v; }),
@@ -60,15 +61,28 @@ describe('tabs', () => {
     tabs.initTabs();
     expect(window.localStorage.getItem).toHaveBeenCalledWith('v10_activeTab');
     const active = document.querySelector('nav .tab.active');
-      expect(active.dataset.tab).toBe('A – Kvėpavimo takai');
-    });
-
-    test('includes timeline tab before report', () => {
-      const tabs = require('../tabs.js');
-      const timelineIndex = tabs.TABS.findIndex(t => t.name === 'Laiko juosta');
-      const reportIndex = tabs.TABS.findIndex(t => t.name === 'Ataskaita');
-      expect(timelineIndex).toBeGreaterThan(-1);
-      expect(reportIndex).toBeGreaterThan(-1);
-      expect(timelineIndex).toBeLessThan(reportIndex);
-    });
+    expect(active.dataset.tab).toBe('A – Kvėpavimo takai');
   });
+
+  test('activates tab based on path', () => {
+    document.body.innerHTML = `
+      <nav id="tabs"></nav>
+      <div class="view" data-tab="Aktyvacija"></div>
+      <div class="view" data-tab="B – Kvėpavimas"></div>
+    `;
+    window.history.pushState({}, '', '/breathing');
+    const tabs = require('../tabs.js');
+    tabs.initTabs();
+    const active = document.querySelector('nav .tab.active');
+    expect(active.dataset.tab).toBe('B – Kvėpavimas');
+  });
+
+  test('includes timeline tab before report', () => {
+    const tabs = require('../tabs.js');
+    const timelineIndex = tabs.TABS.findIndex(t => t.name === 'Laiko juosta');
+    const reportIndex = tabs.TABS.findIndex(t => t.name === 'Ataskaita');
+    expect(timelineIndex).toBeGreaterThan(-1);
+    expect(reportIndex).toBeGreaterThan(-1);
+    expect(timelineIndex).toBeLessThan(reportIndex);
+  });
+});

--- a/public/js/tabs.js
+++ b/public/js/tabs.js
@@ -1,17 +1,17 @@
 export const TABS = [
-  { name: 'Aktyvacija', icon: '🚨' },
-  { name: 'A – Kvėpavimo takai' },
-  { name: 'B – Kvėpavimas' },
-  { name: 'C – Kraujotaka' },
-  { name: 'D – Sąmonė' },
-  { name: 'E – Kita' },
-  { name: 'Intervencijos', icon: '💉' },
-  { name: 'Vaizdiniai tyrimai', icon: '☢️' },
-  { name: 'Laboratorija', icon: '🧪' },
-  { name: 'Komanda', icon: '👥' },
-  { name: 'Sprendimas', icon: '⚖️' },
-  { name: 'Laiko juosta', icon: '🕒' },
-  { name: 'Ataskaita', icon: '📝' }
+  { name: 'Aktyvacija', icon: '🚨', path: '/' },
+  { name: 'A – Kvėpavimo takai', path: '/airway' },
+  { name: 'B – Kvėpavimas', path: '/breathing' },
+  { name: 'C – Kraujotaka', path: '/circulation' },
+  { name: 'D – Sąmonė', path: '/consciousness' },
+  { name: 'E – Kita', path: '/other' },
+  { name: 'Intervencijos', icon: '💉', path: '/interventions' },
+  { name: 'Vaizdiniai tyrimai', icon: '☢️', path: '/imaging' },
+  { name: 'Laboratorija', icon: '🧪', path: '/labs' },
+  { name: 'Komanda', icon: '👥', path: '/team' },
+  { name: 'Sprendimas', icon: '⚖️', path: '/decision' },
+  { name: 'Laiko juosta', icon: '🕒', path: '/timeline' },
+  { name: 'Ataskaita', icon: '📝', path: '/report' }
 ];
 
 export const TAB_NAMES = TABS.map(t => t.name);
@@ -24,6 +24,10 @@ export function showTab(name){
   });
   document.querySelectorAll('.view').forEach(v=>v.style.display = (v.dataset.tab===name)?'block':'none');
   localStorage.setItem('v10_activeTab', name);
+  const tab=TABS.find(t=>t.name===name);
+  if(tab&&tab.path){
+    history.replaceState(null,'',tab.path);
+  }
   document.dispatchEvent(new CustomEvent('tabShown',{detail:name}));
 }
 
@@ -69,6 +73,9 @@ export function initTabs(){
     }
   });
 
+  const pathSeg=window.location.pathname.split('/').filter(Boolean).pop()||'';
+  const pathTab=TABS.find(t=>t.path.replace(/^\//,'')===pathSeg);
   const savedTab = localStorage.getItem('v10_activeTab');
-  if(savedTab && TAB_NAMES.includes(savedTab)) showTab(savedTab);
+  if(pathTab) showTab(pathTab.name);
+  else if(savedTab && TAB_NAMES.includes(savedTab)) showTab(savedTab);
 }

--- a/server/index.js
+++ b/server/index.js
@@ -160,6 +160,12 @@ app.put('/api/sessions/:id/data', auth, async (req, res) => {
   res.json({ ok: true });
 });
 
+// Serve the app for all non-API routes so deep links like /breathing work
+app.get('*', (req, res) => {
+  if (req.path.startsWith('/api')) return res.status(404).json({ error: 'Not found' });
+  res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
+});
+
 const server = http.createServer(app);
 const io = new Server(server, { cors: { origin: '*' } });
 


### PR DESCRIPTION
## Summary
- serve index for non-API routes so links like `/breathing` work
- map URL paths to tabs and update history for navigation
- test tab activation based on path

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a70a0894a483209de0c8d557b325e0