### PR TITLE
Fix activation fields collapsing

### DIFF
--- a/public/js/sections.js
+++ b/public/js/sections.js
@@ -1,38 +1,40 @@
 import { $$ } from './utils.js';
 
 export function initCollapsibles(){
-  $$( 'fieldset.collapsible').forEach((fs, i) => {
-    const legend = fs.querySelector('legend');
-    if(!legend) return;
-    const content = document.createElement('div');
-    content.className = 'fieldset-content';
-    while(legend.nextSibling){
-      content.appendChild(legend.nextSibling);
-    }
-    fs.appendChild(content);
-    legend.style.cursor = 'pointer';
-    legend.setAttribute('role','button');
-    legend.setAttribute('tabindex','0');
-    const collapsed = i > 0;
-    if(collapsed){
-      fs.classList.add('collapsed');
-      content.style.display = 'none';
-      legend.setAttribute('aria-expanded','false');
-    } else {
-      legend.setAttribute('aria-expanded','true');
-    }
-    const toggle = () => {
-      fs.classList.toggle('collapsed');
-      const isCollapsed = fs.classList.contains('collapsed');
-      content.style.display = isCollapsed ? 'none' : '';
-      legend.setAttribute('aria-expanded', (!isCollapsed).toString());
-    };
-    legend.addEventListener('click', toggle);
-    legend.addEventListener('keydown', e => {
-      if(e.key === 'Enter' || e.key === ' '){
-        e.preventDefault();
-        toggle();
+  $$('.view').forEach(view => {
+    $$('fieldset.collapsible', view).forEach((fs, i) => {
+      const legend = fs.querySelector('legend');
+      if(!legend) return;
+      const content = document.createElement('div');
+      content.className = 'fieldset-content';
+      while(legend.nextSibling){
+        content.appendChild(legend.nextSibling);
       }
+      fs.appendChild(content);
+      legend.style.cursor = 'pointer';
+      legend.setAttribute('role','button');
+      legend.setAttribute('tabindex','0');
+      const collapsed = i > 0 && view.id !== 'view-aktivacija';
+      if(collapsed){
+        fs.classList.add('collapsed');
+        content.style.display = 'none';
+        legend.setAttribute('aria-expanded','false');
+      } else {
+        legend.setAttribute('aria-expanded','true');
+      }
+      const toggle = () => {
+        fs.classList.toggle('collapsed');
+        const isCollapsed = fs.classList.contains('collapsed');
+        content.style.display = isCollapsed ? 'none' : '';
+        legend.setAttribute('aria-expanded', (!isCollapsed).toString());
+      };
+      legend.addEventListener('click', toggle);
+      legend.addEventListener('keydown', e => {
+        if(e.key === 'Enter' || e.key === ' '){
+          e.preventDefault();
+          toggle();
+        }
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- prevent collapse of trauma activation inputs
- collapse other sections per view

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a70d4665348320a0ebfa492e84c9cb