### PR TITLE
Ensure aktivacija view collapsibles start expanded

### DIFF
--- a/docs/js/sections.js
+++ b/docs/js/sections.js
@@ -1,38 +1,40 @@
 import { $$ } from './utils.js';
 
 export function initCollapsibles(){
-  $$( 'fieldset.collapsible').forEach((fs, i) => {
-    const legend = fs.querySelector('legend');
-    if(!legend) return;
-    const content = document.createElement('div');
-    content.className = 'fieldset-content';
-    while(legend.nextSibling){
-      content.appendChild(legend.nextSibling);
-    }
-    fs.appendChild(content);
-    legend.style.cursor = 'pointer';
-    legend.setAttribute('role','button');
-    legend.setAttribute('tabindex','0');
-    const collapsed = i > 0;
-    if(collapsed){
-      fs.classList.add('collapsed');
-      content.style.display = 'none';
-      legend.setAttribute('aria-expanded','false');
-    } else {
-      legend.setAttribute('aria-expanded','true');
-    }
-    const toggle = () => {
-      fs.classList.toggle('collapsed');
-      const isCollapsed = fs.classList.contains('collapsed');
-      content.style.display = isCollapsed ? 'none' : '';
-      legend.setAttribute('aria-expanded', (!isCollapsed).toString());
-    };
-    legend.addEventListener('click', toggle);
-    legend.addEventListener('keydown', e => {
-      if(e.key === 'Enter' || e.key === ' '){
-        e.preventDefault();
-        toggle();
+  $$('.view').forEach(view => {
+    $$('fieldset.collapsible', view).forEach((fs, i) => {
+      const legend = fs.querySelector('legend');
+      if(!legend) return;
+      const content = document.createElement('div');
+      content.className = 'fieldset-content';
+      while(legend.nextSibling){
+        content.appendChild(legend.nextSibling);
       }
+      fs.appendChild(content);
+      legend.style.cursor = 'pointer';
+      legend.setAttribute('role','button');
+      legend.setAttribute('tabindex','0');
+      const collapsed = view.id !== 'view-aktivacija' && i > 0;
+      if(collapsed){
+        fs.classList.add('collapsed');
+        content.style.display = 'none';
+        legend.setAttribute('aria-expanded','false');
+      } else {
+        legend.setAttribute('aria-expanded','true');
+      }
+      const toggle = () => {
+        fs.classList.toggle('collapsed');
+        const isCollapsed = fs.classList.contains('collapsed');
+        content.style.display = isCollapsed ? 'none' : '';
+        legend.setAttribute('aria-expanded', (!isCollapsed).toString());
+      };
+      legend.addEventListener('click', toggle);
+      legend.addEventListener('keydown', e => {
+        if(e.key === 'Enter' || e.key === ' '){
+          e.preventDefault();
+          toggle();
+        }
+      });
     });
   });
 }

--- a/public/js/sections.js
+++ b/public/js/sections.js
@@ -14,7 +14,7 @@ export function initCollapsibles(){
       legend.style.cursor = 'pointer';
       legend.setAttribute('role','button');
       legend.setAttribute('tabindex','0');
-      const collapsed = i > 0 && view.id !== 'view-aktivacija';
+      const collapsed = view.id !== 'view-aktivacija' && i > 0;
       if(collapsed){
         fs.classList.add('collapsed');
         content.style.display = 'none';


### PR DESCRIPTION
## Summary
- Prevent collapsing of fieldsets within the `view-aktivacija` tab so they are always expanded on load
- Rebuild published docs to include updated behavior

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7130b498083208b10a8d428f2b5c4