### PR TITLE
Add selectable body map marks

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -272,6 +272,7 @@
         <button type="button" class="tool" data-tool="N">Nudegimas</button>
         <span class="flex-1"></span>
         <button type="button" class="tool" id="btnUndo">↩ Anuliuoti</button>
+        <button type="button" class="tool" id="btnDelete">✖ Pašalinti</button>
         <button type="button" class="tool" id="btnClearMap">🧹 Išvalyti</button>
         <button type="button" class="tool" id="btnExportSvg">⬇ Eksportuoti SVG</button>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -272,6 +272,7 @@
         <button type="button" class="tool" data-tool="N">Nudegimas</button>
         <span class="flex-1"></span>
         <button type="button" class="tool" id="btnUndo">↩ Anuliuoti</button>
+        <button type="button" class="tool" id="btnDelete">✖ Pašalinti</button>
         <button type="button" class="tool" id="btnClearMap">🧹 Išvalyti</button>
         <button type="button" class="tool" id="btnExportSvg">⬇ Eksportuoti SVG</button>
       </div>

--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -18,6 +18,49 @@ describe('body map serialization', () => {
   });
 });
 
+test('selects and deletes marks', () => {
+  document.body.innerHTML = `
+    <svg id="bodySvg"><g id="layer-front"></g><g id="layer-back"></g><g id="marks"></g></svg>
+    <button id="btnUndo"></button>
+    <button id="btnClearMap"></button>
+    <button id="btnExportSvg"></button>
+    <button id="btnDelete"></button>
+    <div class="map-toolbar"><button class="tool" data-tool="Ž"></button></div>
+  `;
+  const show = jest.fn();
+  window.showWoundDetails = show;
+  initBodyMap(()=>{});
+  load({tool:'Ž', marks:[{id:1,x:1,y:2,type:'Ž',side:'front'},{id:2,x:3,y:4,type:'S',side:'front'}]});
+  const marksGroup=document.getElementById('marks');
+  const [m1] = marksGroup.querySelectorAll('use');
+  m1.dispatchEvent(new Event('click',{bubbles:true}));
+  expect(m1.classList.contains('selected')).toBe(true);
+  expect(show).toHaveBeenCalledWith('1');
+  document.getElementById('btnDelete').click();
+  expect(marksGroup.querySelectorAll('use').length).toBe(1);
+});
+
+test('undo removes selected mark first', () => {
+  document.body.innerHTML = `
+    <svg id="bodySvg"><g id="layer-front"></g><g id="layer-back"></g><g id="marks"></g></svg>
+    <button id="btnUndo"></button>
+    <button id="btnClearMap"></button>
+    <button id="btnExportSvg"></button>
+    <button id="btnDelete"></button>
+    <div class="map-toolbar"><button class="tool" data-tool="Ž"></button></div>
+  `;
+  initBodyMap(()=>{});
+  load({tool:'Ž', marks:[{id:1,x:0,y:0,type:'Ž',side:'front'},{id:2,x:1,y:1,type:'Ž',side:'front'}]});
+  const marksGroup=document.getElementById('marks');
+  const [m1] = marksGroup.querySelectorAll('use');
+  m1.dispatchEvent(new Event('click',{bubbles:true}));
+  document.getElementById('btnUndo').click();
+  expect(marksGroup.querySelectorAll('use').length).toBe(1);
+  expect(marksGroup.querySelector('use').dataset.id).toBe('2');
+  document.getElementById('btnUndo').click();
+  expect(marksGroup.querySelectorAll('use').length).toBe(0);
+});
+
 test('restores burn zones and counts area', () => {
   document.body.innerHTML = `
     <svg id="bodySvg">


### PR DESCRIPTION
## Summary
- Give body map marks unique IDs and allow selecting a mark to view its details
- Add delete button and undo logic for removing selected marks
- Persist mark IDs through serialization

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a729b04d98832097294dbb840f207f