### PR TITLE
Enable explicit open fieldsets and expose breathing breath by default

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -128,7 +128,7 @@
             <div><label for="b_spo2">SpO₂ (%)</label><input id="b_spo2" type="number" min="0" max="100"></div>
           </div>
         </fieldset>
-        <fieldset class="collapsible" id="breathing-breath">
+        <fieldset class="collapsible" id="breathing-breath" data-open="true">
           <legend>Alsavimas</legend>
           <div class="row">
             <div>

--- a/public/js/sections.js
+++ b/public/js/sections.js
@@ -14,7 +14,7 @@ export function initCollapsibles(){
       legend.style.cursor = 'pointer';
       legend.setAttribute('role','button');
       legend.setAttribute('tabindex','0');
-      const collapsed = view.id !== 'view-aktivacija' && i > 0;
+      const collapsed = fs.dataset.open !== 'true' && view.id !== 'view-aktivacija' && i > 0;
       if(collapsed){
         fs.classList.add('collapsed');
         content.style.display = 'none';


### PR DESCRIPTION
## Summary
- Allow collapsible fieldsets to start expanded when marked with `data-open="true"`
- Mark breathing breath fieldset as open by default so it's visible on load

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a72b9bfa788320b3192526f6f282aa