### PR TITLE
fix: validate burn area values

### DIFF
--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -72,6 +72,7 @@ test('restores burn zones and counts area', () => {
       <g id="layer-back"></g>
       <g id="marks"></g>
     </svg>
+    <div id="burnTotal"></div>
     <div class="map-toolbar"><button class="tool" data-tool="Ž"></button></div>
     <button id="btnUndo"></button>
     <button id="btnClearMap"></button>
@@ -80,6 +81,30 @@ test('restores burn zones and counts area', () => {
   initBodyMap(()=>{});
   load({tool:'N', marks:[], burns:[{zone:'head-front', side:'front'}]});
   expect(counts().burned).toBe(4.5);
+  expect(document.getElementById('burnTotal').textContent).toBe('Nudegimai: 4.5%');
   const s=JSON.parse(serialize());
   expect(s.burns[0].zone).toBe('head-front');
+});
+
+test('ignores invalid burn areas when displaying total', () => {
+  document.body.innerHTML = `
+    <svg id="bodySvg">
+      <g id="layer-front">
+        <g id="zones-front">
+          <polygon class="zone" data-zone="head-front" data-area="abc"></polygon>
+        </g>
+      </g>
+      <g id="layer-back"></g>
+      <g id="marks"></g>
+    </svg>
+    <div id="burnTotal"></div>
+    <div class="map-toolbar"><button class="tool" data-tool="Ž"></button></div>
+    <button id="btnUndo"></button>
+    <button id="btnClearMap"></button>
+    <button id="btnExportSvg"></button>
+  `;
+  initBodyMap(()=>{});
+  load({tool:'N', marks:[], burns:[{zone:'head-front', side:'front'}]});
+  expect(counts().burned).toBe(0);
+  expect(document.getElementById('burnTotal').textContent).toBe('');
 });

--- a/public/js/bodyMap.js
+++ b/public/js/bodyMap.js
@@ -65,7 +65,11 @@ function addMark(x, y, t, s, zone, id){
 
 function burnArea(){
   let s=0;
-  burns.forEach(z=>{ const el=zoneMap.get(z); s+= el? +el.dataset.area : 0; });
+  burns.forEach(z=>{
+    const el = zoneMap.get(z);
+    const area = el ? parseFloat(el.dataset.area) : 0;
+    s += isNaN(area) ? 0 : area;
+  });
   return s;
 }
 


### PR DESCRIPTION
## Summary
- avoid NaN when calculating burn area by validating dataset.area
- ensure burn area display ignores invalid values
- add tests for burn area display and invalid data handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a734cfc4448320a277359ced03d7bb