### PR TITLE
Clear burn state when clearing body map

### DIFF
--- a/docs/js/bodyMap.js
+++ b/docs/js/bodyMap.js
@@ -123,6 +123,9 @@ export function initBodyMap(saveAll){
   btnClear?.addEventListener('click', async ()=>{
     if(await notify({type:'confirm', message:'Išvalyti visas žymas (priekis ir nugara)?'})){
       marks.innerHTML='';
+      burns.clear();
+      $$('.zone').forEach(z=>z.classList.remove('burned'));
+      updateBurnDisplay();
       saveCb();
     }
   });

--- a/public/js/bodyMap.js
+++ b/public/js/bodyMap.js
@@ -159,6 +159,9 @@ export function initBodyMap(saveAll){
   btnClear?.addEventListener('click', async ()=>{
     if(await notify({type:'confirm', message:'Išvalyti visas žymas (priekis ir nugara)?'})){
       marks.innerHTML='';
+      burns.clear();
+      $$('.zone').forEach(z=>z.classList.remove('burned'));
+      updateBurnDisplay();
       selectedList && (selectedList.innerHTML='');
       saveCb();
     }


### PR DESCRIPTION
## Summary
- Reset burn tracking when clearing the body map
- Remove burn highlights and refresh burn percentage display

## Testing
- `npm run lint`
- `npm run test:client`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68a745f483c88320869b88f91f79d416