### PR TITLE
Remove duplicate session rename button

### DIFF
--- a/docs/assets/partials/topbar.html
+++ b/docs/assets/partials/topbar.html
@@ -18,7 +18,6 @@
     <div class="toolbar" id="sessionBar">
       <select id="sessionSelect" class="w-auto"></select>
         <button type="button" class="btn" id="btnNewSession"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Naujas</button>
-        <button type="button" class="btn" id="btnRenameSession"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>Pervadinti</button>
     </div>
   </div>
   <div class="header-actions">

--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -183,17 +183,6 @@ export async function initSessions(){
     localStorage.setItem('v10_activeTab','Aktyvacija');
     location.reload();
   });
-  $('#btnRenameSession').addEventListener('click',async()=>{
-    const sess=sessions.find(s=>s.id===select.value);
-    if(!sess) return;
-    const name=await notify({type:'prompt', message:'Naujas pavadinimas', defaultValue:sess.name});
-    if(!name) return;
-    sess.name=name;
-    saveSessions(sessions);
-    populateSessionSelect(select, sessions);
-    select.value=currentSessionId;
-    renderDeleteButtons();
-  });
   select.addEventListener('change',()=>{
     const id=select.value;
     saveAll();

--- a/public/assets/partials/topbar.html
+++ b/public/assets/partials/topbar.html
@@ -18,7 +18,6 @@
     <div class="toolbar" id="sessionBar">
       <select id="sessionSelect" class="w-auto"></select>
         <button type="button" class="btn" id="btnNewSession"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Naujas</button>
-        <button type="button" class="btn" id="btnRenameSession"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>Pervadinti</button>
     </div>
   </div>
   <div class="header-actions">

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -183,17 +183,6 @@ export async function initSessions(){
     localStorage.setItem('v10_activeTab','Aktyvacija');
     location.reload();
   });
-  $('#btnRenameSession').addEventListener('click',async()=>{
-    const sess=sessions.find(s=>s.id===select.value);
-    if(!sess) return;
-    const name=await notify({type:'prompt', message:'Naujas pavadinimas', defaultValue:sess.name});
-    if(!name) return;
-    sess.name=name;
-    saveSessions(sessions);
-    populateSessionSelect(select, sessions);
-    select.value=currentSessionId;
-    renderDeleteButtons();
-  });
   select.addEventListener('change',()=>{
     const id=select.value;
     saveAll();


### PR DESCRIPTION
## Summary
- drop redundant "Pervadinti" button from session toolbar
- clean up obsolete rename handler in session manager

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a760362f0c8320a3d5f39af0db07e1