### PR TITLE
Improve body map realism

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -278,6 +278,7 @@
       </div>
 
       <!-- SVG BODY MAP -->
+      <div id="selectedLocations"></div>
       <svg id="bodySvg" viewBox="0 0 800 900" xmlns="http://www.w3.org/2000/svg">
         <!-- Marker symbols -->
         <defs>
@@ -303,12 +304,12 @@
           </g>
           <g id="zones-front" class="zones" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)">
             <polygon class="zone" data-zone="head-front" data-area="4.5" points="24,0 26,0.5 27,1 28,2.5 29,4 29,12 28,13 27,13.5 24,14 21,13.5 20,13 19,12 19,4 20,2.5 21,1 22,0.5"/>
-            <polygon class="zone" data-zone="chest-front" data-area="9" points="20,14 24,14 28,14 30,14.5 32,16 33,18 34,20 34,26 24,26 14,26 14,20 15,18 16,16 18,14.5"/>
-            <polygon class="zone" data-zone="abdomen-front" data-area="9" points="16,26 24,26 32,26 33,29 34,32 33,35 32,38 24,38 16,38 15,35 14,32 15,29"/>
-            <polygon class="zone" data-zone="arm-left-front" data-area="4.5" points="5,14 9,14 14,14 14,38 12,38 9,38 8,35 7,32 7,26 6,23 5,20 5,17"/>
-            <polygon class="zone" data-zone="arm-right-front" data-area="4.5" points="43,14 39,14 34,14 34,38 36,38 39,38 40,35 41,32 41,26 42,23 43,20 43,17"/>
-            <polygon class="zone" data-zone="leg-left-front" data-area="9" points="18,38 22,38 26,38 26,48 24,48 22,48 21,46 20,44 20,42 19,40 18,42"/>
-            <polygon class="zone" data-zone="leg-right-front" data-area="9" points="30,38 26,38 22,38 22,48 24,48 26,48 27,46 28,44 28,42 29,40 30,42"/>
+            <polygon class="zone" data-zone="chest-front" data-area="9" points="20,14 24,14 28,14 30,14.5 32,16 33,18 34,20 34,23 34,26 24,26 14,26 14,23 14,20 15,18 16,16 18,14.5"/>
+            <polygon class="zone" data-zone="abdomen-front" data-area="9" points="16,26 24,26 32,26 33,28 34,30 34,32 34,34 33,36 32,38 24,38 16,38 15,36 14,34 14,32 14,30 15,28"/>
+            <polygon class="zone" data-zone="arm-left-front" data-area="4.5" points="14,14 9,14 4,14 3,16 3,20 4,24 5,28 6,32 7,35 8,37 9,38 11,38 14,38"/>
+            <polygon class="zone" data-zone="arm-right-front" data-area="4.5" points="34,14 39,14 44,14 45,16 45,20 44,24 43,28 42,32 41,35 40,37 39,38 37,38 34,38"/>
+            <polygon class="zone" data-zone="leg-left-front" data-area="9" points="26,38 26,48 25,48 23,48 21,48 19,48 18,46 17.5,44 17,42 17,40 18,38 22,38"/>
+            <polygon class="zone" data-zone="leg-right-front" data-area="9" points="22,38 22,48 23,48 25,48 27,48 29,48 30,46 30.5,44 31,42 31,40 30,38 26,38"/>
             <polygon class="zone" data-zone="perineum-front" data-area="1" points="23,38 26,38 29,38 28,39 28,40 26,41 24,41 24,40 23,39"/>
           </g>
         </g>
@@ -323,12 +324,12 @@
           </g>
           <g id="zones-back" class="zones" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)">
             <polygon class="zone" data-zone="head-back" data-area="4.5" points="24,0 26,0.5 27,1 28,2.5 29,4 29,12 28,13 27,13.5 24,14 21,13.5 20,13 19,12 19,4 20,2.5 21,1 22,0.5"/>
-            <polygon class="zone" data-zone="upper-back" data-area="9" points="20,14 24,14 28,14 31,16 32,18 33,21 34,24 34,26 24,26 14,26 14,24 15,21 16,18 19,16"/>
-            <polygon class="zone" data-zone="lower-back" data-area="9" points="16,26 24,26 32,26 33,29 34,32 33,35 32,38 24,38 16,38 15,35 14,32 15,29"/>
-            <polygon class="zone" data-zone="arm-left-back" data-area="4.5" points="5,14 9,14 14,14 14,38 12,38 9,38 8,35 7,32 7,26 6,23 5,20 5,17"/>
-            <polygon class="zone" data-zone="arm-right-back" data-area="4.5" points="43,14 39,14 34,14 34,38 36,38 39,38 40,35 41,32 41,26 42,23 43,20 43,17"/>
-            <polygon class="zone" data-zone="leg-left-back" data-area="9" points="18,38 22,38 26,38 26,48 24,48 22,48 21,46 20,44 20,42 19,40 18,42"/>
-            <polygon class="zone" data-zone="leg-right-back" data-area="9" points="30,38 26,38 22,38 22,48 24,48 26,48 27,46 28,44 28,42 29,40 30,42"/>
+            <polygon class="zone" data-zone="upper-back" data-area="9" points="20,14 24,14 28,14 31,16 32,18 33,21 34,23 34,26 24,26 14,26 14,23 14,21 15,18 16,16 19,14"/>
+            <polygon class="zone" data-zone="lower-back" data-area="9" points="16,26 24,26 32,26 33,28 34,30 34,32 34,34 33,36 32,38 24,38 16,38 15,36 14,34 14,32 14,30 15,28"/>
+            <polygon class="zone" data-zone="arm-left-back" data-area="4.5" points="14,14 9,14 4,14 3,16 3,20 4,24 5,28 6,32 7,35 8,37 9,38 11,38 14,38"/>
+            <polygon class="zone" data-zone="arm-right-back" data-area="4.5" points="34,14 39,14 44,14 45,16 45,20 44,24 43,28 42,32 41,35 40,37 39,38 37,38 34,38"/>
+            <polygon class="zone" data-zone="leg-left-back" data-area="9" points="26,38 26,48 25,48 23,48 21,48 19,48 18,46 17.5,44 17,42 17,40 18,38 22,38"/>
+            <polygon class="zone" data-zone="leg-right-back" data-area="9" points="22,38 22,48 23,48 25,48 27,48 29,48 30,46 30.5,44 31,42 31,40 30,38 26,38"/>
           </g>
         </g>
 

--- a/public/index.html
+++ b/public/index.html
@@ -304,12 +304,12 @@
           </g>
           <g id="zones-front" class="zones" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)">
             <polygon class="zone" data-zone="head-front" data-area="4.5" points="24,0 26,0.5 27,1 28,2.5 29,4 29,12 28,13 27,13.5 24,14 21,13.5 20,13 19,12 19,4 20,2.5 21,1 22,0.5"/>
-            <polygon class="zone" data-zone="chest-front" data-area="9" points="20,14 24,14 28,14 30,14.5 32,16 33,18 34,20 34,26 24,26 14,26 14,20 15,18 16,16 18,14.5"/>
-            <polygon class="zone" data-zone="abdomen-front" data-area="9" points="16,26 24,26 32,26 33,29 34,32 33,35 32,38 24,38 16,38 15,35 14,32 15,29"/>
-            <polygon class="zone" data-zone="arm-left-front" data-area="4.5" points="5,14 9,14 14,14 14,38 12,38 9,38 8,35 7,32 7,26 6,23 5,20 5,17"/>
-            <polygon class="zone" data-zone="arm-right-front" data-area="4.5" points="43,14 39,14 34,14 34,38 36,38 39,38 40,35 41,32 41,26 42,23 43,20 43,17"/>
-            <polygon class="zone" data-zone="leg-left-front" data-area="9" points="18,38 22,38 26,38 26,48 24,48 22,48 21,46 20,44 20,42 19,40 18,42"/>
-            <polygon class="zone" data-zone="leg-right-front" data-area="9" points="30,38 26,38 22,38 22,48 24,48 26,48 27,46 28,44 28,42 29,40 30,42"/>
+            <polygon class="zone" data-zone="chest-front" data-area="9" points="20,14 24,14 28,14 30,14.5 32,16 33,18 34,20 34,23 34,26 24,26 14,26 14,23 14,20 15,18 16,16 18,14.5"/>
+            <polygon class="zone" data-zone="abdomen-front" data-area="9" points="16,26 24,26 32,26 33,28 34,30 34,32 34,34 33,36 32,38 24,38 16,38 15,36 14,34 14,32 14,30 15,28"/>
+            <polygon class="zone" data-zone="arm-left-front" data-area="4.5" points="14,14 9,14 4,14 3,16 3,20 4,24 5,28 6,32 7,35 8,37 9,38 11,38 14,38"/>
+            <polygon class="zone" data-zone="arm-right-front" data-area="4.5" points="34,14 39,14 44,14 45,16 45,20 44,24 43,28 42,32 41,35 40,37 39,38 37,38 34,38"/>
+            <polygon class="zone" data-zone="leg-left-front" data-area="9" points="26,38 26,48 25,48 23,48 21,48 19,48 18,46 17.5,44 17,42 17,40 18,38 22,38"/>
+            <polygon class="zone" data-zone="leg-right-front" data-area="9" points="22,38 22,48 23,48 25,48 27,48 29,48 30,46 30.5,44 31,42 31,40 30,38 26,38"/>
             <polygon class="zone" data-zone="perineum-front" data-area="1" points="23,38 26,38 29,38 28,39 28,40 26,41 24,41 24,40 23,39"/>
           </g>
         </g>
@@ -324,12 +324,12 @@
           </g>
           <g id="zones-back" class="zones" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)">
             <polygon class="zone" data-zone="head-back" data-area="4.5" points="24,0 26,0.5 27,1 28,2.5 29,4 29,12 28,13 27,13.5 24,14 21,13.5 20,13 19,12 19,4 20,2.5 21,1 22,0.5"/>
-            <polygon class="zone" data-zone="upper-back" data-area="9" points="20,14 24,14 28,14 31,16 32,18 33,21 34,24 34,26 24,26 14,26 14,24 15,21 16,18 19,16"/>
-            <polygon class="zone" data-zone="lower-back" data-area="9" points="16,26 24,26 32,26 33,29 34,32 33,35 32,38 24,38 16,38 15,35 14,32 15,29"/>
-            <polygon class="zone" data-zone="arm-left-back" data-area="4.5" points="5,14 9,14 14,14 14,38 12,38 9,38 8,35 7,32 7,26 6,23 5,20 5,17"/>
-            <polygon class="zone" data-zone="arm-right-back" data-area="4.5" points="43,14 39,14 34,14 34,38 36,38 39,38 40,35 41,32 41,26 42,23 43,20 43,17"/>
-            <polygon class="zone" data-zone="leg-left-back" data-area="9" points="18,38 22,38 26,38 26,48 24,48 22,48 21,46 20,44 20,42 19,40 18,42"/>
-            <polygon class="zone" data-zone="leg-right-back" data-area="9" points="30,38 26,38 22,38 22,48 24,48 26,48 27,46 28,44 28,42 29,40 30,42"/>
+            <polygon class="zone" data-zone="upper-back" data-area="9" points="20,14 24,14 28,14 31,16 32,18 33,21 34,23 34,26 24,26 14,26 14,23 14,21 15,18 16,16 19,14"/>
+            <polygon class="zone" data-zone="lower-back" data-area="9" points="16,26 24,26 32,26 33,28 34,30 34,32 34,34 33,36 32,38 24,38 16,38 15,36 14,34 14,32 14,30 15,28"/>
+            <polygon class="zone" data-zone="arm-left-back" data-area="4.5" points="14,14 9,14 4,14 3,16 3,20 4,24 5,28 6,32 7,35 8,37 9,38 11,38 14,38"/>
+            <polygon class="zone" data-zone="arm-right-back" data-area="4.5" points="34,14 39,14 44,14 45,16 45,20 44,24 43,28 42,32 41,35 40,37 39,38 37,38 34,38"/>
+            <polygon class="zone" data-zone="leg-left-back" data-area="9" points="26,38 26,48 25,48 23,48 21,48 19,48 18,46 17.5,44 17,42 17,40 18,38 22,38"/>
+            <polygon class="zone" data-zone="leg-right-back" data-area="9" points="22,38 22,48 23,48 25,48 27,48 29,48 30,46 30.5,44 31,42 31,40 30,38 26,38"/>
           </g>
         </g>
 


### PR DESCRIPTION
## Summary
- refine chest and abdomen zone polygons for smoother body outline
- add detailed arm and leg polygons depicting arms-down stance

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a798cf25208320860d3cbf37309e29