### PR TITLE
Refactor body map zones into reusable module

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -297,13 +297,13 @@
         <!-- FRONT silhouette -->
         <g id="layer-front" transform="translate(0,0)">
           <text x="16" y="28" class="label">PRIEKIS</text>
-          <use href="assets/body_front.svg#front-map" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
+          <use href="assets/body_front.svg#front-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
         </g>
 
         <!-- BACK silhouette -->
         <g id="layer-back" transform="translate(500,0)">
           <text x="16" y="28" class="label">NUGARA</text>
-          <use href="assets/body_back.svg#back-map" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
+          <use href="assets/body_back.svg#back-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
         </g>
 
         <!-- MARKS container -->

--- a/public/js/bodyMapZones.js
+++ b/public/js/bodyMapZones.js
@@ -1,0 +1,18 @@
+export default [
+  { id: 'head-front', side: 'front', polygonPoints: '24,0 26,0.5 27,1 28,2.5 29,4 29,12 28,13 27,13.5 24,14 21,13.5 20,13 19,12 19,4 20,2.5 21,1 22,0.5', area: 4.5, label: 'Galva (priekis)' },
+  { id: 'chest-front', side: 'front', polygonPoints: '20,14 24,14 28,14 30,14.5 32,16 33,18 34,20 34,23 34,26 24,26 14,26 14,23 14,20 15,18 16,16 18,14.5', area: 9, label: 'Krūtinė (priekis)' },
+  { id: 'abdomen-front', side: 'front', polygonPoints: '16,26 24,26 32,26 33,28 34,30 34,32 34,34 33,36 32,38 24,38 16,38 15,36 14,34 14,32 14,30 15,28', area: 9, label: 'Pilvas (priekis)' },
+  { id: 'arm-left-front', side: 'front', polygonPoints: '14,14 9,14 4,14 3,16 3,20 4,24 5,28 6,32 7,35 8,37 9,38 11,38 14,38', area: 4.5, label: 'Kairė ranka (priekis)' },
+  { id: 'arm-right-front', side: 'front', polygonPoints: '34,14 39,14 44,14 45,16 45,20 44,24 43,28 42,32 41,35 40,37 39,38 37,38 34,38', area: 4.5, label: 'Dešinė ranka (priekis)' },
+  { id: 'leg-left-front', side: 'front', polygonPoints: '26,38 26,48 25,48 23,48 21,48 19,48 18,46 17.5,44 17,42 17,40 18,38 22,38', area: 9, label: 'Kairė koja (priekis)' },
+  { id: 'leg-right-front', side: 'front', polygonPoints: '22,38 22,48 23,48 25,48 27,48 29,48 30,46 30.5,44 31,42 31,40 30,38 26,38', area: 9, label: 'Dešinė koja (priekis)' },
+  { id: 'perineum-front', side: 'front', polygonPoints: '23,38 26,38 29,38 28,39 28,40 26,41 24,41 24,40 23,39', area: 1, label: 'Perinė sritis (priekis)' },
+  { id: 'head-back', side: 'back', polygonPoints: '24,0 26,0.5 27,1 28,2.5 29,4 29,12 28,13 27,13.5 24,14 21,13.5 20,13 19,12 19,4 20,2.5 21,1 22,0.5', area: 4.5, label: 'Galva (nugara)' },
+  { id: 'upper-back', side: 'back', polygonPoints: '20,14 24,14 28,14 31,16 32,18 33,21 34,23 34,26 24,26 14,26 14,23 14,21 15,18 16,16 19,14', area: 9, label: 'Viršutinė nugara' },
+  { id: 'lower-back', side: 'back', polygonPoints: '16,26 24,26 32,26 33,28 34,30 34,32 34,34 33,36 32,38 24,38 16,38 15,36 14,34 14,32 14,30 15,28', area: 9, label: 'Apatinė nugara' },
+  { id: 'arm-left-back', side: 'back', polygonPoints: '14,14 9,14 4,14 3,16 3,20 4,24 5,28 6,32 7,35 8,37 9,38 11,38 14,38', area: 4.5, label: 'Kairė ranka (nugara)' },
+  { id: 'arm-right-back', side: 'back', polygonPoints: '34,14 39,14 44,14 45,16 45,20 44,24 43,28 42,32 41,35 40,37 39,38 37,38 34,38', area: 4.5, label: 'Dešinė ranka (nugara)' },
+  { id: 'leg-left-back', side: 'back', polygonPoints: '26,38 26,48 25,48 23,48 21,48 19,48 18,46 17.5,44 17,42 17,40 18,38 22,38', area: 9, label: 'Kairė koja (nugara)' },
+  { id: 'leg-right-back', side: 'back', polygonPoints: '22,38 22,48 23,48 25,48 27,48 29,48 30,46 30.5,44 31,42 31,40 30,38 26,38', area: 9, label: 'Dešinė koja (nugara)' }
+];
+


### PR DESCRIPTION
## Summary
- add `bodyMapZones.js` module exporting zone polygons, areas and labels
- build body map zones dynamically from module in `bodyMap.js`
- load only silhouettes in `index.html` to remove hard-coded zones

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b9d385548320a3e6bb5ba9d7f7da