### PR TITLE
test: refactor BodyMap tests with instance and zone fixtures

### DIFF
--- a/public/js/__fixtures__/zoneConfig.js
+++ b/public/js/__fixtures__/zoneConfig.js
@@ -1,0 +1,4 @@
+export default [
+  { id: 'head-front', side: 'front', polygonPoints: '0,0 10,0 10,10 0,10', area: 5, label: 'Head (front)' },
+  { id: 'head-back', side: 'back', polygonPoints: '0,0 10,0 10,10 0,10', area: 5, label: 'Head (back)' }
+];


### PR DESCRIPTION
## Summary
- add simplified zone configuration fixtures
- refactor BodyMap tests to instantiate class and verify mark handling, serialization, loading, zone counts, drag, and deletion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8c2a343fc83208694c9aff163f832