### PR TITLE
Ensure burn zone toggle triggers save

### DIFF
--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -63,6 +63,20 @@ describe('BodyMap instance', () => {
     expect(document.getElementById('burnTotal').textContent).toBe('Nudegimai: 5%');
   });
 
+  test('toggleZoneBurn toggles burn state and saves', () => {
+    setupDom();
+    const save = jest.fn();
+    const bm = new BodyMap();
+    bm.init(save);
+    bm.toggleZoneBurn('head-front');
+    const zone = document.querySelector('.zone[data-zone="head-front"]');
+    expect(zone.classList.contains('burned')).toBe(true);
+    expect(save).toHaveBeenCalledTimes(1);
+    bm.toggleZoneBurn('head-front');
+    expect(zone.classList.contains('burned')).toBe(false);
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
   test('pointer events move mark and save', () => {
     setupDom();
     const save = jest.fn();

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -104,6 +104,7 @@ export default class BodyMap {
     el.classList.toggle('burned');
     if(el.classList.contains('burned')) this.burns.add(name); else this.burns.delete(name);
     this.updateBurnDisplay();
+    this.saveCb();
   }
 
   burnArea(){
@@ -172,7 +173,6 @@ export default class BodyMap {
         const side=z.closest('#layer-back')?'back':'front';
         if(this.activeTool===TOOLS.BURN.char){
           this.toggleZoneBurn(name);
-          this.saveCb();
         }else{
           const p=this.svgPoint(evt);
           this.addMark(p.x,p.y,this.activeTool,side,name);


### PR DESCRIPTION
## Summary
- Call `saveCb` inside `toggleZoneBurn` after updating burn display
- Drop redundant save call in zone click handler
- Add unit test for direct `toggleZoneBurn` usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8c88a5ffc832081d33ef86f07c003