### PR TITLE
Guard BodyMap initialization

### DIFF
--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -107,4 +107,17 @@ describe('BodyMap instance', () => {
     document.getElementById('btnDelete').click();
     expect(document.querySelectorAll('#marks use').length).toBe(1);
   });
+
+  test('init only runs once and avoids duplicating listeners', () => {
+    setupDom();
+    const save = jest.fn();
+    const bm = new BodyMap();
+    bm.init(save);
+    bm.init(save);
+    bm.setTool(TOOLS.BURN.char);
+    const zone = document.querySelector('.zone[data-zone="head-front"]');
+    zone.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(zone.classList.contains('burned')).toBe(true);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
 });

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -28,6 +28,7 @@ export default class BodyMap {
     this.dragStart = this.dragStart.bind(this);
     this.dragMove = this.dragMove.bind(this);
     this.dragEnd = this.dragEnd.bind(this);
+    this.initialized = false;
   }
 
   setTool(t) {
@@ -125,6 +126,8 @@ export default class BodyMap {
   }
 
   init(saveAll){
+    if(this.initialized) return;
+    this.zoneMap.clear();
     this.saveCb = saveAll || (()=>{});
     this.svg = $('#bodySvg');
     this.marks = $('#marks');
@@ -136,6 +139,7 @@ export default class BodyMap {
     this.burnTotalEl = $('#burnTotal');
     this.selectedList = $('#selectedLocations');
     if(!this.svg || !this.marks) return;
+    this.initialized = true;
 
     if(!this.svg.querySelector('.zone')){
       const layers = { front: $('#layer-front'), back: $('#layer-back') };


### PR DESCRIPTION
## Summary
- Prevent double initialisation with a new `initialized` flag
- Clear `zoneMap` at start of `BodyMap.init`
- Test that `init` runs once without duplicating listeners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8cbf81f088320b30a772a33dc494b