### PR TITLE
Fix body map silhouette click handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -297,13 +297,13 @@
         <!-- FRONT silhouette -->
         <g id="layer-front" transform="translate(0,0)">
           <text x="16" y="28" class="label">PRIEKIS</text>
-          <use href="assets/body_front.svg#front-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
+          <use id="front-shape" data-side="front" href="assets/body_front.svg#front-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
         </g>
 
         <!-- BACK silhouette -->
         <g id="layer-back" transform="translate(500,0)">
           <text x="16" y="28" class="label">NUGARA</text>
-          <use href="assets/body_back.svg#back-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
+          <use id="back-shape" data-side="back" href="assets/body_back.svg#back-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
         </g>
 
         <!-- MARKS container -->

--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -121,4 +121,17 @@ describe('BodyMap instance', () => {
     expect(zone.classList.contains('burned')).toBe(true);
     expect(save).toHaveBeenCalledTimes(1);
   });
+
+  test('clicking silhouettes adds marks', () => {
+    setupDom();
+    document.querySelector('#layer-front').innerHTML = '<use id="front-shape" data-side="front"></use>';
+    document.querySelector('#layer-back').innerHTML = '<use id="back-shape" data-side="back"></use>';
+    const bm = new BodyMap();
+    bm.init(() => {});
+    // Provide deterministic coordinates
+    bm.svgPoint = () => ({ x: 1, y: 1 });
+    document.getElementById('front-shape').dispatchEvent(new MouseEvent('click'));
+    document.getElementById('back-shape').dispatchEvent(new MouseEvent('click'));
+    expect(document.querySelectorAll('#marks use').length).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary
- Add IDs and side data attributes to front and back silhouette `<use>` elements so BodyMap can attach click handlers
- Ensure clicking the silhouettes adds marks with new unit test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8d7dba3f48320abc16518bb331c68