### PR TITLE
Align body-map zones with silhouette transform

### DIFF
--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -148,6 +148,9 @@ export default class BodyMap {
         if(!container){
           container = document.createElementNS('http://www.w3.org/2000/svg','g');
           container.classList.add('zones');
+          const shape = layers[z.side].querySelector(`#${z.side}-shape`);
+          const tr = shape?.getAttribute('transform');
+          if(tr) container.setAttribute('transform', tr);
           layers[z.side].appendChild(container);
         }
         const poly = document.createElementNS('http://www.w3.org/2000/svg','polygon');


### PR DESCRIPTION
## Summary
- Apply the same transform used for silhouette to zone groups by copying the front/back shape transform
- Ensures clickable zones scale and position with body outline

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8dd556bf08320be2471d929ae82b9