### PR TITLE
Use non-namespaced href for BodyMap markers

### DIFF
--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -28,6 +28,7 @@ describe('BodyMap instance', () => {
     bm.addMark(10, 20, TOOLS.WOUND.char, 'front', 'head-front');
     const mark = document.querySelector('#marks use');
     expect(mark.dataset.zone).toBe('head-front');
+    expect(mark.getAttribute('href')).toBe(TOOLS.WOUND.symbol);
     const data = JSON.parse(bm.serialize());
     expect(data.marks[0]).toMatchObject({ x: 10, y: 20, type: TOOLS.WOUND.char, side: 'front', zone: 'head-front' });
   });

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -76,9 +76,9 @@ export default class BodyMap {
   }
 
   addMark(x, y, t = this.activeTool, s, zone, id){
-    const use = document.createElementNS('http://www.w3.org/2000/svg','use');
+    const use = document.createElementNS('http://www.w3.org/2000/svg', 'use');
     const symbol = Object.values(TOOLS).find(tool => tool.char === t)?.symbol;
-    if(symbol) use.setAttributeNS('http://www.w3.org/1999/xlink','href',symbol);
+    if (symbol) use.setAttribute('href', symbol);
     use.setAttribute('transform',`translate(${x},${y})`);
     use.dataset.type = t;
     use.dataset.side = s;


### PR DESCRIPTION
## Summary
- use standard `href` attribute when adding BodyMap symbols
- check for `href` in BodyMap tests to ensure markers reference symbols correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8de69a0d88320b53e72a71fcc1f82