### PR TITLE
Ensure exported body map SVG embeds silhouettes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -280,7 +280,7 @@
 
       <!-- SVG BODY MAP -->
       <div id="selectedLocations"></div>
-      <svg id="bodySvg" viewBox="0 0 850 900" xmlns="http://www.w3.org/2000/svg">
+      <svg id="bodySvg" viewBox="0 0 850 900" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <!-- Marker symbols -->
         <defs>
           <g id="sym-wound">
@@ -298,13 +298,13 @@
         <!-- FRONT silhouette -->
         <g id="layer-front" transform="translate(0,0)">
           <text x="16" y="28" class="label">PRIEKIS</text>
-          <use id="front-shape" data-side="front" href="assets/body_front.svg#front-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
+          <use id="front-shape" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
         </g>
 
         <!-- BACK silhouette -->
         <g id="layer-back" transform="translate(500,0)">
           <text x="16" y="28" class="label">NUGARA</text>
-          <use id="back-shape" data-side="back" href="assets/body_back.svg#back-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
+          <use id="back-shape" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
         </g>
 
         <!-- MARKS container -->


### PR DESCRIPTION
## Summary
- Inline external body silhouette assets when exporting the map so the SVG is self-contained
- Mark silhouette placeholders in HTML and include xlink namespace

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab59d8bf688320b23537fd962b8112