### PR TITLE
Increase spacing between body models

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -310,7 +310,7 @@
         </g>
 
         <!-- BACK silhouette -->
-        <g id="layer-back" transform="translate(500,0)">
+        <g id="layer-back" transform="translate(600,0)">
           <text x="16" y="28" class="label">NUGARA</text>
           <g id="back-map" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)">
             <g class="silhouette" id="back-shape" data-side="back">

--- a/public/index.html
+++ b/public/index.html
@@ -302,7 +302,7 @@
         </g>
 
         <!-- BACK silhouette -->
-        <g id="layer-back" transform="translate(500,0)">
+        <g id="layer-back" transform="translate(600,0)">
           <text x="16" y="28" class="label">NUGARA</text>
           <use id="back-shape" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
         </g>


### PR DESCRIPTION
## Summary
- widen gap between front and back body map silhouettes for clearer separation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac01537a0c8320a1ecf946f9423537