### PR TITLE
Center body map stick figures

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -298,7 +298,7 @@
         <!-- FRONT silhouette -->
         <g id="layer-front" transform="translate(0,0)">
           <text x="16" y="28" class="label">PRIEKIS</text>
-          <g id="front-map" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)">
+          <g id="front-map" transform="translate(3,50) scale(15.5,21.05)">
             <g class="silhouette" id="front-shape" data-side="front">
             <!-- Silhouette paths from Health Icons (CC0) -->
             <path fill-rule="evenodd" clip-rule="evenodd" d="M24 12C25.6569 12 27 10.6569 27 9C27 7.34315 25.6569 6 24 6C22.3431 6 21 7.34315 21 9C21 10.6569 22.3431 12 24 12ZM24 14C26.7614 14 29 11.7614 29 9C29 6.23858 26.7614 4 24 4C21.2386 4 19 6.23858 19 9C19 11.7614 21.2386 14 24 14Z"/>
@@ -312,7 +312,7 @@
         <!-- BACK silhouette -->
         <g id="layer-back" transform="translate(750,0)">
           <text x="16" y="28" class="label">NUGARA</text>
-          <g id="back-map" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)">
+          <g id="back-map" transform="translate(3,50) scale(15.5,21.05)">
             <g class="silhouette" id="back-shape" data-side="back">
             <!-- Silhouette paths from Health Icons (CC0) -->
             <path fill-rule="evenodd" clip-rule="evenodd" d="M24 12C25.6569 12 27 10.6569 27 9C27 7.34315 25.6569 6 24 6C22.3431 6 21 7.34315 21 9C21 10.6569 22.3431 12 24 12ZM24 14C26.7614 14 29 11.7614 29 9C29 6.23858 26.7614 4 24 4C21.2386 4 19 6.23858 19 9C19 11.7614 21.2386 14 24 14Z"/>

--- a/public/index.html
+++ b/public/index.html
@@ -298,13 +298,13 @@
         <!-- FRONT silhouette -->
         <g id="layer-front" transform="translate(0,0)">
           <text x="16" y="28" class="label">PRIEKIS</text>
-          <use id="front-shape" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
+          <use id="front-shape" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
         </g>
 
         <!-- BACK silhouette -->
         <g id="layer-back" transform="translate(750,0)">
           <text x="16" y="28" class="label">NUGARA</text>
-          <use id="back-shape" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
+          <use id="back-shape" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
         </g>
 
         <!-- MARKS container -->


### PR DESCRIPTION
## Summary
- center body map figures so silhouettes no longer clip against container edges

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac071e1dcc8320bc410f6603dd259f