### PR TITLE
Add back inspection change toggle

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -260,27 +260,27 @@
       <h2>E – Kita</h2>
       <div class="grid cols-3 cols-auto">
         <div><label for="e_temp">Temperatūra (°C)</label><input id="e_temp" type="number" step="0.1" min="30" max="43"></div>
-        <div><label for="e_back_notes">Nugaros apžiūra</label><div class="row"><label class="pill" for="e_back_ny"><input id="e_back_ny" type="checkbox"> n.y.</label><input id="e_back_notes" type="text" placeholder="Pastabos..."></div></div>
+        <div><label for="e_back_notes">Nugaros apžiūra</label><div class="row"><label class="pill" for="e_back_none"><input id="e_back_none" name="e_back_state" type="radio" checked> Be pakitimų</label><label class="pill red" for="e_back_changes"><input id="e_back_changes" name="e_back_state" type="radio"> Pakitimai</label><input id="e_back_notes" type="text" placeholder="Pakitimai..." class="hidden" disabled></div></div>
         <div><label for="e_other">Kitos pastabos</label><input id="e_other" type="text" placeholder="..."></div>
       </div>
 
       <div class="divider"></div>
       <h3 class="h3-muted m-0 mb-6">Kūno žemėlapis (SVG) – Žaizda (Ž), Sumušimas (S), Nudegimas (N)</h3>
       <div class="map-toolbar">
-        <button type="button" class="tool" data-tool="Ž">Žaizda</button>
-        <button type="button" class="tool" data-tool="S">Sumušimas</button>
-        <button type="button" class="tool" data-tool="N">Nudegimas</button>
+        <button type="button" class="tool" data-tool="Ž"><svg class="icon" viewBox="-15 -15 30 30"><circle r="14" class="mark-w"/><path d="M-10 0 L10 0 M0 -10 L0 10" class="mark-w"/></svg><span>Žaizda</span></button>
+        <button type="button" class="tool" data-tool="S"><svg class="icon" viewBox="-12 -12 24 24"><circle r="10" class="mark-b"/></svg><span>Sumušimas</span></button>
+        <button type="button" class="tool" data-tool="N"><svg class="icon" viewBox="-12 -12 24 24"><polygon points="0,-12 12,0 0,12 -12,0" class="mark-n"/></svg><span>Nudegimas</span></button>
         <span class="flex-1"></span>
-        <button type="button" class="tool" id="btnUndo">↩ Anuliuoti</button>
-        <button type="button" class="tool" id="btnRedo">↪ Perdaryti</button>
-        <button type="button" class="tool" id="btnDelete">✖ Pašalinti</button>
-        <button type="button" class="tool" id="btnClearMap">🧹 Išvalyti</button>
-        <button type="button" class="tool" id="btnExportSvg">⬇ Eksportuoti SVG</button>
+        <button type="button" class="tool" id="btnUndo"><span class="icon">↩</span><span>Anuliuoti</span></button>
+        <button type="button" class="tool" id="btnRedo"><span class="icon">↪</span><span>Perdaryti</span></button>
+        <button type="button" class="tool" id="btnDelete"><span class="icon">✖</span><span>Pašalinti</span></button>
+        <button type="button" class="tool" id="btnClearMap"><span class="icon">🧹</span><span>Išvalyti</span></button>
+        <button type="button" class="tool" id="btnExportSvg"><span class="icon">⬇</span><span>Eksportuoti SVG</span></button>
       </div>
 
       <!-- SVG BODY MAP -->
       <div id="selectedLocations"></div>
-      <svg id="bodySvg" viewBox="0 0 1500 900" xmlns="http://www.w3.org/2000/svg">
+      <svg id="bodySvg" viewBox="0 0 1500 900" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <!-- Marker symbols -->
         <defs>
           <g id="sym-wound">
@@ -298,29 +298,13 @@
         <!-- FRONT silhouette -->
         <g id="layer-front" transform="translate(0,0)">
           <text x="16" y="28" class="label">PRIEKIS</text>
-          <g id="front-map" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)">
-            <g class="silhouette" id="front-shape" data-side="front">
-            <!-- Silhouette paths from Health Icons (CC0) -->
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M24 12C25.6569 12 27 10.6569 27 9C27 7.34315 25.6569 6 24 6C22.3431 6 21 7.34315 21 9C21 10.6569 22.3431 12 24 12ZM24 14C26.7614 14 29 11.7614 29 9C29 6.23858 26.7614 4 24 4C21.2386 4 19 6.23858 19 9C19 11.7614 21.2386 14 24 14Z"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M17.374 18.3144C18.3174 18.494 19 19.3188 19 20.2792L19 41C19 41.5523 19.4477 42 20 42H20.0868C20.604 42 21.0359 41.6056 21.0827 41.0905L22 31C22.0029 29.8975 22.8975 29.0052 24 29.0052C25.1025 29.0052 25.9971 29.8974 26 30.9999L26.9173 41.0905C26.9641 41.6056 27.396 42 27.9132 42H28C28.5523 42 29 41.5523 29 41V20.3169C29 19.3564 29.6828 18.5316 30.6264 18.3521C32.3824 18.0182 34.2392 17.5548 36.2798 16.9601C36.8101 16.8056 37.1146 16.2505 36.9601 15.7202C36.8056 15.19 36.2505 14.8855 35.7202 15.04C31.0861 16.3906 27.5307 17.0156 24.0043 16.9998C20.4743 16.9839 16.9146 16.3259 12.2674 15.0365C11.7352 14.8888 11.1841 15.2005 11.0364 15.7327C10.8888 16.2649 11.2005 16.816 11.7327 16.9636C13.7658 17.5278 15.6186 17.9803 17.374 18.3144ZM22.9779 41.8025C22.6245 43.0798 21.4552 44 20.0868 44H20C18.3431 44 17 42.6569 17 41L17 20.2792C15.1742 19.9317 13.2653 19.4645 11.1979 18.8908C9.60138 18.4478 8.66625 16.7945 9.10925 15.1979C9.55225 13.6014 11.2056 12.6663 12.8021 13.1093C17.3715 14.3772 20.7371 14.9851 24.0132 14.9998C27.2788 15.0144 30.6314 14.4399 35.1606 13.1199C36.7513 12.6563 38.4166 13.57 38.8802 15.1606C39.3438 16.7513 38.4301 18.4166 36.8394 18.8802C34.7552 19.4876 32.8345 19.9681 31 20.3169V41C31 42.6569 29.6569 44 28 44H27.9132C26.5448 44 25.3755 43.0798 25.0221 41.8025C24.9897 41.6851 24.9641 41.5647 24.9458 41.4417C24.9375 41.3856 24.9307 41.3288 24.9255 41.2716L24.0082 31.1811C24.0029 31.1223 24.0002 31.0637 24 31.0052C23.9998 31.0637 23.9971 31.1223 23.9918 31.1811L23.0745 41.2716C23.0693 41.3288 23.0625 41.3856 23.0542 41.4417C23.0359 41.5647 23.0103 41.6851 22.9779 41.8025Z"/>
-            <g id="zones-front" class="zones">
-              <polygon class="zone" data-zone="front" data-area="50" points="0,0 48,0 48,48 0,48"/>
-            </g>
-          </g>
+          <use id="front-shape" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
         </g>
 
         <!-- BACK silhouette -->
         <g id="layer-back" transform="translate(750,0)">
           <text x="16" y="28" class="label">NUGARA</text>
-          <g id="back-map" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)">
-            <g class="silhouette" id="back-shape" data-side="back">
-            <!-- Silhouette paths from Health Icons (CC0) -->
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M24 12C25.6569 12 27 10.6569 27 9C27 7.34315 25.6569 6 24 6C22.3431 6 21 7.34315 21 9C21 10.6569 22.3431 12 24 12ZM24 14C26.7614 14 29 11.7614 29 9C29 6.23858 26.7614 4 24 4C21.2386 4 19 6.23858 19 9C19 11.7614 21.2386 14 24 14Z"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M17.374 18.3144C18.3174 18.494 19 19.3188 19 20.2792L19 41C19 41.5523 19.4477 42 20 42H20.0868C20.604 42 21.0359 41.6056 21.0827 41.0905L22 31C22.0029 29.8975 22.8975 29.0052 24 29.0052C25.1025 29.0052 25.9971 29.8974 26 30.9999L26.9173 41.0905C26.9641 41.6056 27.396 42 27.9132 42H28C28.5523 42 29 41.5523 29 41V20.3169C29 19.3564 29.6828 18.5316 30.6264 18.3521C32.3824 18.0182 34.2392 17.5548 36.2798 16.9601C36.8101 16.8056 37.1146 16.2505 36.9601 15.7202C36.8056 15.19 36.2505 14.8855 35.7202 15.04C31.0861 16.3906 27.5307 17.0156 24.0043 16.9998C20.4743 16.9839 16.9146 16.3259 12.2674 15.0365C11.7352 14.8888 11.1841 15.2005 11.0364 15.7327C10.8888 16.2649 11.2005 16.816 11.7327 16.9636C13.7658 17.5278 15.6186 17.9803 17.374 18.3144ZM22.9779 41.8025C22.6245 43.0798 21.4552 44 20.0868 44H20C18.3431 44 17 42.6569 17 41L17 20.2792C15.1742 19.9317 13.2653 19.4645 11.1979 18.8908C9.60138 18.4478 8.66625 16.7945 9.10925 15.1979C9.55225 13.6014 11.2056 12.6663 12.8021 13.1093C17.3715 14.3772 20.7371 14.9851 24.0132 14.9998C27.2788 15.0144 30.6314 14.4399 35.1606 13.1199C36.7513 12.6563 38.4166 13.57 38.8802 15.1606C39.3438 16.7513 38.4301 18.4166 36.8394 18.8802C34.7552 19.4876 32.8345 19.9681 31 20.3169V41C31 42.6569 29.6569 44 28 44H27.9132C26.5448 44 25.3755 43.0798 25.0221 41.8025C24.9897 41.6851 24.9641 41.5647 24.9458 41.4417C24.9375 41.3856 24.9307 41.3288 24.9255 41.2716L24.0082 31.1811C24.0029 31.1223 24.0002 31.0637 24 31.0052C23.9998 31.0637 23.9971 31.1223 23.9918 31.1811L23.0745 41.2716C23.0693 41.3288 23.0625 41.3856 23.0542 41.4417C23.0359 41.5647 23.0103 41.6851 22.9779 41.8025Z"/>
-            <g id="zones-back" class="zones">
-              <polygon class="zone" data-zone="back" data-area="50" points="0,0 48,0 48,48 0,48"/>
-            </g>
-          </g>
+          <use id="back-shape" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(0,50) scale(15.5,21.05) translate(-11,-6)"></use>
         </g>
 
         <!-- MARKS container -->

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -10,7 +10,7 @@ import { initValidation, validateVitals } from './validation.js';
 import { initTopbar } from './components/topbar.js';
 import { initCollapsibles } from './sections.js';
 import { connectSocket, initSessions, fetchUsers, initTheme, saveAll, loadAll } from './sessionManager.js';
-import { initBodyMap } from './bodyMap.js';
+import bodyMap from './bodyMap.js';
 import { generateReport, gksSum } from './report.js';
 import { setupHeaderActions } from './headerActions.js';
 export { validateVitals };
@@ -188,7 +188,22 @@ if($('#spr_gcs_calc') && $('#btnSprGCSCalc')){
   const toggleSprGcs=setupGcsCalc('spr');
   $('#btnSprGCSCalc').addEventListener('click',toggleSprGcs);
 }
-$('#e_back_ny').addEventListener('change',e=>{ $('#e_back_notes').disabled=e.target.checked; if(e.target.checked) $('#e_back_notes').value=''; saveAll();});
+const backNone=$('#e_back_none'), backChanges=$('#e_back_changes'), backNotes=$('#e_back_notes');
+if(backNone && backChanges && backNotes){
+  const updateBack=()=>{
+    if(backChanges.checked){
+      backNotes.disabled=false;
+      backNotes.classList.remove('hidden');
+    }else{
+      backNotes.disabled=true;
+      backNotes.classList.add('hidden');
+      backNotes.value='';
+    }
+    saveAll();
+  };
+  [backNone,backChanges].forEach(el=>el.addEventListener('change',updateBack));
+  updateBack();
+}
 
 function clampNumberInputs(){
   const clamp=el=>{
@@ -225,7 +240,7 @@ async function init(){
   await initSessions();
   initTabs();
   initCollapsibles();
-  initBodyMap(saveAllDebounced);
+  bodyMap.init(saveAllDebounced);
   initChips(saveAllDebounced);
   initAutoActivate(saveAllDebounced);
   initActions(saveAllDebounced);

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -1,6 +1,6 @@
 import { $ } from './utils.js';
 import { listChips } from './chips.js';
-import { zoneCounts as bodyMapZoneCounts, TOOLS } from './bodyMap.js';
+import bodyMap, { TOOLS } from './bodyMap.js';
 
 const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas'];
 const fastAreas=[
@@ -16,12 +16,12 @@ export function gksSum(a,k,m){ a=+a||0;k=+k||0;m=+m||0; return (a&&k&&m)?(a+k+m)
 const getSingleValue=sel=>listChips(sel)[0]||'';
 
 export function bodymapSummary(){
-  const zones=bodyMapZoneCounts();
+  const zones=bodyMap.zoneCounts();
   const parts=Object.values(zones).map(z=>{
     const seg=[];
-    if(z[TOOLS.WOUND]) seg.push(`${z[TOOLS.WOUND]} ${TOOLS.WOUND}`);
-    if(z[TOOLS.BRUISE]) seg.push(`${z[TOOLS.BRUISE]} ${TOOLS.BRUISE}`);
-    if(z[TOOLS.BURN]) seg.push(`${z[TOOLS.BURN]} ${TOOLS.BURN}`);
+    if(z[TOOLS.WOUND.char]) seg.push(`${z[TOOLS.WOUND.char]} ${TOOLS.WOUND.char}`);
+    if(z[TOOLS.BRUISE.char]) seg.push(`${z[TOOLS.BRUISE.char]} ${TOOLS.BRUISE.char}`);
+    if(z[TOOLS.BURN.char]) seg.push(`${z[TOOLS.BURN.char]} ${TOOLS.BURN.char}`);
     if(z.burned) seg.push(`Nudegimai ${z.burned}%`);
     return `${z.label}: ${seg.join(', ')}`;
   });
@@ -55,7 +55,12 @@ export function generateReport(){
   const dgks=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value); const left=getSingleValue('#d_pupil_left_group'); const right=getSingleValue('#d_pupil_right_group');
   out.push('\n--- D Sąmonė ---'); out.push([dgks?('GKS '+dgks+' (A'+$('#d_gksa').value+'-K'+$('#d_gksk').value+'-M'+$('#d_gksm').value+')'):null, left?('Vyzdžiai kairė: '+left+ (left==='kita'&&$('#d_pupil_left_note').value?(' ('+$('#d_pupil_left_note').value+')'):'') ):null, right?('Vyzdžiai dešinė: '+right+ (right==='kita'&&$('#d_pupil_right_note').value?(' ('+$('#d_pupil_right_note').value+')'):'') ):null, $('#d_notes').value?('Pastabos: '+$('#d_notes').value):null].filter(Boolean).join(' | '));
 
-  out.push('\n--- E Kita ---'); out.push([$('#e_temp').value?('T '+$('#e_temp').value+'°C'):null, $('#e_back_ny').checked?'Nugara: n.y.':($('#e_back_notes').value?('Nugara: '+$('#e_back_notes').value):null), $('#e_other').value?('Kita: '+$('#e_other').value):null, bodymapSummary()].filter(Boolean).join(' | '));
+  out.push('\n--- E Kita ---'); out.push([
+    $('#e_temp').value?('T '+$('#e_temp').value+'°C'):null,
+    $('#e_back_none').checked?'Nugara: be pakitimų':($('#e_back_notes').value?('Nugara: '+$('#e_back_notes').value):null),
+    $('#e_other').value?('Kita: '+$('#e_other').value):null,
+    bodymapSummary()
+  ].filter(Boolean).join(' | '));
 
   function collect(container){ return Array.from(container.children).map(card=>{ const on=card.querySelector('.act_chk').checked; if(!on) return null; const nameInput=card.querySelector('.act_custom_name'); const base=card.querySelector('.act_name').textContent.trim(); const customName=nameInput?nameInput.value.trim():''; const name=nameInput?customName:base; if(nameInput && !customName) return null; const time=card.querySelector('.act_time').value; const doseInput=card.querySelector('.act_dose'); const dose=doseInput?doseInput.value:''; const note=card.querySelector('.act_note').value; return [name, time?('laikas '+time):null, dose?('dozė '+dose):null, note?('pastabos '+note):null].filter(Boolean).join(' | '); }).filter(Boolean);}
   const pain=collect($('#pain_meds')), bleeding=collect($('#bleeding_meds')), other=collect($('#other_meds')), procs=collect($('#procedures'));

--- a/public/index.html
+++ b/public/index.html
@@ -260,7 +260,7 @@
       <h2>E – Kita</h2>
       <div class="grid cols-3 cols-auto">
         <div><label for="e_temp">Temperatūra (°C)</label><input id="e_temp" type="number" step="0.1" min="30" max="43"></div>
-        <div><label for="e_back_notes">Nugaros apžiūra</label><div class="row"><label class="pill" for="e_back_ny"><input id="e_back_ny" type="checkbox"> n.y.</label><input id="e_back_notes" type="text" placeholder="Pastabos..."></div></div>
+        <div><label for="e_back_notes">Nugaros apžiūra</label><div class="row"><label class="pill" for="e_back_none"><input id="e_back_none" name="e_back_state" type="radio" checked> Be pakitimų</label><label class="pill red" for="e_back_changes"><input id="e_back_changes" name="e_back_state" type="radio"> Pakitimai</label><input id="e_back_notes" type="text" placeholder="Pakitimai..." class="hidden" disabled></div></div>
         <div><label for="e_other">Kitos pastabos</label><input id="e_other" type="text" placeholder="..."></div>
       </div>
 

--- a/public/js/__tests__/patient.test.js
+++ b/public/js/__tests__/patient.test.js
@@ -25,7 +25,8 @@ const setupDom = () => {
       <button id="d_gcs_apply"></button>
       <span id="d_gcs_calc_total"></span>
     </div>
-    <input type="checkbox" id="e_back_ny" />
+    <input type="radio" id="e_back_none" name="e_back_state" checked />
+    <input type="radio" id="e_back_changes" name="e_back_state" />
     <textarea id="output"></textarea>
     <svg id="bodySvg"><g id="layer-front"></g><g id="layer-back"></g><g id="marks"></g></svg>
     <div id="front-shape"></div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -188,7 +188,22 @@ if($('#spr_gcs_calc') && $('#btnSprGCSCalc')){
   const toggleSprGcs=setupGcsCalc('spr');
   $('#btnSprGCSCalc').addEventListener('click',toggleSprGcs);
 }
-$('#e_back_ny').addEventListener('change',e=>{ $('#e_back_notes').disabled=e.target.checked; if(e.target.checked) $('#e_back_notes').value=''; saveAll();});
+const backNone=$('#e_back_none'), backChanges=$('#e_back_changes'), backNotes=$('#e_back_notes');
+if(backNone && backChanges && backNotes){
+  const updateBack=()=>{
+    if(backChanges.checked){
+      backNotes.disabled=false;
+      backNotes.classList.remove('hidden');
+    }else{
+      backNotes.disabled=true;
+      backNotes.classList.add('hidden');
+      backNotes.value='';
+    }
+    saveAll();
+  };
+  [backNone,backChanges].forEach(el=>el.addEventListener('change',updateBack));
+  updateBack();
+}
 
 function clampNumberInputs(){
   const clamp=el=>{

--- a/public/js/report.js
+++ b/public/js/report.js
@@ -55,7 +55,12 @@ export function generateReport(){
   const dgks=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value); const left=getSingleValue('#d_pupil_left_group'); const right=getSingleValue('#d_pupil_right_group');
   out.push('\n--- D Sąmonė ---'); out.push([dgks?('GKS '+dgks+' (A'+$('#d_gksa').value+'-K'+$('#d_gksk').value+'-M'+$('#d_gksm').value+')'):null, left?('Vyzdžiai kairė: '+left+ (left==='kita'&&$('#d_pupil_left_note').value?(' ('+$('#d_pupil_left_note').value+')'):'') ):null, right?('Vyzdžiai dešinė: '+right+ (right==='kita'&&$('#d_pupil_right_note').value?(' ('+$('#d_pupil_right_note').value+')'):'') ):null, $('#d_notes').value?('Pastabos: '+$('#d_notes').value):null].filter(Boolean).join(' | '));
 
-  out.push('\n--- E Kita ---'); out.push([$('#e_temp').value?('T '+$('#e_temp').value+'°C'):null, $('#e_back_ny').checked?'Nugara: n.y.':($('#e_back_notes').value?('Nugara: '+$('#e_back_notes').value):null), $('#e_other').value?('Kita: '+$('#e_other').value):null, bodymapSummary()].filter(Boolean).join(' | '));
+  out.push('\n--- E Kita ---'); out.push([
+    $('#e_temp').value?('T '+$('#e_temp').value+'°C'):null,
+    $('#e_back_none').checked?'Nugara: be pakitimų':($('#e_back_notes').value?('Nugara: '+$('#e_back_notes').value):null),
+    $('#e_other').value?('Kita: '+$('#e_other').value):null,
+    bodymapSummary()
+  ].filter(Boolean).join(' | '));
 
   function collect(container){ return Array.from(container.children).map(card=>{ const on=card.querySelector('.act_chk').checked; if(!on) return null; const nameInput=card.querySelector('.act_custom_name'); const base=card.querySelector('.act_name').textContent.trim(); const customName=nameInput?nameInput.value.trim():''; const name=nameInput?customName:base; if(nameInput && !customName) return null; const time=card.querySelector('.act_time').value; const doseInput=card.querySelector('.act_dose'); const dose=doseInput?doseInput.value:''; const note=card.querySelector('.act_note').value; return [name, time?('laikas '+time):null, dose?('dozė '+dose):null, note?('pastabos '+note):null].filter(Boolean).join(' | '); }).filter(Boolean);}
   const pain=collect($('#pain_meds')), bleeding=collect($('#bleeding_meds')), other=collect($('#other_meds')), procs=collect($('#procedures'));


### PR DESCRIPTION
## Summary
- Rename back inspection "n.y." button to "Be pakitimų" and add "Pakitimai" option
- Toggle notes field visibility and save state based on selection
- Update report generation and tests to reflect new back inspection controls

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac07cad7808320803fafe7d8d49b73