### PR TITLE
Improve body map silhouette visibility

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -298,13 +298,13 @@
         <!-- FRONT silhouette -->
         <g id="layer-front" transform="translate(0,0)">
           <text x="16" y="28" class="label">PRIEKIS</text>
-          <use id="front-shape" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
+          <use id="front-shape" class="silhouette" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
         </g>
 
         <!-- BACK silhouette -->
         <g id="layer-back" transform="translate(750,0)">
           <text x="16" y="28" class="label">NUGARA</text>
-          <use id="back-shape" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
+          <use id="back-shape" class="silhouette" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
         </g>
 
         <!-- MARKS container -->

--- a/public/index.html
+++ b/public/index.html
@@ -298,13 +298,13 @@
         <!-- FRONT silhouette -->
         <g id="layer-front" transform="translate(0,0)">
           <text x="16" y="28" class="label">PRIEKIS</text>
-          <use id="front-shape" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
+          <use id="front-shape" class="silhouette" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
         </g>
 
         <!-- BACK silhouette -->
         <g id="layer-back" transform="translate(750,0)">
           <text x="16" y="28" class="label">NUGARA</text>
-          <use id="back-shape" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
+          <use id="back-shape" class="silhouette" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
         </g>
 
         <!-- MARKS container -->


### PR DESCRIPTION
## Summary
- apply `silhouette` styling to body map `<use>` elements so silhouettes render with light stroke color
- rebuild docs

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac149d0c908320a7ce8db727ecc3a1