### PR TITLE
feat: replace stick figure with human silhouette

### DIFF
--- a/public/assets/body_back.svg
+++ b/public/assets/body_back.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
   <g id="back-map">
     <g class="silhouette" id="back-shape" data-side="back">
-      <!-- Silhouette path from Font Awesome Free (CC BY 4.0) -->
-      <path transform="scale(0.15,0.09375)" d="M112 48a48 48 0 1 1 96 0 48 48 0 1 1 -96 0zm40 304l0 128c0 17.7-14.3 32-32 32s-32-14.3-32-32l0-223.1L59.4 304.5c-9.1 15.1-28.8 20-43.9 10.9s-20-28.8-10.9-43.9l58.3-97c17.4-28.9 48.6-46.6 82.3-46.6l29.7 0c33.7 0 64.9 17.7 82.3 46.6l58.3 97c9.1 15.1 4.2 34.8-10.9 43.9s-34.8 4.2-43.9-10.9L232 256.9 232 480c0 17.7-14.3 32-32 32s-32-14.3-32-32l0-128-16 0z"/>
+      <!-- Silhouette path from Material Design Icons (Apache License 2.0) -->
+      <path transform="scale(2)" d="M12,2A2,2 0 0,1 14,4A2,2 0 0,1 12,6A2,2 0 0,1 10,4A2,2 0 0,1 12,2M10.5,7H13.5A2,2 0 0,1 15.5,9V14.5H14V22H10V14.5H8.5V9A2,2 0 0,1 10.5,7Z"/>
     </g>
   </g>
 </svg>

--- a/public/assets/body_front.svg
+++ b/public/assets/body_front.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
   <g id="front-map">
     <g class="silhouette" id="front-shape" data-side="front">
-      <!-- Silhouette path from Font Awesome Free (CC BY 4.0) -->
-      <path transform="scale(0.15,0.09375)" d="M112 48a48 48 0 1 1 96 0 48 48 0 1 1 -96 0zm40 304l0 128c0 17.7-14.3 32-32 32s-32-14.3-32-32l0-223.1L59.4 304.5c-9.1 15.1-28.8 20-43.9 10.9s-20-28.8-10.9-43.9l58.3-97c17.4-28.9 48.6-46.6 82.3-46.6l29.7 0c33.7 0 64.9 17.7 82.3 46.6l58.3 97c9.1 15.1 4.2 34.8-10.9 43.9s-34.8 4.2-43.9-10.9L232 256.9 232 480c0 17.7-14.3 32-32 32s-32-14.3-32-32l0-128-16 0z"/>
+      <!-- Silhouette path from Material Design Icons (Apache License 2.0) -->
+      <path transform="scale(2)" d="M12,2A2,2 0 0,1 14,4A2,2 0 0,1 12,6A2,2 0 0,1 10,4A2,2 0 0,1 12,2M10.5,7H13.5A2,2 0 0,1 15.5,9V14.5H14V22H10V14.5H8.5V9A2,2 0 0,1 10.5,7Z"/>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace simplified body map icons with Material Design human silhouette for front and back views

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac23530cc083209cd36b896f0a2c6d