### PR TITLE
Restrict burn brush to body zones

### DIFF
--- a/docs/js/components/BodyMap.js
+++ b/docs/js/components/BodyMap.js
@@ -56,6 +56,11 @@ export default class BodyMap {
     this.onDragEnd = this.onDragEnd.bind(this);
   }
 
+  /** Check if event target is within body shapes. */
+  inBody(evt) {
+    return !!evt.target.closest('.zone, #front-shape, #back-shape');
+  }
+
   /** Initialise DOM references and event listeners. */
   init(saveCb) {
     if (this.initialized) return;
@@ -143,13 +148,13 @@ export default class BodyMap {
 
     // Brush drawing on SVG
     this.svg.addEventListener('pointerdown', e => {
-      if (this.activeTool === TOOLS.BURN_BRUSH.char) {
+      if (this.activeTool === TOOLS.BURN_BRUSH.char && this.inBody(e)) {
         this.isDrawing = true;
         this.drawBrush(e);
       }
     });
     this.svg.addEventListener('pointermove', e => {
-      if (this.activeTool === TOOLS.BURN_BRUSH.char && this.isDrawing) {
+      if (this.activeTool === TOOLS.BURN_BRUSH.char && this.isDrawing && this.inBody(e)) {
         this.drawBrush(e);
       }
     });
@@ -257,6 +262,7 @@ export default class BodyMap {
     circle.setAttribute('cy', y);
     circle.setAttribute('r', r);
     circle.classList.add('burn-area');
+    circle.setAttribute('pointer-events', 'none');
     circle.dataset.id = mid;
     this.brushLayer.appendChild(circle);
     const area = Math.PI * r * r;

--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -154,6 +154,26 @@ describe('BodyMap instance', () => {
     expect(bm2.burnArea()).toBeGreaterThan(0);
   });
 
+  test('burn brush only paints over body zones', () => {
+    setupDom();
+    const bm = new BodyMap();
+    bm.init(() => {});
+    bm.setTool(TOOLS.BURN_BRUSH.char);
+    // deterministic coordinates
+    bm.svgPoint = () => ({ x: 10, y: 10 });
+
+    // outside body -> no brush
+    bm.svg.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointerup'));
+    expect(bm.brushLayer.childElementCount).toBe(0);
+
+    // inside body -> brush added
+    const zone = document.querySelector('.zone[data-zone="front"]');
+    zone.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointerup'));
+    expect(bm.brushLayer.childElementCount).toBe(1);
+  });
+
   test('undo and redo actions manage stacks and buttons', () => {
     setupDom();
     const bm = new BodyMap();

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -56,6 +56,11 @@ export default class BodyMap {
     this.onDragEnd = this.onDragEnd.bind(this);
   }
 
+  /** Check if event target is within body shapes. */
+  inBody(evt) {
+    return !!evt.target.closest('.zone, #front-shape, #back-shape');
+  }
+
   /** Initialise DOM references and event listeners. */
   init(saveCb) {
     if (this.initialized) return;
@@ -143,13 +148,13 @@ export default class BodyMap {
 
     // Brush drawing on SVG
     this.svg.addEventListener('pointerdown', e => {
-      if (this.activeTool === TOOLS.BURN_BRUSH.char) {
+      if (this.activeTool === TOOLS.BURN_BRUSH.char && this.inBody(e)) {
         this.isDrawing = true;
         this.drawBrush(e);
       }
     });
     this.svg.addEventListener('pointermove', e => {
-      if (this.activeTool === TOOLS.BURN_BRUSH.char && this.isDrawing) {
+      if (this.activeTool === TOOLS.BURN_BRUSH.char && this.isDrawing && this.inBody(e)) {
         this.drawBrush(e);
       }
     });
@@ -257,6 +262,7 @@ export default class BodyMap {
     circle.setAttribute('cy', y);
     circle.setAttribute('r', r);
     circle.classList.add('burn-area');
+    circle.setAttribute('pointer-events', 'none');
     circle.dataset.id = mid;
     this.brushLayer.appendChild(circle);
     const area = Math.PI * r * r;


### PR DESCRIPTION
## Summary
- prevent burn brush from drawing outside the body silhouette
- ignore brush circles during hit testing to allow continuous painting
- add test ensuring burn brush only paints body zones

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6e7d1e008320aad2f241b60071b0