### PR TITLE
Add trauma mechanism datalist and persistence

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,7 +65,18 @@
               <div><label for="gmp_time">GMP pranešimo laikas</label><div class="row"><input id="gmp_time" type="time"><button type="button" class="btn ghost" id="btnGmpNow">Dabar</button></div></div>
           </div>
           <div class="grid cols-2 cols-auto mt-8">
-              <div><label for="gmp_mechanism">Traumos mechanizmas</label><input id="gmp_mechanism" type="text"></div>
+              <div>
+                <label for="gmp_mechanism">Traumos mechanizmas</label>
+                <input id="gmp_mechanism" type="text" list="gmp_mechanism_list">
+                <datalist id="gmp_mechanism_list">
+                  <option value="Autoavarija"></option>
+                  <option value="Kritimas"></option>
+                  <option value="Motociklo avarija"></option>
+                  <option value="Šautinė žaizda"></option>
+                  <option value="Durinė žaizda"></option>
+                  <option value="Nudegimas"></option>
+                </datalist>
+              </div>
               <div><label for="gmp_notes">Pastabos</label><input id="gmp_notes" type="text" placeholder="Trumpai..."></div>
           </div>
         </fieldset>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -21,6 +21,7 @@ const IMG_XRAY=['Krūtinės Ro','Dubens Ro'];
 const LABS=['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
 const BLOOD_GROUPS=['0-','0+','A-','A+','B-','B+','AB-','AB+'];
 const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas'];
+const LS_MECHANISM_KEY='traumos_mechanizmai';
 
 const imgCtWrap=$('#imaging_ct'); IMG_CT.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); imgCtWrap.appendChild(s);});
 const imgXrayWrap=$('#imaging_xray'); IMG_XRAY.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); imgXrayWrap.appendChild(s);});
@@ -68,6 +69,32 @@ const teamWrap=$('#teamGrid'); TEAM_ROLES.forEach(r=>{
   box.innerHTML=`<label>${r}</label><input type="text" data-team="${r}" data-field="team_${slug}" placeholder="Vardas Pavardė">`;
   teamWrap.appendChild(box);
 });
+
+function initMechanismList(){
+  const list=$('#gmp_mechanism_list');
+  const input=$('#gmp_mechanism');
+  if(!list||!input) return;
+  const existing=new Set(Array.from(list.options).map(o=>o.value));
+  const stored=JSON.parse(localStorage.getItem(LS_MECHANISM_KEY)||'[]');
+  stored.forEach(v=>{
+    if(!existing.has(v)){
+      const opt=document.createElement('option');
+      opt.value=v;
+      list.appendChild(opt);
+      existing.add(v);
+    }
+  });
+  input.addEventListener('change',()=>{
+    const val=input.value.trim();
+    if(!val||existing.has(val)) return;
+    const opt=document.createElement('option');
+    opt.value=val;
+    list.appendChild(opt);
+    existing.add(val);
+    stored.push(val);
+    localStorage.setItem(LS_MECHANISM_KEY, JSON.stringify(stored));
+  });
+}
 
 /* ===== Activation indicator ===== */
 function ensureSingleTeam(){
@@ -230,6 +257,7 @@ async function init(){
   initActions(saveAllDebounced);
   initTimeline();
   setupActivationControls();
+  initMechanismList();
   document.addEventListener('input', saveAllDebounced);
 
   const vitals = {


### PR DESCRIPTION
## Summary
- Add `datalist` with common trauma mechanisms and link it to the mechanism input
- Populate the datalist on startup and store custom mechanisms in localStorage
- Translate default mechanism options to Lithuanian and centralize the storage key

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6fe388d883209482bf20b06c539f