### PR TITLE
Prevent brush strokes outside body

### DIFF
--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -57,8 +57,10 @@ export default class BodyMap {
 
   /** Determine whether event occurred within body silhouette. */
   inBody(evt) {
+    const inside = !!evt.target.closest('.zone, #front-shape, #back-shape');
+    if (!inside) return false;
     if (!this.svg || typeof this.svg.createSVGPoint !== 'function') {
-      return !!evt.target.closest('.zone, #front-shape, #back-shape');
+      return inside;
     }
     const p = this.svgPoint(evt);
     return this.pointInBody(p.x, p.y);


### PR DESCRIPTION
## Summary
- avoid adding burn brushes when pointer isn't over body zones

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac7aae17fc8320a4e67ee6af698e0a