### PR TITLE
Remove zone label list from body map

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -292,7 +292,6 @@
       </div>
 
       <!-- SVG BODY MAP -->
-      <div id="selectedLocations"></div>
       <svg id="bodySvg" viewBox="0 0 1500 1100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <!-- Marker symbols -->
         <defs>

--- a/docs/js/components/BodyMap.js
+++ b/docs/js/components/BodyMap.js
@@ -32,7 +32,6 @@ export default class BodyMap {
     this.btnClear = null;
     this.btnExport = null;
     this.burnTotalEl = null;
-    this.selectedList = null;
     this.brushSizeInput = null;
     this.brushLayer = null;
 
@@ -94,7 +93,6 @@ export default class BodyMap {
     this.btnClear = $('#btnClearMap');
     this.btnExport = $('#btnExportSvg');
     this.burnTotalEl = $('#burnTotal');
-    this.selectedList = $('#selectedLocations');
     this.brushSizeInput = $('#brushSize');
 
     const vb = this.svg?.getAttribute('viewBox')?.split(/\s+/).map(Number);
@@ -217,7 +215,6 @@ export default class BodyMap {
         this.marks.innerHTML = '';
         this.burns.clear();
         this.zoneMap.forEach(z => z.classList.remove('burned'));
-        this.selectedList && (this.selectedList.innerHTML = '');
         this.brushLayer && (this.brushLayer.innerHTML = '');
         this.brushBurns = [];
         this.markSeq = 0;
@@ -344,12 +341,6 @@ export default class BodyMap {
     if (mid > this.markSeq) this.markSeq = mid;
     if (zone) {
       use.dataset.zone = zone;
-      if (this.selectedList) {
-        const el = document.createElement('div');
-        el.textContent = ZONE_LABELS[zone] || zone;
-        el.dataset.id = mid;
-        this.selectedList.appendChild(el);
-      }
     }
     use.addEventListener('pointerdown', e => this.startDrag(e, use));
     this.marks.appendChild(use);
@@ -392,9 +383,6 @@ export default class BodyMap {
   /** Remove a mark from the map. */
   removeMark(el, record = true) {
     if (!el) return;
-    if (this.selectedList && el.dataset.zone) {
-      this.selectedList.querySelector(`[data-id="${el.dataset.id}"]`)?.remove();
-    }
     const tr = el.getAttribute('transform');
     const m = /translate\(([-\d.]+),([-\d.]+)\)/.exec(tr) || [0, 0, 0];
     const data = {
@@ -598,7 +586,6 @@ export default class BodyMap {
       this.brushLayer.innerHTML = '';
       this.burns.clear();
       this.zoneMap.forEach(z => z.classList.remove('burned'));
-      this.selectedList && (this.selectedList.innerHTML = '');
       this.undoStack = [];
       this.redoStack = [];
       (data.marks || []).forEach(m => this.addMark(m.x, m.y, m.type, m.side, m.zone, m.id, false));

--- a/public/index.html
+++ b/public/index.html
@@ -292,7 +292,6 @@
       </div>
 
       <!-- SVG BODY MAP -->
-      <div id="selectedLocations"></div>
       <svg id="bodySvg" viewBox="0 0 1500 1100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <!-- Marker symbols -->
         <defs>

--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -8,7 +8,6 @@ function setupDom() {
   document.body.innerHTML = `
     <svg id="bodySvg"><g id="layer-front"></g><g id="layer-back"></g><g id="marks"></g></svg>
     <div id="burnTotal"></div>
-    <div id="selectedLocations"></div>
     <div class="map-toolbar">
       <button class="tool" data-tool="${TOOLS.WOUND.char}"></button>
       <button class="tool" data-tool="${TOOLS.BURN.char}"></button>

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -32,7 +32,6 @@ export default class BodyMap {
     this.btnClear = null;
     this.btnExport = null;
     this.burnTotalEl = null;
-    this.selectedList = null;
     this.brushSizeInput = null;
     this.brushLayer = null;
 
@@ -96,7 +95,6 @@ export default class BodyMap {
     this.btnClear = $('#btnClearMap');
     this.btnExport = $('#btnExportSvg');
     this.burnTotalEl = $('#burnTotal');
-    this.selectedList = $('#selectedLocations');
     this.brushSizeInput = $('#brushSize');
 
     const vb = this.svg?.getAttribute('viewBox')?.split(/\s+/).map(Number);
@@ -219,7 +217,6 @@ export default class BodyMap {
         this.marks.innerHTML = '';
         this.burns.clear();
         this.zoneMap.forEach(z => z.classList.remove('burned'));
-        this.selectedList && (this.selectedList.innerHTML = '');
         this.brushLayer && (this.brushLayer.innerHTML = '');
         this.brushBurns = [];
         this.markSeq = 0;
@@ -346,12 +343,6 @@ export default class BodyMap {
     if (mid > this.markSeq) this.markSeq = mid;
     if (zone) {
       use.dataset.zone = zone;
-      if (this.selectedList) {
-        const el = document.createElement('div');
-        el.textContent = ZONE_LABELS[zone] || zone;
-        el.dataset.id = mid;
-        this.selectedList.appendChild(el);
-      }
     }
     use.addEventListener('pointerdown', e => this.startDrag(e, use));
     this.marks.appendChild(use);
@@ -394,9 +385,6 @@ export default class BodyMap {
   /** Remove a mark from the map. */
   removeMark(el, record = true) {
     if (!el) return;
-    if (this.selectedList && el.dataset.zone) {
-      this.selectedList.querySelector(`[data-id="${el.dataset.id}"]`)?.remove();
-    }
     const tr = el.getAttribute('transform');
     const m = /translate\(([-\d.]+),([-\d.]+)\)/.exec(tr) || [0, 0, 0];
     const data = {
@@ -600,7 +588,6 @@ export default class BodyMap {
       this.brushLayer.innerHTML = '';
       this.burns.clear();
       this.zoneMap.forEach(z => z.classList.remove('burned'));
-      this.selectedList && (this.selectedList.innerHTML = '');
       this.undoStack = [];
       this.redoStack = [];
       (data.marks || []).forEach(m => this.addMark(m.x, m.y, m.type, m.side, m.zone, m.id, false));


### PR DESCRIPTION
## Summary
- stop tracking selected body zones when adding marks
- drop unused selected locations container from body map UI

## Testing
- `npm run lint`
- `npm test`
- `npm run test:server`
- `npm run test:client`


------
https://chatgpt.com/codex/tasks/task_e_68ac7cabf2648320854ff454ab5a7105