### PR TITLE
Refine burn zones for body map

### DIFF
--- a/docs/js/bodyMapZones.js
+++ b/docs/js/bodyMapZones.js
@@ -1,4 +1,17 @@
 export default [
-  { id: 'front', side: 'front', path: 'M0 0h48v48H0z', area: 50, label: 'Priekis' },
-  { id: 'back', side: 'back', path: 'M0 0h48v48H0z', area: 50, label: 'Nugara' }
+  // Front zones
+  { id: 'front-head', side: 'front', path: 'M18 0h12v12H18z', area: 4.5, label: 'Galva (priekis)' },
+  { id: 'front-torso', side: 'front', path: 'M12 12h24v18H12z', area: 18, label: 'Liemuo (priekis)' },
+  { id: 'front-left-arm', side: 'front', path: 'M0 12h12v18H0z', area: 4.5, label: 'Kairė ranka (priekis)' },
+  { id: 'front-right-arm', side: 'front', path: 'M36 12h12v18H36z', area: 4.5, label: 'Dešinė ranka (priekis)' },
+  { id: 'front-left-leg', side: 'front', path: 'M14 30h10v18H14z', area: 9, label: 'Kairė koja (priekis)' },
+  { id: 'front-right-leg', side: 'front', path: 'M24 30h10v18H24z', area: 9, label: 'Dešinė koja (priekis)' },
+
+  // Back zones
+  { id: 'back-head', side: 'back', path: 'M18 0h12v12H18z', area: 4.5, label: 'Galva (nugara)' },
+  { id: 'back-torso', side: 'back', path: 'M12 12h24v18H12z', area: 18, label: 'Liemuo (nugara)' },
+  { id: 'back-left-arm', side: 'back', path: 'M0 12h12v18H0z', area: 4.5, label: 'Kairė ranka (nugara)' },
+  { id: 'back-right-arm', side: 'back', path: 'M36 12h12v18H36z', area: 4.5, label: 'Dešinė ranka (nugara)' },
+  { id: 'back-left-leg', side: 'back', path: 'M14 30h10v18H14z', area: 9, label: 'Kairė koja (nugara)' },
+  { id: 'back-right-leg', side: 'back', path: 'M24 30h10v18H24z', area: 9, label: 'Dešinė koja (nugara)' }
 ];

--- a/public/js/__fixtures__/zoneConfig.js
+++ b/public/js/__fixtures__/zoneConfig.js
@@ -1,4 +1,14 @@
 export default [
-  { id: 'front', side: 'front', path: 'M0 0h10v10H0z', area: 50, label: 'Priekis' },
-  { id: 'back', side: 'back', path: 'M0 0h10v10H0z', area: 50, label: 'Nugara' }
+  { id: 'front-head', side: 'front', path: 'M4 0h2v2H4z', area: 4.5, label: 'Galva (priekis)' },
+  { id: 'front-torso', side: 'front', path: 'M3 3h4v4H3z', area: 18, label: 'Liemuo (priekis)' },
+  { id: 'front-left-arm', side: 'front', path: 'M0 3h3v4H0z', area: 4.5, label: 'Kairė ranka (priekis)' },
+  { id: 'front-right-arm', side: 'front', path: 'M7 3h3v4H7z', area: 4.5, label: 'Dešinė ranka (priekis)' },
+  { id: 'front-left-leg', side: 'front', path: 'M3 7h2v3H3z', area: 9, label: 'Kairė koja (priekis)' },
+  { id: 'front-right-leg', side: 'front', path: 'M5 7h2v3H5z', area: 9, label: 'Dešinė koja (priekis)' },
+  { id: 'back-head', side: 'back', path: 'M4 0h2v2H4z', area: 4.5, label: 'Galva (nugara)' },
+  { id: 'back-torso', side: 'back', path: 'M3 3h4v4H3z', area: 18, label: 'Liemuo (nugara)' },
+  { id: 'back-left-arm', side: 'back', path: 'M0 3h3v4H0z', area: 4.5, label: 'Kairė ranka (nugara)' },
+  { id: 'back-right-arm', side: 'back', path: 'M7 3h3v4H7z', area: 4.5, label: 'Dešinė ranka (nugara)' },
+  { id: 'back-left-leg', side: 'back', path: 'M3 7h2v3H3z', area: 9, label: 'Kairė koja (nugara)' },
+  { id: 'back-right-leg', side: 'back', path: 'M5 7h2v3H5z', area: 9, label: 'Dešinė koja (nugara)' }
 ];

--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -2,7 +2,8 @@ import zones from '../bodyMapZones.js';
 import BodyMap from '../components/BodyMap.js';
 import { TOOLS } from '../BodyMapTools.js';
 
-const frontZone = zones.find(z => z.id === 'front');
+// Use the torso zone for tests
+const frontZone = zones.find(z => z.id === 'front-torso');
 
 function setupDom() {
   document.body.innerHTML = `
@@ -27,12 +28,12 @@ describe('BodyMap instance', () => {
     setupDom();
     const bm = new BodyMap();
     bm.init(() => {});
-    bm.addMark(10, 20, TOOLS.WOUND.char, 'front', 'front');
+    bm.addMark(10, 20, TOOLS.WOUND.char, 'front', 'front-torso');
     const mark = document.querySelector('#marks use');
-    expect(mark.dataset.zone).toBe('front');
+    expect(mark.dataset.zone).toBe('front-torso');
     expect(mark.getAttribute('href')).toBe(TOOLS.WOUND.symbol);
     const data = JSON.parse(bm.serialize());
-    expect(data.marks[0]).toMatchObject({ x: 10, y: 20, type: TOOLS.WOUND.char, side: 'front', zone: 'front' });
+    expect(data.marks[0]).toMatchObject({ x: 10, y: 20, type: TOOLS.WOUND.char, side: 'front', zone: 'front-torso' });
   });
 
   test('load restores marks and burn zones', () => {
@@ -41,29 +42,29 @@ describe('BodyMap instance', () => {
     bm.init(() => {});
     bm.load({
       tool: TOOLS.WOUND.char,
-      marks: [{ id: 1, x: 5, y: 5, type: TOOLS.WOUND.char, side: 'front', zone: 'front' }],
-      burns: [{ zone: 'front', side: 'front' }]
+      marks: [{ id: 1, x: 5, y: 5, type: TOOLS.WOUND.char, side: 'front', zone: 'front-torso' }],
+      burns: [{ zone: 'front-torso', side: 'front' }]
     });
-    const zone = document.querySelector('.zone[data-zone="front"]');
+    const zone = document.querySelector('.zone[data-zone="front-torso"]');
     expect(document.querySelectorAll('#marks use').length).toBe(1);
     expect(zone.classList.contains('burned')).toBe(true);
     expect(bm.counts().burned).toBe(frontZone.area);
     const serialized = JSON.parse(bm.serialize());
-    expect(serialized.burns[0].zone).toBe('front');
+    expect(serialized.burns[0].zone).toBe('front-torso');
   });
 
   test('zoneCounts aggregates marks and burn area', () => {
     setupDom();
     const bm = new BodyMap();
     bm.init(() => {});
-    bm.addMark(1, 1, TOOLS.WOUND.char, 'front', 'front');
+    bm.addMark(1, 1, TOOLS.WOUND.char, 'front', 'front-torso');
     bm.setTool(TOOLS.BURN.char);
-    const zone = document.querySelector('.zone[data-zone="front"]');
+    const zone = document.querySelector('.zone[data-zone="front-torso"]');
     zone.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     const z = bm.zoneCounts();
-    expect(z['front'][TOOLS.WOUND.char]).toBe(1);
-    expect(z['front'].burned).toBe(frontZone.area);
-    expect(z['front'].label).toBe(frontZone.label);
+    expect(z['front-torso'][TOOLS.WOUND.char]).toBe(1);
+    expect(z['front-torso'].burned).toBe(frontZone.area);
+    expect(z['front-torso'].label).toBe(frontZone.label);
     expect(document.getElementById('burnTotal').textContent).toBe(`Nudegimai: ${frontZone.area}%`);
   });
 
@@ -72,11 +73,11 @@ describe('BodyMap instance', () => {
     const save = jest.fn();
     const bm = new BodyMap();
     bm.init(save);
-    bm.toggleZoneBurn('front');
-    const zone = document.querySelector('.zone[data-zone="front"]');
+    bm.toggleZoneBurn('front-torso');
+    const zone = document.querySelector('.zone[data-zone="front-torso"]');
     expect(zone.classList.contains('burned')).toBe(true);
     expect(save).toHaveBeenCalledTimes(1);
-    bm.toggleZoneBurn('front');
+    bm.toggleZoneBurn('front-torso');
     expect(zone.classList.contains('burned')).toBe(false);
     expect(save).toHaveBeenCalledTimes(2);
   });
@@ -102,7 +103,7 @@ describe('BodyMap instance', () => {
     bm.init(save);
     bm.init(save);
     bm.setTool(TOOLS.BURN.char);
-    const zone = document.querySelector('.zone[data-zone="front"]');
+    const zone = document.querySelector('.zone[data-zone="front-torso"]');
     zone.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(zone.classList.contains('burned')).toBe(true);
     expect(save).toHaveBeenCalledTimes(1);
@@ -150,7 +151,7 @@ describe('BodyMap instance', () => {
     expect(bm.brushLayer.childElementCount).toBe(0);
 
     // inside body -> brush added
-    const zone = document.querySelector('.zone[data-zone="front"]');
+    const zone = document.querySelector('.zone[data-zone="front-torso"]');
     zone.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
     document.dispatchEvent(new MouseEvent('pointerup'));
     expect(bm.brushLayer.childElementCount).toBe(1);

--- a/public/js/bodyMapZones.js
+++ b/public/js/bodyMapZones.js
@@ -1,4 +1,17 @@
 export default [
-  { id: 'front', side: 'front', path: 'M0 0h48v48H0z', area: 50, label: 'Priekis' },
-  { id: 'back', side: 'back', path: 'M0 0h48v48H0z', area: 50, label: 'Nugara' }
+  // Front zones
+  { id: 'front-head', side: 'front', path: 'M18 0h12v12H18z', area: 4.5, label: 'Galva (priekis)' },
+  { id: 'front-torso', side: 'front', path: 'M12 12h24v18H12z', area: 18, label: 'Liemuo (priekis)' },
+  { id: 'front-left-arm', side: 'front', path: 'M0 12h12v18H0z', area: 4.5, label: 'Kairė ranka (priekis)' },
+  { id: 'front-right-arm', side: 'front', path: 'M36 12h12v18H36z', area: 4.5, label: 'Dešinė ranka (priekis)' },
+  { id: 'front-left-leg', side: 'front', path: 'M14 30h10v18H14z', area: 9, label: 'Kairė koja (priekis)' },
+  { id: 'front-right-leg', side: 'front', path: 'M24 30h10v18H24z', area: 9, label: 'Dešinė koja (priekis)' },
+
+  // Back zones
+  { id: 'back-head', side: 'back', path: 'M18 0h12v12H18z', area: 4.5, label: 'Galva (nugara)' },
+  { id: 'back-torso', side: 'back', path: 'M12 12h24v18H12z', area: 18, label: 'Liemuo (nugara)' },
+  { id: 'back-left-arm', side: 'back', path: 'M0 12h12v18H0z', area: 4.5, label: 'Kairė ranka (nugara)' },
+  { id: 'back-right-arm', side: 'back', path: 'M36 12h12v18H36z', area: 4.5, label: 'Dešinė ranka (nugara)' },
+  { id: 'back-left-leg', side: 'back', path: 'M14 30h10v18H14z', area: 9, label: 'Kairė koja (nugara)' },
+  { id: 'back-right-leg', side: 'back', path: 'M24 30h10v18H24z', area: 9, label: 'Dešinė koja (nugara)' }
 ];


### PR DESCRIPTION
## Summary
- Subdivide body map into specific front and back zones for burns
- Adjust tests to use new torso zone

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac8100077883209bf6a98699d8008f