### PR TITLE
Add screen-reader activation status to top bar

### DIFF
--- a/public/assets/partials/topbar.html
+++ b/public/assets/partials/topbar.html
@@ -7,7 +7,7 @@
     </button>
     <div>
       <h1>Sunkios traumos forma</h1>
-      <div class="sub">Aktyvacija · ABCE · Santrauka <span id="activationIndicator" class="activation-dot"></span></div>
+      <div class="sub">Aktyvacija · ABCE · Santrauka <span id="activationIndicator" class="activation-dot"></span><span id="activationStatusText" class="sr-only" aria-live="polite"></span></div>
     </div>
   </div>
   <div class="header-center">

--- a/public/css/scss/_components.scss
+++ b/public/css/scss/_components.scss
@@ -58,9 +58,10 @@ section[data-tab="B – Kvėpavimas"] h3:first-of-type{margin-top:0}
 input.invalid,select.invalid{border-color:var(--red)}
       .badge{padding:$space-2 $space-8;border-radius:$space-8;font-size:$font-xs;border:1px solid var(--line);background:#152231;color:var(--muted)}
   .activation-dot{width:0.75rem;height:0.75rem;border-radius:50%;display:none;margin-left:$space-8}
-.activation-dot.red{background:var(--red);display:inline-block}
-.activation-dot.yellow{background:var(--yellow);display:inline-block}
-      #saveStatus{color:var(--muted);font-size:$font-sm;margin-top:$space-4}
+  .activation-dot.red{background:var(--red);display:inline-block}
+  .activation-dot.yellow{background:var(--yellow);display:inline-block}
+  #activationStatusText{@extend .sr-only !optional}
+        #saveStatus{color:var(--muted);font-size:$font-sm;margin-top:$space-4}
 #saveStatus.offline{color:var(--yellow)}
 #saveStatus.offline::before{content:'⚠ ';}
 .split{display:flex;gap:$space-12;flex-wrap:wrap}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -108,12 +108,22 @@ function ensureSingleTeam(){
 }
 function updateActivationIndicator(){
   const dot=$('#activationIndicator');
+  const status=$('#activationStatusText');
   const redActive=$$('.chip.active', $('#chips_red')).length>0;
   const yellowActive=$$('.chip.active', $('#chips_yellow')).length>0;
   dot.classList.remove('red','yellow');
   dot.style.display='none';
-  if(redActive){ dot.classList.add('red'); dot.style.display='inline-block'; }
-  else if(yellowActive){ dot.classList.add('yellow'); dot.style.display='inline-block'; }
+  let text='No team activated';
+  if(redActive){
+    dot.classList.add('red');
+    dot.style.display='inline-block';
+    text='Red team activated';
+  } else if(yellowActive){
+    dot.classList.add('yellow');
+    dot.style.display='inline-block';
+    text='Yellow team activated';
+  }
+  if(status) status.textContent=text;
 }
 function setupActivationControls(){
   const redGroup=$('#chips_red');


### PR DESCRIPTION
## Summary
- announce activation status text to assistive tech
- update indicator logic to sync color and status text
- hide status text with sr-only utility class

## Testing
- `npm test`
- `npm run lint`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68ac852f3f808320a7ac5a94def09c87