### PR TITLE
refactor: centralize team roles

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -14,6 +14,7 @@ import bodyMap from './bodyMap.js';
 import { initARBodyMap } from './arBodyMap.js';
 import { generateReport, gksSum } from './report.js';
 import { setupHeaderActions } from './headerActions.js';
+import { TEAM_ROLES } from './constants.js';
 export { validateVitals };
 
 /* ===== Imaging / Labs / Team ===== */
@@ -21,7 +22,6 @@ const IMG_CT=['Galvos KT','Kaklo KT','Viso kūno KT'];
 const IMG_XRAY=['Krūtinės Ro','Dubens Ro'];
 const LABS=['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
 const BLOOD_GROUPS=['0-','0+','A-','A+','B-','B+','AB-','AB+'];
-const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas'];
 
 const imgCtWrap=$('#imaging_ct'); IMG_CT.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); imgCtWrap.appendChild(s);});
 const imgXrayWrap=$('#imaging_xray'); IMG_XRAY.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); imgXrayWrap.appendChild(s);});

--- a/docs/js/constants.js
+++ b/docs/js/constants.js
@@ -1,0 +1,11 @@
+export const TEAM_ROLES = [
+  'Komandos vadovas',
+  'Raštininkas',
+  'ED gydytojas 1',
+  'ED gydytojas 2',
+  'Slaugytoja 1',
+  'Slaugytoja 2',
+  'Anesteziologas',
+  'Chirurgas',
+  'Ortopedas'
+];

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -1,8 +1,8 @@
 import { $ } from './utils.js';
 import { listChips } from './chips.js';
 import bodyMap, { TOOLS } from './bodyMap.js';
+import { TEAM_ROLES } from './constants.js';
 
-const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas'];
 const fastAreas=[
   {name:'Perikardas', marker:'skystis'},
   {name:'Dešinė pleura', marker:'skystis ar oras'},

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -14,6 +14,7 @@ import bodyMap from './bodyMap.js';
 import { initARBodyMap } from './arBodyMap.js';
 import { generateReport, gksSum } from './report.js';
 import { setupHeaderActions } from './headerActions.js';
+import { TEAM_ROLES } from './constants.js';
 export { validateVitals };
 
 /* ===== Imaging / Labs / Team ===== */
@@ -21,7 +22,6 @@ const IMG_CT=['Galvos KT','Kaklo KT','Viso kūno KT'];
 const IMG_XRAY=['Krūtinės Ro','Dubens Ro'];
 const LABS=['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
 const BLOOD_GROUPS=['0-','0+','A-','A+','B-','B+','AB-','AB+'];
-const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas'];
 const LS_MECHANISM_KEY='traumos_mechanizmai';
 
 const imgCtWrap=$('#imaging_ct'); IMG_CT.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); imgCtWrap.appendChild(s);});

--- a/public/js/constants.js
+++ b/public/js/constants.js
@@ -1,0 +1,11 @@
+export const TEAM_ROLES = [
+  'Komandos vadovas',
+  'Raštininkas',
+  'ED gydytojas 1',
+  'ED gydytojas 2',
+  'Slaugytoja 1',
+  'Slaugytoja 2',
+  'Anesteziologas',
+  'Chirurgas',
+  'Ortopedas'
+];

--- a/public/js/report.js
+++ b/public/js/report.js
@@ -1,8 +1,8 @@
 import { $ } from './utils.js';
 import { listChips } from './chips.js';
 import bodyMap, { TOOLS } from './bodyMap.js';
+import { TEAM_ROLES } from './constants.js';
 
-const TEAM_ROLES=['Komandos vadovas','Raštininkas','ED gydytojas 1','ED gydytojas 2','Slaugytoja 1','Slaugytoja 2','Anesteziologas','Chirurgas','Ortopedas'];
 const fastAreas=[
   {name:'Perikardas', marker:'skystis'},
   {name:'Dešinė pleura', marker:'skystis ar oras'},


### PR DESCRIPTION
## Summary
- Extract shared `TEAM_ROLES` array into `constants.js`
- Replace inline team role arrays with imports in `app.js` and `report.js`
- Mirror constants usage in public JS bundle

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad58e21b2c8320b979b800b368ed9d