### PR TITLE
Use CDN Socket.IO client and explicit backend URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -484,7 +484,7 @@
 </main>
 
 <script src="https://unpkg.com/vis-timeline@8.3.0/standalone/umd/vis-timeline-graph2d.min.js"></script>
-<script src="/socket.io/socket.io.js"></script>
+<script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
 <script src="js/app.js" defer type="module"></script>
 </body>
 </html>

--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -5,6 +5,7 @@ import bodyMap from './bodyMap.js';
 
 let authToken = localStorage.getItem('trauma_token') || null;
 let socket = null;
+const socketEndpoint = window.SOCKET_URL || 'https://your-backend.example.com';
 let currentSessionId = localStorage.getItem('trauma_current_session') || null;
 
 function updateUserList(users){
@@ -31,7 +32,7 @@ export function initTheme(){
 
 export function connectSocket(){
   if(typeof io === 'undefined' || socket || !authToken) return;
-  socket = io({ auth: { token: 'Bearer '+authToken } });
+  socket = io(socketEndpoint, { auth: { token: 'Bearer ' + authToken } });
   socket.on('sessions', list => {
     const sel = $('#sessionSelect');
     if(sel) populateSessionSelect(sel, list);

--- a/public/index.html
+++ b/public/index.html
@@ -484,7 +484,7 @@
 </main>
 
 <script src="https://unpkg.com/vis-timeline@8.3.0/standalone/umd/vis-timeline-graph2d.min.js"></script>
-<script src="/socket.io/socket.io.js"></script>
+<script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
 <script src="js/app.js" defer type="module"></script>
 </body>
 </html>

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -6,6 +6,7 @@ import { serializeAR, loadAR } from './arBodyMap.js';
 
 let authToken = localStorage.getItem('trauma_token') || null;
 let socket = null;
+const socketEndpoint = window.SOCKET_URL || 'https://your-backend.example.com';
 let currentSessionId = localStorage.getItem('trauma_current_session') || null;
 
 function updateUserList(users){
@@ -32,7 +33,7 @@ export function initTheme(){
 
 export function connectSocket(){
   if(typeof io === 'undefined' || socket || !authToken) return;
-  socket = io({ auth: { token: 'Bearer '+authToken } });
+  socket = io(socketEndpoint, { auth: { token: 'Bearer ' + authToken } });
   socket.on('sessions', list => {
     const sel = $('#sessionSelect');
     if(sel) populateSessionSelect(sel, list);


### PR DESCRIPTION
## Summary
- Load the Socket.IO client from a CDN instead of the default `/socket.io/socket.io.js` path.
- Connect the session manager to a configurable backend URL rather than assuming a local Socket.IO endpoint.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5a577fbc8320a77ed401b1429449