### PR TITLE
Use setAnimationLoop for AR rendering

### DIFF
--- a/docs/js/arBodyMap.js
+++ b/docs/js/arBodyMap.js
@@ -71,16 +71,15 @@ export function initARBodyMap(onChange){
         };
         session.addEventListener('select', onSelect);
 
-      const loop = (t,frame) => {
-        session.requestAnimationFrame(loop);
+      renderer.setAnimationLoop((t, frame) => {
         const pose = frame.getViewerPose(refSpace);
-        if(pose){
-          renderer.render(scene,camera);
+        if (pose) {
+          renderer.render(scene, camera);
         }
-      };
-      session.requestAnimationFrame(loop);
+      });
 
       session.addEventListener('end', () => {
+        renderer.setAnimationLoop(null);
         canvas.remove();
         btn.classList.remove('active');
         session = null;

--- a/public/js/arBodyMap.js
+++ b/public/js/arBodyMap.js
@@ -71,16 +71,15 @@ export function initARBodyMap(onChange){
         };
         session.addEventListener('select', onSelect);
 
-      const loop = (t,frame) => {
-        session.requestAnimationFrame(loop);
+      renderer.setAnimationLoop((t, frame) => {
         const pose = frame.getViewerPose(refSpace);
-        if(pose){
-          renderer.render(scene,camera);
+        if (pose) {
+          renderer.render(scene, camera);
         }
-      };
-      session.requestAnimationFrame(loop);
+      });
 
       session.addEventListener('end', () => {
+        renderer.setAnimationLoop(null);
         canvas.remove();
         btn.classList.remove('active');
         session = null;


### PR DESCRIPTION
## Summary
- replace manual `session.requestAnimationFrame` loop with `renderer.setAnimationLoop`
- stop animation loop and remove AR canvas when session ends

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad7ddb93808320b28f8164a5ee4b28