### PR TITLE
Handle HTTP errors when saving session data

### DIFF
--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -223,16 +223,11 @@ export function saveAll(){
       method: 'PUT',
       headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + authToken },
       body: JSON.stringify(data)
-    }).then(()=>{
-      if(statusEl){
-        statusEl.textContent='Saved';
-        statusEl.classList.remove('offline');
-      }
-    }).catch(()=>{
-      if(statusEl){
-        statusEl.textContent='Save failed';
-        statusEl.classList.add('offline');
-      }
+    }).then(res => {
+      if(!res.ok) throw new Error(res.status);
+      if(statusEl){ statusEl.textContent='Saved'; statusEl.classList.remove('offline'); }
+    }).catch(() => {
+      if(statusEl){ statusEl.textContent='Save failed'; statusEl.classList.add('offline'); }
     });
   } else if(statusEl){
     statusEl.textContent='Saved';


### PR DESCRIPTION
## Summary
- Treat non-OK responses from saveAll fetch call as failures
- Update status element to show save failures

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad8cf20d308320b9cb0e7ccc8af5de