### PR TITLE
Handle non-OK responses in session load fetch

### DIFF
--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -275,7 +275,8 @@ export function loadAll(){
   };
   if(authToken && typeof fetch === 'function'){
     fetch(`/api/sessions/${currentSessionId}/data`, { headers:{ 'Authorization': 'Bearer ' + authToken }})
-      .then(r=>r.json()).then(d=>{ localStorage.setItem(sessionKey(), JSON.stringify(d)); apply(d); })
+      .then(r=>{ if(!r.ok) throw new Error(r.status); return r.json(); })
+      .then(d=>{ localStorage.setItem(sessionKey(), JSON.stringify(d)); apply(d); })
       .catch(fallback);
   } else {
     fallback();


### PR DESCRIPTION
## Summary
- Ensure loadAll fetch throws on non-OK responses
- Continue to fallback to local storage on any fetch error

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad912b67048320a829ba3f13d4de37