### PR TITLE
Handle missing session select element

### DIFF
--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -85,6 +85,7 @@ function populateSessionSelect(sel, sessions){
 
 export async function initSessions(){
   const select=$('#sessionSelect');
+  if(!select) return;
   let sessions=await getSessions();
   let delWrap=$('#sessionDeleteList');
   if(!delWrap){


### PR DESCRIPTION
## Summary
- guard `initSessions` against missing `#sessionSelect`

## Testing
- `npm run test:client`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68ada1b7a79c83208377aa778767221e