### PR TITLE
Improve body map realism

### DIFF
--- a/docs/js/bodyMapZones.js
+++ b/docs/js/bodyMapZones.js
@@ -1,17 +1,17 @@
 export default [
   // Front zones
-  { id: 'front-head', side: 'front', path: 'M18 0h12v12H18z', area: 4.5, label: 'Galva (priekis)' },
-  { id: 'front-torso', side: 'front', path: 'M12 12h24v18H12z', area: 18, label: 'Liemuo (priekis)' },
-  { id: 'front-left-arm', side: 'front', path: 'M0 12h12v18H0z', area: 4.5, label: 'Kairė ranka (priekis)' },
-  { id: 'front-right-arm', side: 'front', path: 'M36 12h12v18H36z', area: 4.5, label: 'Dešinė ranka (priekis)' },
-  { id: 'front-left-leg', side: 'front', path: 'M14 30h10v18H14z', area: 9, label: 'Kairė koja (priekis)' },
-  { id: 'front-right-leg', side: 'front', path: 'M24 30h10v18H24z', area: 9, label: 'Dešinė koja (priekis)' },
+  { id: 'front-head', side: 'front', path: 'M24 0a6 6 0 1 1 0 12a6 6 0 1 1 0-12z', area: 4.5, label: 'Galva (priekis)' },
+  { id: 'front-torso', side: 'front', path: 'M14 12c0-2 4-4 10-4s10 2 10 4v18c0 2-4 4-10 4s-10-2-10-4z', area: 18, label: 'Liemuo (priekis)' },
+  { id: 'front-left-arm', side: 'front', path: 'M0 12c-2 4-2 14 0 18h8V12z', area: 4.5, label: 'Kairė ranka (priekis)' },
+  { id: 'front-right-arm', side: 'front', path: 'M48 12c2 4 2 14 0 18h-8V12z', area: 4.5, label: 'Dešinė ranka (priekis)' },
+  { id: 'front-left-leg', side: 'front', path: 'M14 30v18h8V34c0-2-2-4-4-4z', area: 9, label: 'Kairė koja (priekis)' },
+  { id: 'front-right-leg', side: 'front', path: 'M26 30v18h8V34c0-2-2-4-4-4z', area: 9, label: 'Dešinė koja (priekis)' },
 
   // Back zones
-  { id: 'back-head', side: 'back', path: 'M18 0h12v12H18z', area: 4.5, label: 'Galva (nugara)' },
-  { id: 'back-torso', side: 'back', path: 'M12 12h24v18H12z', area: 18, label: 'Liemuo (nugara)' },
-  { id: 'back-left-arm', side: 'back', path: 'M0 12h12v18H0z', area: 4.5, label: 'Kairė ranka (nugara)' },
-  { id: 'back-right-arm', side: 'back', path: 'M36 12h12v18H36z', area: 4.5, label: 'Dešinė ranka (nugara)' },
-  { id: 'back-left-leg', side: 'back', path: 'M14 30h10v18H14z', area: 9, label: 'Kairė koja (nugara)' },
-  { id: 'back-right-leg', side: 'back', path: 'M24 30h10v18H24z', area: 9, label: 'Dešinė koja (nugara)' }
+  { id: 'back-head', side: 'back', path: 'M24 0a6 6 0 1 1 0 12a6 6 0 1 1 0-12z', area: 4.5, label: 'Galva (nugara)' },
+  { id: 'back-torso', side: 'back', path: 'M14 12c0-2 4-4 10-4s10 2 10 4v18c0 2-4 4-10 4s-10-2-10-4z', area: 18, label: 'Liemuo (nugara)' },
+  { id: 'back-left-arm', side: 'back', path: 'M0 12c-2 4-2 14 0 18h8V12z', area: 4.5, label: 'Kairė ranka (nugara)' },
+  { id: 'back-right-arm', side: 'back', path: 'M48 12c2 4 2 14 0 18h-8V12z', area: 4.5, label: 'Dešinė ranka (nugara)' },
+  { id: 'back-left-leg', side: 'back', path: 'M14 30v18h8V34c0-2-2-4-4-4z', area: 9, label: 'Kairė koja (nugara)' },
+  { id: 'back-right-leg', side: 'back', path: 'M26 30v18h8V34c0-2-2-4-4-4z', area: 9, label: 'Dešinė koja (nugara)' }
 ];

--- a/public/js/bodyMapZones.js
+++ b/public/js/bodyMapZones.js
@@ -1,17 +1,17 @@
 export default [
   // Front zones
-  { id: 'front-head', side: 'front', path: 'M18 0h12v12H18z', area: 4.5, label: 'Galva (priekis)' },
-  { id: 'front-torso', side: 'front', path: 'M12 12h24v18H12z', area: 18, label: 'Liemuo (priekis)' },
-  { id: 'front-left-arm', side: 'front', path: 'M0 12h12v18H0z', area: 4.5, label: 'Kairė ranka (priekis)' },
-  { id: 'front-right-arm', side: 'front', path: 'M36 12h12v18H36z', area: 4.5, label: 'Dešinė ranka (priekis)' },
-  { id: 'front-left-leg', side: 'front', path: 'M14 30h10v18H14z', area: 9, label: 'Kairė koja (priekis)' },
-  { id: 'front-right-leg', side: 'front', path: 'M24 30h10v18H24z', area: 9, label: 'Dešinė koja (priekis)' },
+  { id: 'front-head', side: 'front', path: 'M24 0a6 6 0 1 1 0 12a6 6 0 1 1 0-12z', area: 4.5, label: 'Galva (priekis)' },
+  { id: 'front-torso', side: 'front', path: 'M14 12c0-2 4-4 10-4s10 2 10 4v18c0 2-4 4-10 4s-10-2-10-4z', area: 18, label: 'Liemuo (priekis)' },
+  { id: 'front-left-arm', side: 'front', path: 'M0 12c-2 4-2 14 0 18h8V12z', area: 4.5, label: 'Kairė ranka (priekis)' },
+  { id: 'front-right-arm', side: 'front', path: 'M48 12c2 4 2 14 0 18h-8V12z', area: 4.5, label: 'Dešinė ranka (priekis)' },
+  { id: 'front-left-leg', side: 'front', path: 'M14 30v18h8V34c0-2-2-4-4-4z', area: 9, label: 'Kairė koja (priekis)' },
+  { id: 'front-right-leg', side: 'front', path: 'M26 30v18h8V34c0-2-2-4-4-4z', area: 9, label: 'Dešinė koja (priekis)' },
 
   // Back zones
-  { id: 'back-head', side: 'back', path: 'M18 0h12v12H18z', area: 4.5, label: 'Galva (nugara)' },
-  { id: 'back-torso', side: 'back', path: 'M12 12h24v18H12z', area: 18, label: 'Liemuo (nugara)' },
-  { id: 'back-left-arm', side: 'back', path: 'M0 12h12v18H0z', area: 4.5, label: 'Kairė ranka (nugara)' },
-  { id: 'back-right-arm', side: 'back', path: 'M36 12h12v18H36z', area: 4.5, label: 'Dešinė ranka (nugara)' },
-  { id: 'back-left-leg', side: 'back', path: 'M14 30h10v18H14z', area: 9, label: 'Kairė koja (nugara)' },
-  { id: 'back-right-leg', side: 'back', path: 'M24 30h10v18H24z', area: 9, label: 'Dešinė koja (nugara)' }
+  { id: 'back-head', side: 'back', path: 'M24 0a6 6 0 1 1 0 12a6 6 0 1 1 0-12z', area: 4.5, label: 'Galva (nugara)' },
+  { id: 'back-torso', side: 'back', path: 'M14 12c0-2 4-4 10-4s10 2 10 4v18c0 2-4 4-10 4s-10-2-10-4z', area: 18, label: 'Liemuo (nugara)' },
+  { id: 'back-left-arm', side: 'back', path: 'M0 12c-2 4-2 14 0 18h8V12z', area: 4.5, label: 'Kairė ranka (nugara)' },
+  { id: 'back-right-arm', side: 'back', path: 'M48 12c2 4 2 14 0 18h-8V12z', area: 4.5, label: 'Dešinė ranka (nugara)' },
+  { id: 'back-left-leg', side: 'back', path: 'M14 30v18h8V34c0-2-2-4-4-4z', area: 9, label: 'Kairė koja (nugara)' },
+  { id: 'back-right-leg', side: 'back', path: 'M26 30v18h8V34c0-2-2-4-4-4z', area: 9, label: 'Dešinė koja (nugara)' }
 ];


### PR DESCRIPTION
## Summary
- refine body map zone paths to better match human silhouette
- keep public and docs versions in sync

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ada8bfc71c8320ae597160686648f6