### PR TITLE
Trim and validate session rename input

### DIFF
--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -105,22 +105,30 @@ export async function initSessions(){
       rename.textContent='✎';
       rename.className='btn ghost';
       rename.setAttribute('aria-label','Rename session');
-      rename.addEventListener('click',async()=>{
-        const name=await notify({type:'prompt', message:'Naujas pavadinimas', defaultValue:s.name});
-        if(!name) return;
-        s.name=name;
+      rename.addEventListener('click', async () => {
+        const name = (await notify({ type: 'prompt', message: 'Naujas pavadinimas', defaultValue: s.name }))?.trim();
+        if (name == null) return;
+        if (!name) {
+          notify({ type: 'error', message: 'Pavadinimas negali būti tuščias.' });
+          return;
+        }
+        if (sessions.some(x => x.id !== s.id && x.name.toLowerCase() === name.toLowerCase())) {
+          notify({ type: 'error', message: 'Pacientas su tokiu pavadinimu jau egzistuoja.' });
+          return;
+        }
+        s.name = name;
         localStorage.setItem('trauma_sessions', JSON.stringify(sessions));
         populateSessionSelect(select, sessions);
-        if(currentSessionId){ select.value=currentSessionId; }
+        if (currentSessionId) { select.value = currentSessionId; }
         renderDeleteButtons();
-        if(authToken && typeof fetch==='function'){
-          try{
+        if (authToken && typeof fetch === 'function') {
+          try {
             await fetch(`/api/sessions/${s.id}`, {
-              method:'PUT',
-              headers:{ 'Content-Type':'application/json','Authorization':'Bearer '+authToken },
-              body:JSON.stringify({name})
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + authToken },
+              body: JSON.stringify({ name })
             });
-          }catch(e){ console.error(e); }
+          } catch (e) { console.error(e); }
         }
       });
       const btn=document.createElement('button');

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -112,11 +112,12 @@ export async function initSessions(){
           notify({ type: 'error', message: 'Pavadinimas negali būti tuščias.' });
           return;
         }
-        if (sessions.some(x => x.id !== s.id && x.name.trim().toLowerCase() === newName.toLowerCase())) {
+        if (newName === s.name) return;
+        const newNameLower = newName.toLowerCase();
+        if (sessions.some(x => x.id !== s.id && x.name.trim().toLowerCase() === newNameLower)) {
           notify({ type: 'error', message: 'Pacientas su tokiu pavadinimu jau egzistuoja.' });
           return;
         }
-        if (newName === s.name) return;
         s.name = newName;
         saveSessions(sessions);
         populateSessionSelect(select, sessions);

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -106,30 +106,22 @@ export async function initSessions(){
       rename.className='btn ghost';
       rename.setAttribute('aria-label','Rename session');
       rename.addEventListener('click', async () => {
-        const name = (await notify({ type: 'prompt', message: 'Naujas pavadinimas', defaultValue: s.name }))?.trim();
-        if (name == null) return;
-        if (!name) {
+        const newName = (await notify({ type: 'prompt', message: 'Naujas pavadinimas', defaultValue: s.name }))?.trim();
+        if (newName == null) return;
+        if (!newName) {
           notify({ type: 'error', message: 'Pavadinimas negali būti tuščias.' });
           return;
         }
-        if (sessions.some(x => x.id !== s.id && x.name.toLowerCase() === name.toLowerCase())) {
+        if (sessions.some(x => x.id !== s.id && x.name.trim().toLowerCase() === newName.toLowerCase())) {
           notify({ type: 'error', message: 'Pacientas su tokiu pavadinimu jau egzistuoja.' });
           return;
         }
-        s.name = name;
-        localStorage.setItem('trauma_sessions', JSON.stringify(sessions));
+        if (newName === s.name) return;
+        s.name = newName;
+        saveSessions(sessions);
         populateSessionSelect(select, sessions);
         if (currentSessionId) { select.value = currentSessionId; }
         renderDeleteButtons();
-        if (authToken && typeof fetch === 'function') {
-          try {
-            await fetch(`/api/sessions/${s.id}`, {
-              method: 'PUT',
-              headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + authToken },
-              body: JSON.stringify({ name })
-            });
-          } catch (e) { console.error(e); }
-        }
       });
       const btn=document.createElement('button');
       btn.type='button';


### PR DESCRIPTION
## Summary
- Trim session rename input, reject empty or duplicate names
- Alert via `notify` when rename validation fails

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adaa85e1408320952d9df120909f56