### PR TITLE
Embed body map silhouettes when printing

### DIFF
--- a/docs/js/components/BodyMap.js
+++ b/docs/js/components/BodyMap.js
@@ -418,10 +418,12 @@ export default class BodyMap {
     if (this.btnRedo) this.btnRedo.disabled = this.redoStack.length === 0;
   }
 
-  /** Export a self-contained SVG with embedded silhouettes. */
-  async exportSvg() {
-    const clone = this.svg.cloneNode(true);
-    const uses = [...clone.querySelectorAll('use[data-src]')];
+  /**
+   * Replace external <use> references with embedded elements so the
+   * resulting SVG is self-contained.
+   */
+  async embedSilhouettes(svg) {
+    const uses = [...svg.querySelectorAll('use[data-src]')];
     for (const u of uses) {
       const ref = u.dataset.src;
       if (!ref) continue;
@@ -445,8 +447,14 @@ export default class BodyMap {
         console.error(e);
       }
     }
+  }
+
+  /** Export a self-contained SVG with embedded silhouettes. */
+  async exportSvg() {
+    const clone = this.svg.cloneNode(true);
+    await this.embedSilhouettes(clone);
     const style = document.createElement('style');
-      style.textContent = `#bodySvg{display:block;width:100%;height:auto;aspect-ratio:1500/1100;max-width:40rem;max-height:80vh;border:1px solid #2d3b4f;border-radius:0.75rem;background:#0b141e}
+    style.textContent = `#bodySvg{display:block;width:100%;height:auto;aspect-ratio:1500/1100;max-width:40rem;max-height:80vh;border:1px solid #2d3b4f;border-radius:0.75rem;background:#0b141e}
   .silhouette{fill:none;stroke:#c2d0e0;stroke-width:2}
   .mark-w{stroke:#ef5350;stroke-width:3;fill:none}
   .mark-b{fill:#64b5f6}

--- a/docs/js/headerActions.js
+++ b/docs/js/headerActions.js
@@ -3,6 +3,7 @@ import { notify } from './alerts.js';
 import { startArrivalTimer } from './arrival.js';
 import { showTab } from './tabs.js';
 import { sessionKey, getAuthToken, logout } from './sessionManager.js';
+import bodyMap from './bodyMap.js';
 
 export function setupHeaderActions({ validateForm, saveAll }){
   const btnAtvyko=document.getElementById('btnAtvyko');
@@ -46,7 +47,7 @@ export function setupHeaderActions({ validateForm, saveAll }){
   });
 
   const btnPrint=$('#btnPrint');
-  if(btnPrint) btnPrint.addEventListener('click',()=>{
+  if(btnPrint) btnPrint.addEventListener('click', async () => {
     if(!validateForm()) return;
     const prevTab=localStorage.getItem('v10_activeTab');
     showTab('Santrauka');
@@ -58,6 +59,7 @@ export function setupHeaderActions({ validateForm, saveAll }){
       doc.write('<!DOCTYPE html><html><head><meta charset="utf-8"><title>Santrauka</title><link rel="stylesheet" href="/css/main.css"><style>body{font-family:sans-serif;padding:20px;} pre{white-space:pre-wrap;}</style></head><body></body></html>');
       doc.close();
       const svg=doc.importNode(document.getElementById('bodySvg'), true);
+      await bodyMap.embedSilhouettes(svg);
       const front=svg.querySelector('#layer-front');
       const back=svg.querySelector('#layer-back');
       if(front) front.classList.remove('hidden');

--- a/public/js/__tests__/patient.test.js
+++ b/public/js/__tests__/patient.test.js
@@ -143,7 +143,7 @@ describe('patient fields', () => {
     expect(mockSave).toHaveBeenCalledWith('report.pdf');
   });
 
-  test('print window contains body map', () => {
+  test('print window contains body map', async () => {
     const newDoc = document.implementation.createHTMLDocument();
     const win = {
       document: newDoc,
@@ -156,6 +156,7 @@ describe('patient fields', () => {
     document.getElementById('patient_sex').value='M';
     document.getElementById('patient_history').value='H123';
     document.getElementById('btnPrint').click();
+    await new Promise(resolve => setTimeout(resolve, 0));
     expect(openMock).toHaveBeenCalled();
     expect(win.focus).toHaveBeenCalled();
     expect(win.print).toHaveBeenCalled();

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -418,10 +418,12 @@ export default class BodyMap {
     if (this.btnRedo) this.btnRedo.disabled = this.redoStack.length === 0;
   }
 
-  /** Export a self-contained SVG with embedded silhouettes. */
-  async exportSvg() {
-    const clone = this.svg.cloneNode(true);
-    const uses = [...clone.querySelectorAll('use[data-src]')];
+  /**
+   * Replace external <use> references with embedded elements so the
+   * resulting SVG is self-contained.
+   */
+  async embedSilhouettes(svg) {
+    const uses = [...svg.querySelectorAll('use[data-src]')];
     for (const u of uses) {
       const ref = u.dataset.src;
       if (!ref) continue;
@@ -445,8 +447,14 @@ export default class BodyMap {
         console.error(e);
       }
     }
+  }
+
+  /** Export a self-contained SVG with embedded silhouettes. */
+  async exportSvg() {
+    const clone = this.svg.cloneNode(true);
+    await this.embedSilhouettes(clone);
     const style = document.createElement('style');
-      style.textContent = `#bodySvg{display:block;width:100%;height:auto;aspect-ratio:1500/1100;max-width:40rem;max-height:80vh;border:1px solid #2d3b4f;border-radius:0.75rem;background:#0b141e}
+    style.textContent = `#bodySvg{display:block;width:100%;height:auto;aspect-ratio:1500/1100;max-width:40rem;max-height:80vh;border:1px solid #2d3b4f;border-radius:0.75rem;background:#0b141e}
   .silhouette{fill:none;stroke:#c2d0e0;stroke-width:2}
   .mark-w{stroke:#ef5350;stroke-width:3;fill:none}
   .mark-b{fill:#64b5f6}

--- a/public/js/headerActions.js
+++ b/public/js/headerActions.js
@@ -3,6 +3,7 @@ import { notify } from './alerts.js';
 import { startArrivalTimer } from './arrival.js';
 import { showTab } from './tabs.js';
 import { sessionKey, getAuthToken, logout } from './sessionManager.js';
+import bodyMap from './bodyMap.js';
 
 export function setupHeaderActions({ validateForm, saveAll }){
   const btnAtvyko=document.getElementById('btnAtvyko');
@@ -46,7 +47,7 @@ export function setupHeaderActions({ validateForm, saveAll }){
   });
 
   const btnPrint=$('#btnPrint');
-  if(btnPrint) btnPrint.addEventListener('click',()=>{
+  if(btnPrint) btnPrint.addEventListener('click', async () => {
     if(!validateForm()) return;
     const prevTab=localStorage.getItem('v10_activeTab');
     showTab('Santrauka');
@@ -58,6 +59,7 @@ export function setupHeaderActions({ validateForm, saveAll }){
       doc.write('<!DOCTYPE html><html><head><meta charset="utf-8"><title>Santrauka</title><link rel="stylesheet" href="/css/main.css"><style>body{font-family:sans-serif;padding:20px;} pre{white-space:pre-wrap;}</style></head><body></body></html>');
       doc.close();
       const svg=doc.importNode(document.getElementById('bodySvg'), true);
+      await bodyMap.embedSilhouettes(svg);
       const front=svg.querySelector('#layer-front');
       const back=svg.querySelector('#layer-back');
       if(front) front.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- inline external body-map SVG fragments so exported images are self-contained
- ensure print/export flow embeds silhouettes before rendering
- adjust patient print test for async print flow

## Testing
- `npm run test:client`
- `npm run test:server`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adbaff345c8320a68ed93837280443