### PR TITLE
Add tooltip for GMP time input

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -62,7 +62,14 @@
           <div class="grid cols-3 cols-auto mt-8">
               <div class="row"><div class="flex-1"><label for="gmp_sbp">GMP AKS s</label><input id="gmp_sbp" type="number" min="0" max="300" title="AKS s – mmHg, 0–300"></div><div class="flex-1"><label for="gmp_dbp">GMP AKS d</label><input id="gmp_dbp" type="number" min="0" max="200" title="AKS d – mmHg, 0–200"></div></div>
               <div><label>GMP GKS (A-K-M)</label><div class="row"><input id="gmp_gksa" type="number" min="1" max="4" placeholder="A"><input id="gmp_gksk" type="number" min="1" max="5" placeholder="K"><input id="gmp_gksm" type="number" min="1" max="6" placeholder="M"><span id="gmp_gks_total"></span></div></div>
-              <div><label for="gmp_time">GMP pranešimo laikas</label><div class="row"><input id="gmp_time" type="time"><button type="button" class="btn ghost" id="btnGmpNow">Dabar</button></div></div>
+              <div>
+                <label for="gmp_time">GMP pranešimo laikas</label>
+                <div class="row">
+                  <input id="gmp_time" type="time" aria-describedby="gmp_time_hint" title="24 val. formatas (HH:MM)">
+                  <button type="button" class="btn ghost" id="btnGmpNow" aria-describedby="gmp_time_hint" title="Įrašyti dabartinį laiką">Dabar</button>
+                </div>
+                <div class="hint" id="gmp_time_hint">Naudokite 24 val. formatą (HH:MM); mygtukas „Dabar“ įrašo dabartinį laiką.</div>
+              </div>
           </div>
           <div class="grid cols-2 cols-auto mt-8">
               <div>


### PR DESCRIPTION
## Summary
- clarify GMP time entry with a 24-hour format tooltip and hint for "Dabar" button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adbd435e34832083cc6c1134318670