### PR TITLE
feat: add PDF and print buttons to summary

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -478,7 +478,7 @@
     <div id="timelineGraph" class="timeline-graph mb-8"></div>
     <div id="timelineList" class="timeline-list"></div>
   </section>
-    <section class="card view" id="view-santrauka" data-tab="Santrauka"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Santrauka sugeneruojama automatiškai"></textarea><div class="row mb-8"><button type="button" class="btn" id="btnCopyReport">Kopijuoti</button></div><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
+    <section class="card view" id="view-santrauka" data-tab="Santrauka"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Santrauka sugeneruojama automatiškai"></textarea><div class="row mb-8"><button type="button" class="btn" id="btnCopyReport">Kopijuoti</button><button type="button" class="btn" id="btnPdfReport">PDF</button><button type="button" class="btn" id="btnPrintReport">Spausdinti</button></div><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
   </div>
 </main>
 

--- a/docs/js/headerActions.js
+++ b/docs/js/headerActions.js
@@ -28,8 +28,8 @@ export function setupHeaderActions({ validateForm, saveAll }){
   const btnClear=$('#btnClear');
   if(btnClear) btnClear.addEventListener('click',async()=>{ if(await notify({type:'confirm', message:'Išvalyti viską?'})){ localStorage.removeItem(sessionKey()); location.reload(); }});
 
-  const btnPdf=$('#btnPdf');
-  if(btnPdf) btnPdf.addEventListener('click', async () => {
+  const pdfButtons=[$('#btnPdf'), $('#btnPdfReport')].filter(Boolean);
+  pdfButtons.forEach(btn=>btn.addEventListener('click', async () => {
     if(!validateForm()) return;
     showTab('Santrauka');
     const text = $('#output').value || '';
@@ -44,10 +44,10 @@ export function setupHeaderActions({ validateForm, saveAll }){
       notify({message:'Nepavyko sugeneruoti PDF.', type:'error'});
       console.error('PDF generation failed', e);
     }
-  });
+  }));
 
-  const btnPrint=$('#btnPrint');
-  if(btnPrint) btnPrint.addEventListener('click', async () => {
+  const printButtons=[$('#btnPrint'), $('#btnPrintReport')].filter(Boolean);
+  printButtons.forEach(btn=>btn.addEventListener('click', async () => {
     if(!validateForm()) return;
     const prevTab=localStorage.getItem('v10_activeTab');
     showTab('Santrauka');
@@ -75,7 +75,7 @@ export function setupHeaderActions({ validateForm, saveAll }){
       window.print();
     }
     if(prevTab) showTab(prevTab);
-  });
+  }));
 
   const menu=document.querySelector('.more-actions .menu');
   if(menu && getAuthToken() && !document.getElementById('btnLogout')){

--- a/public/index.html
+++ b/public/index.html
@@ -486,7 +486,7 @@
     <div id="timelineGraph" class="timeline-graph mb-8"></div>
     <div id="timelineList" class="timeline-list"></div>
   </section>
-    <section class="card view" id="view-santrauka" data-tab="Santrauka"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Santrauka sugeneruojama automatiškai"></textarea><div class="row mb-8"><button type="button" class="btn" id="btnCopyReport">Kopijuoti</button></div><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
+    <section class="card view" id="view-santrauka" data-tab="Santrauka"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Santrauka sugeneruojama automatiškai"></textarea><div class="row mb-8"><button type="button" class="btn" id="btnCopyReport">Kopijuoti</button><button type="button" class="btn" id="btnPdfReport">PDF</button><button type="button" class="btn" id="btnPrintReport">Spausdinti</button></div><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
   </div>
 </main>
 

--- a/public/js/headerActions.js
+++ b/public/js/headerActions.js
@@ -28,8 +28,8 @@ export function setupHeaderActions({ validateForm, saveAll }){
   const btnClear=$('#btnClear');
   if(btnClear) btnClear.addEventListener('click',async()=>{ if(await notify({type:'confirm', message:'Išvalyti viską?'})){ localStorage.removeItem(sessionKey()); location.reload(); }});
 
-  const btnPdf=$('#btnPdf');
-  if(btnPdf) btnPdf.addEventListener('click', async () => {
+  const pdfButtons=[$('#btnPdf'), $('#btnPdfReport')].filter(Boolean);
+  pdfButtons.forEach(btn=>btn.addEventListener('click', async () => {
     if(!validateForm()) return;
     showTab('Santrauka');
     const text = $('#output').value || '';
@@ -44,10 +44,10 @@ export function setupHeaderActions({ validateForm, saveAll }){
       notify({message:'Nepavyko sugeneruoti PDF.', type:'error'});
       console.error('PDF generation failed', e);
     }
-  });
+  }));
 
-  const btnPrint=$('#btnPrint');
-  if(btnPrint) btnPrint.addEventListener('click', async () => {
+  const printButtons=[$('#btnPrint'), $('#btnPrintReport')].filter(Boolean);
+  printButtons.forEach(btn=>btn.addEventListener('click', async () => {
     if(!validateForm()) return;
     const prevTab=localStorage.getItem('v10_activeTab');
     showTab('Santrauka');
@@ -75,7 +75,7 @@ export function setupHeaderActions({ validateForm, saveAll }){
       window.print();
     }
     if(prevTab) showTab(prevTab);
-  });
+  }));
 
   const menu=document.querySelector('.more-actions .menu');
   if(menu && getAuthToken() && !document.getElementById('btnLogout')){


### PR DESCRIPTION
## Summary
- add PDF and print actions to Santrauka view
- support new summary export buttons in header actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc7eb021c8320b1cba87381bfe2d4