### PR TITLE
Add keyboard support for blood order entry

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -31,7 +31,8 @@ const bloodGroupWrap=$('#bloodGroup'); if(bloodGroupWrap){ BLOOD_GROUPS.forEach(
 const bloodUnitsInput=$('#bloodUnits');
 const addBloodOrderBtn=$('#addBloodOrder');
 if(bloodUnitsInput && bloodGroupWrap && addBloodOrderBtn){
-  addBloodOrderBtn.addEventListener('click',()=>{
+  const addOrder=e=>{
+    e.preventDefault();
     const units=bloodUnitsInput.value.trim();
     const groupEl=$$('.chip',bloodGroupWrap).find(c=>isChipActive(c));
     const group=groupEl?.dataset.value||'';
@@ -47,7 +48,9 @@ if(bloodUnitsInput && bloodGroupWrap && addBloodOrderBtn){
     saveAll();
     bloodUnitsInput.value='';
     $$('.chip',bloodGroupWrap).forEach(c=>setChipActive(c,false));
-  });
+  };
+  addBloodOrderBtn.addEventListener('click',addOrder);
+  bloodUnitsInput.addEventListener('keydown',e=>{ if(e.key==='Enter') addOrder(e); });
 }
 const fastAreas=[
   {name:'Perikardas', marker:'skystis'},


### PR DESCRIPTION
## Summary
- Allow blood orders to be submitted by pressing Enter in the units field

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adc9c477e08320825974b4024e0c44