### PR TITLE
Handle overlapping burn brushes via union area

### DIFF
--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -116,6 +116,18 @@ describe('BodyMap instance', () => {
     expect(bm2.burnArea()).toBeGreaterThan(0);
   });
 
+  test('overlapping burn brushes are counted once', () => {
+    setupDom();
+    const bm = new BodyMap();
+    bm.init(() => {});
+    bm.addBrush(50, 50, 20);
+    const area1 = bm.burnArea();
+    const text1 = bm.burnTotalEl.textContent;
+    bm.addBrush(50, 50, 20);
+    expect(bm.burnArea()).toBeCloseTo(area1);
+    expect(bm.burnTotalEl.textContent).toBe(text1);
+  });
+
   test('burn brush only paints over body zones', () => {
     setupDom();
     const bm = new BodyMap();


### PR DESCRIPTION
## Summary
- Track burn brush coordinates and compute burn percentage using a pixel-grid union algorithm.
- Reflect the new calculation in UI burn display.
- Add regression test ensuring overlapping burn brushes are only counted once.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adcef1f3708320b235c0cbe83a774b