### PR TITLE
feat: compute burn coverage per zone

### DIFF
--- a/docs/js/bodyMapZones.js
+++ b/docs/js/bodyMapZones.js
@@ -1,17 +1,17 @@
 export default [
   // Front zones
-  { id: 'front-head', side: 'front', path: 'M24 3c4 0 7 3 7 7s-3 7-7 7-7-3-7-7 3-7 7-7z', area: 4.5, label: 'Galva (priekis)' },
-  { id: 'front-torso', side: 'front', path: 'M14 16c0-8 10-12 10-12s10 4 10 12v18c0 8-10 12-10 12s-10-4-10-12V16z', area: 18, label: 'Liemuo (priekis)' },
-  { id: 'front-left-arm', side: 'front', path: 'M2 18c-1 6-1 16 0 22h6c1-6 1-16 0-22z', area: 4.5, label: 'Kairė ranka (priekis)' },
-  { id: 'front-right-arm', side: 'front', path: 'M46 18c1 6 1 16 0 22h-6c-1-6-1-16 0-22z', area: 4.5, label: 'Dešinė ranka (priekis)' },
-  { id: 'front-left-leg', side: 'front', path: 'M18 34c-3 4-3 12-3 16h8c0-4 0-12-3-16z', area: 9, label: 'Kairė koja (priekis)' },
-  { id: 'front-right-leg', side: 'front', path: 'M30 34c3 4 3 12 3 16h-8c0-4 0-12 3-16z', area: 9, label: 'Dešinė koja (priekis)' },
+  { id: 'front-head', side: 'front', path: 'M24 3c4 0 7 3 7 7s-3 7-7 7-7-3-7-7 3-7 7-7z', area: 4.5, label: 'Galva (priekis)', bbox: [17, 3, 31, 17] },
+  { id: 'front-torso', side: 'front', path: 'M14 16c0-8 10-12 10-12s10 4 10 12v18c0 8-10 12-10 12s-10-4-10-12V16z', area: 18, label: 'Liemuo (priekis)', bbox: [14, 4, 34, 46] },
+  { id: 'front-left-arm', side: 'front', path: 'M2 18c-1 6-1 16 0 22h6c1-6 1-16 0-22z', area: 4.5, label: 'Kairė ranka (priekis)', bbox: [1.25, 18, 8.75, 40] },
+  { id: 'front-right-arm', side: 'front', path: 'M46 18c1 6 1 16 0 22h-6c-1-6-1-16 0-22z', area: 4.5, label: 'Dešinė ranka (priekis)', bbox: [39.25, 18, 46.75, 40] },
+  { id: 'front-left-leg', side: 'front', path: 'M18 34c-3 4-3 12-3 16h8c0-4 0-12-3-16z', area: 9, label: 'Kairė koja (priekis)', bbox: [15, 34, 23, 50] },
+  { id: 'front-right-leg', side: 'front', path: 'M30 34c3 4 3 12 3 16h-8c0-4 0-12 3-16z', area: 9, label: 'Dešinė koja (priekis)', bbox: [25, 34, 33, 50] },
 
   // Back zones
-  { id: 'back-head', side: 'back', path: 'M24 3c4 0 7 3 7 7s-3 7-7 7-7-3-7-7 3-7 7-7z', area: 4.5, label: 'Galva (nugara)' },
-  { id: 'back-torso', side: 'back', path: 'M14 16c0-8 10-12 10-12s10 4 10 12v18c0 8-10 12-10 12s-10-4-10-12V16z', area: 18, label: 'Liemuo (nugara)' },
-  { id: 'back-left-arm', side: 'back', path: 'M2 18c-1 6-1 16 0 22h6c1-6 1-16 0-22z', area: 4.5, label: 'Kairė ranka (nugara)' },
-  { id: 'back-right-arm', side: 'back', path: 'M46 18c1 6 1 16 0 22h-6c-1-6-1-16 0-22z', area: 4.5, label: 'Dešinė ranka (nugara)' },
-  { id: 'back-left-leg', side: 'back', path: 'M18 34c-3 4-3 12-3 16h8c0-4 0-12-3-16z', area: 9, label: 'Kairė koja (nugara)' },
-  { id: 'back-right-leg', side: 'back', path: 'M30 34c3 4 3 12 3 16h-8c0-4 0-12 3-16z', area: 9, label: 'Dešinė koja (nugara)' },
+  { id: 'back-head', side: 'back', path: 'M24 3c4 0 7 3 7 7s-3 7-7 7-7-3-7-7 3-7 7-7z', area: 4.5, label: 'Galva (nugara)', bbox: [17, 3, 31, 17] },
+  { id: 'back-torso', side: 'back', path: 'M14 16c0-8 10-12 10-12s10 4 10 12v18c0 8-10 12-10 12s-10-4-10-12V16z', area: 18, label: 'Liemuo (nugara)', bbox: [14, 4, 34, 46] },
+  { id: 'back-left-arm', side: 'back', path: 'M2 18c-1 6-1 16 0 22h6c1-6 1-16 0-22z', area: 4.5, label: 'Kairė ranka (nugara)', bbox: [1.25, 18, 8.75, 40] },
+  { id: 'back-right-arm', side: 'back', path: 'M46 18c1 6 1 16 0 22h-6c-1-6-1-16 0-22z', area: 4.5, label: 'Dešinė ranka (nugara)', bbox: [39.25, 18, 46.75, 40] },
+  { id: 'back-left-leg', side: 'back', path: 'M18 34c-3 4-3 12-3 16h8c0-4 0-12-3-16z', area: 9, label: 'Kairė koja (nugara)', bbox: [15, 34, 23, 50] },
+  { id: 'back-right-leg', side: 'back', path: 'M30 34c3 4 3 12 3 16h-8c0-4 0-12 3-16z', area: 9, label: 'Dešinė koja (nugara)', bbox: [25, 34, 33, 50] },
 ];

--- a/docs/js/components/BodyMap.js
+++ b/docs/js/components/BodyMap.js
@@ -129,6 +129,7 @@ export default class BodyMap {
         path.classList.add('zone');
         path.dataset.zone = z.id;
         path.dataset.area = z.area;
+        if (z.bbox) path.dataset.bbox = z.bbox.join(',');
         path.setAttribute('d', z.path);
         path.setAttribute('aria-label', z.label);
         const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
@@ -545,7 +546,8 @@ export default class BodyMap {
       y: +c.getAttribute('cy'),
       r: +c.getAttribute('r')
     }));
-    return JSON.stringify({ tool: this.activeTool, marks, brushes });
+    const zones = this.zoneCounts();
+    return JSON.stringify({ tool: this.activeTool, marks, brushes, zones });
   }
 
   /** Load previously serialized state. */
@@ -587,15 +589,92 @@ export default class BodyMap {
   zoneCounts() {
     const res = {};
     const types = Object.values(TOOLS).map(t => t.char);
+
+    this.zoneMap.forEach((_, id) => {
+      res[id] = { label: ZONE_LABELS[id] || id, burned: 0 };
+      types.forEach(t => (res[id][t] = 0));
+    });
+
     [...this.marks.querySelectorAll('use')].forEach(u => {
       const z = u.dataset.zone;
-      if (!z) return;
-      if (!res[z]) {
-        res[z] = { label: ZONE_LABELS[z] || z };
-        types.forEach(t => (res[z][t] = 0));
-      }
+      if (!z || !res[z]) return;
       res[z][u.dataset.type] = (res[z][u.dataset.type] || 0) + 1;
     });
+
+    if (this.brushBurns.length && this.zoneMap.size) {
+      const zonePixels = new Map();
+      this.zoneMap.forEach((_, id) => zonePixels.set(id, new Set()));
+
+      const pt = this.svg?.createSVGPoint ? this.svg.createSVGPoint() : null;
+      const inZone = (el, x, y) => {
+        if (!el) return false;
+        if (el.dataset.bbox) {
+          const [minX, minY, maxX, maxY] = el.dataset.bbox.split(',').map(Number);
+          if (x >= minX && x <= maxX && y >= minY && y <= maxY) return true;
+        }
+        if (typeof el.isPointInFill === 'function' && pt) {
+          pt.x = x;
+          pt.y = y;
+          try { return el.isPointInFill(pt); } catch { return false; }
+        }
+        if (typeof el.getBBox === 'function') {
+          try {
+            const b = el.getBBox();
+            if (b && b.width && b.height) {
+              return x >= b.x && x <= b.x + b.width && y >= b.y && y <= b.y + b.height;
+            }
+          } catch {
+            // ignore
+          }
+        }
+        const d = el.getAttribute('d');
+        if (d) {
+          const nums = d.match(/-?\d*\.?\d+/g)?.map(Number) || [];
+          const xs = [];
+          const ys = [];
+          for (let i = 0; i < nums.length; i += 2) {
+            xs.push(nums[i]);
+            if (i + 1 < nums.length) ys.push(nums[i + 1]);
+          }
+          if (xs.length && ys.length) {
+            const minX = Math.min(...xs);
+            const maxX = Math.max(...xs);
+            const minY = Math.min(...ys);
+            const maxY = Math.max(...ys);
+            return x >= minX && x <= maxX && y >= minY && y <= maxY;
+          }
+        }
+        return false;
+      };
+
+      for (const b of this.brushBurns) {
+        const r = Math.round(b.r);
+        const r2 = r * r;
+        const cx = Math.round(b.x);
+        const cy = Math.round(b.y);
+        const minX = Math.max(0, cx - r);
+        const maxX = Math.min(this.vbWidth - 1, cx + r);
+        const minY = Math.max(0, cy - r);
+        const maxY = Math.min(this.vbHeight - 1, cy + r);
+        for (let x = minX; x <= maxX; x++) {
+          for (let y = minY; y <= maxY; y++) {
+            const dx = x - cx;
+            const dy = y - cy;
+            if (dx * dx + dy * dy > r2) continue;
+            this.zoneMap.forEach((el, id) => {
+              if (inZone(el, x, y)) zonePixels.get(id).add(`${x},${y}`);
+            });
+          }
+        }
+      }
+
+      this.zoneMap.forEach((el, id) => {
+        const pixels = zonePixels.get(id).size;
+        const zoneArea = (parseFloat(el.dataset.area) / 100) * this.totalArea;
+        res[id].burned = zoneArea ? (pixels / zoneArea) * 100 : 0;
+      });
+    }
+
     return res;
   }
 }

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -21,6 +21,7 @@ export function bodymapSummary(){
     const seg=[];
     if(z[TOOLS.WOUND.char]) seg.push(`${z[TOOLS.WOUND.char]} ${TOOLS.WOUND.char}`);
     if(z[TOOLS.BRUISE.char]) seg.push(`${z[TOOLS.BRUISE.char]} ${TOOLS.BRUISE.char}`);
+    if(z.burned) seg.push(`nudegimai ${z.burned.toFixed(1)}%`);
     return `${z.label}: ${seg.join(', ')}`;
   });
   return parts.length?`Žemėlapis: ${parts.join('; ')}`:'';

--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -60,6 +60,16 @@ describe('BodyMap instance', () => {
       expect(z['front-torso'].label).toBe(frontZone.label);
     });
 
+    test('zoneCounts calculates burn coverage', () => {
+      setupDom();
+      const bm = new BodyMap();
+      bm.init(() => {});
+      bm.addBrush(24, 30, 5); // inside front-torso
+      const z = bm.zoneCounts();
+      const expected = bm.burnArea() * (100 / frontZone.area);
+      expect(z['front-torso'].burned).toBeCloseTo(expected, 2);
+    });
+
   test('pointer events move mark and save', () => {
     setupDom();
     const save = jest.fn();

--- a/public/js/bodyMapZones.js
+++ b/public/js/bodyMapZones.js
@@ -1,17 +1,17 @@
 export default [
   // Front zones
-  { id: 'front-head', side: 'front', path: 'M24 3c4 0 7 3 7 7s-3 7-7 7-7-3-7-7 3-7 7-7z', area: 4.5, label: 'Galva (priekis)' },
-  { id: 'front-torso', side: 'front', path: 'M14 16c0-8 10-12 10-12s10 4 10 12v18c0 8-10 12-10 12s-10-4-10-12V16z', area: 18, label: 'Liemuo (priekis)' },
-  { id: 'front-left-arm', side: 'front', path: 'M2 18c-1 6-1 16 0 22h6c1-6 1-16 0-22z', area: 4.5, label: 'Kairė ranka (priekis)' },
-  { id: 'front-right-arm', side: 'front', path: 'M46 18c1 6 1 16 0 22h-6c-1-6-1-16 0-22z', area: 4.5, label: 'Dešinė ranka (priekis)' },
-  { id: 'front-left-leg', side: 'front', path: 'M18 34c-3 4-3 12-3 16h8c0-4 0-12-3-16z', area: 9, label: 'Kairė koja (priekis)' },
-  { id: 'front-right-leg', side: 'front', path: 'M30 34c3 4 3 12 3 16h-8c0-4 0-12 3-16z', area: 9, label: 'Dešinė koja (priekis)' },
+  { id: 'front-head', side: 'front', path: 'M24 3c4 0 7 3 7 7s-3 7-7 7-7-3-7-7 3-7 7-7z', area: 4.5, label: 'Galva (priekis)', bbox: [17, 3, 31, 17] },
+  { id: 'front-torso', side: 'front', path: 'M14 16c0-8 10-12 10-12s10 4 10 12v18c0 8-10 12-10 12s-10-4-10-12V16z', area: 18, label: 'Liemuo (priekis)', bbox: [14, 4, 34, 46] },
+  { id: 'front-left-arm', side: 'front', path: 'M2 18c-1 6-1 16 0 22h6c1-6 1-16 0-22z', area: 4.5, label: 'Kairė ranka (priekis)', bbox: [1.25, 18, 8.75, 40] },
+  { id: 'front-right-arm', side: 'front', path: 'M46 18c1 6 1 16 0 22h-6c-1-6-1-16 0-22z', area: 4.5, label: 'Dešinė ranka (priekis)', bbox: [39.25, 18, 46.75, 40] },
+  { id: 'front-left-leg', side: 'front', path: 'M18 34c-3 4-3 12-3 16h8c0-4 0-12-3-16z', area: 9, label: 'Kairė koja (priekis)', bbox: [15, 34, 23, 50] },
+  { id: 'front-right-leg', side: 'front', path: 'M30 34c3 4 3 12 3 16h-8c0-4 0-12 3-16z', area: 9, label: 'Dešinė koja (priekis)', bbox: [25, 34, 33, 50] },
 
   // Back zones
-  { id: 'back-head', side: 'back', path: 'M24 3c4 0 7 3 7 7s-3 7-7 7-7-3-7-7 3-7 7-7z', area: 4.5, label: 'Galva (nugara)' },
-  { id: 'back-torso', side: 'back', path: 'M14 16c0-8 10-12 10-12s10 4 10 12v18c0 8-10 12-10 12s-10-4-10-12V16z', area: 18, label: 'Liemuo (nugara)' },
-  { id: 'back-left-arm', side: 'back', path: 'M2 18c-1 6-1 16 0 22h6c1-6 1-16 0-22z', area: 4.5, label: 'Kairė ranka (nugara)' },
-  { id: 'back-right-arm', side: 'back', path: 'M46 18c1 6 1 16 0 22h-6c-1-6-1-16 0-22z', area: 4.5, label: 'Dešinė ranka (nugara)' },
-  { id: 'back-left-leg', side: 'back', path: 'M18 34c-3 4-3 12-3 16h8c0-4 0-12-3-16z', area: 9, label: 'Kairė koja (nugara)' },
-  { id: 'back-right-leg', side: 'back', path: 'M30 34c3 4 3 12 3 16h-8c0-4 0-12 3-16z', area: 9, label: 'Dešinė koja (nugara)' },
+  { id: 'back-head', side: 'back', path: 'M24 3c4 0 7 3 7 7s-3 7-7 7-7-3-7-7 3-7 7-7z', area: 4.5, label: 'Galva (nugara)', bbox: [17, 3, 31, 17] },
+  { id: 'back-torso', side: 'back', path: 'M14 16c0-8 10-12 10-12s10 4 10 12v18c0 8-10 12-10 12s-10-4-10-12V16z', area: 18, label: 'Liemuo (nugara)', bbox: [14, 4, 34, 46] },
+  { id: 'back-left-arm', side: 'back', path: 'M2 18c-1 6-1 16 0 22h6c1-6 1-16 0-22z', area: 4.5, label: 'Kairė ranka (nugara)', bbox: [1.25, 18, 8.75, 40] },
+  { id: 'back-right-arm', side: 'back', path: 'M46 18c1 6 1 16 0 22h-6c-1-6-1-16 0-22z', area: 4.5, label: 'Dešinė ranka (nugara)', bbox: [39.25, 18, 46.75, 40] },
+  { id: 'back-left-leg', side: 'back', path: 'M18 34c-3 4-3 12-3 16h8c0-4 0-12-3-16z', area: 9, label: 'Kairė koja (nugara)', bbox: [15, 34, 23, 50] },
+  { id: 'back-right-leg', side: 'back', path: 'M30 34c3 4 3 12 3 16h-8c0-4 0-12 3-16z', area: 9, label: 'Dešinė koja (nugara)', bbox: [25, 34, 33, 50] },
 ];

--- a/public/js/report.js
+++ b/public/js/report.js
@@ -21,6 +21,7 @@ export function bodymapSummary(){
     const seg=[];
     if(z[TOOLS.WOUND.char]) seg.push(`${z[TOOLS.WOUND.char]} ${TOOLS.WOUND.char}`);
     if(z[TOOLS.BRUISE.char]) seg.push(`${z[TOOLS.BRUISE.char]} ${TOOLS.BRUISE.char}`);
+    if(z.burned) seg.push(`nudegimai ${z.burned.toFixed(1)}%`);
     return `${z.label}: ${seg.join(', ')}`;
   });
   return parts.length?`Žemėlapis: ${parts.join('; ')}`:'';


### PR DESCRIPTION
## Summary
- compute burn coverage per zone by intersecting burn brushes with zone paths
- expose burn percentages via serialization and report summary
- add unit test for zone burn distribution

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68add16dd3cc832080ad98262389e573