### PR TITLE
Add MAP and shock index metrics to circulation report

### DIFF
--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -49,7 +49,16 @@ export function generateReport(){
     $('#b_dpv_fio2').value?('DPV FiO₂ '+$('#b_dpv_fio2').value):null
   ].filter(Boolean).join('; '));
 
-  out.push('\n--- C Kraujotaka ---'); out.push([$('#c_hr').value?('ŠSD '+$('#c_hr').value+'/min'):null, ($('#c_sbp').value||$('#c_dbp').value)?('AKS '+$('#c_sbp').value+'/'+$('#c_dbp').value):null, $('#c_caprefill').value?('KPL '+$('#c_caprefill').value+'s'):null].filter(Boolean).join('; '));
+  const chr=$('#c_hr').value, csbp=$('#c_sbp').value, cdbp=$('#c_dbp').value;
+  const cmap = (csbp && cdbp) ? Math.round((+csbp + 2*+cdbp)/3) : '';
+  const csi = (chr && csbp) ? (+chr / +csbp).toFixed(2) : '';
+  out.push('\n--- C Kraujotaka ---'); out.push([
+    chr?('ŠSD '+chr+'/min'):null,
+    (csbp||cdbp)?('AKS '+csbp+'/'+cdbp):null,
+    cmap?('MAP '+cmap):null,
+    csi?('SI '+csi):null,
+    $('#c_caprefill').value?('KPL '+$('#c_caprefill').value+'s'):null
+  ].filter(Boolean).join('; '));
 
   const dgks=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value); const left=getSingleValue('#d_pupil_left_group'); const right=getSingleValue('#d_pupil_right_group');
   out.push('\n--- D Sąmonė ---'); out.push([dgks?('GKS '+dgks+' (A'+$('#d_gksa').value+'-K'+$('#d_gksk').value+'-M'+$('#d_gksm').value+')'):null, left?('Vyzdžiai kairė: '+left+ (left==='kita'&&$('#d_pupil_left_note').value?(' ('+$('#d_pupil_left_note').value+')'):'') ):null, right?('Vyzdžiai dešinė: '+right+ (right==='kita'&&$('#d_pupil_right_note').value?(' ('+$('#d_pupil_right_note').value+')'):'') ):null, $('#d_notes').value?('Pastabos: '+$('#d_notes').value):null].filter(Boolean).join(' | '));

--- a/public/index.html
+++ b/public/index.html
@@ -201,7 +201,7 @@
       <h2>C – Kraujotaka</h2>
       <div class="grid cols-3 cols-auto">
         <div><label for="c_hr">ŠSD (k./min)</label><input id="c_hr" type="number" min="0" max="250" title="ŠSD – beats per minute, 0–250"></div>
-        <div class="row"><div class="flex-1"><label for="c_sbp">AKS s</label><input id="c_sbp" type="number" min="0" max="300" title="AKS s – mmHg, 0–300"></div><div class="flex-1"><label for="c_dbp">AKS d</label><input id="c_dbp" type="number" min="0" max="200" title="AKS d – mmHg, 0–200"></div></div>
+        <div class="row"><div class="flex-1"><label for="c_sbp">AKS s</label><input id="c_sbp" type="number" min="0" max="300" title="AKS s – mmHg, 0–300"></div><div class="flex-1"><label for="c_dbp">AKS d</label><input id="c_dbp" type="number" min="0" max="200" title="AKS d – mmHg, 0–200"></div><div class="flex-1"><label>MAP</label><span id="c_map"></span></div><div class="flex-1"><label>SI</label><span id="c_si"></span></div></div>
         <div><label for="c_caprefill">KPL (sek.)</label><input id="c_caprefill" type="number" step="0.1" min="0" max="20" title="KPL – seconds, 0–20"></div>
       </div>
     </section>

--- a/public/js/__tests__/report.test.js
+++ b/public/js/__tests__/report.test.js
@@ -1,4 +1,5 @@
-import { gksSum } from '../report.js';
+import { gksSum, generateReport } from '../report.js';
+import bodyMap from '../bodyMap.js';
 
 describe('gksSum', () => {
   test('sums three values when all present', () => {
@@ -6,5 +7,34 @@ describe('gksSum', () => {
   });
   test('returns empty string if any value missing', () => {
     expect(gksSum(1,0,3)).toBe('');
+  });
+});
+
+describe('generateReport circulation metrics', () => {
+  test('includes MAP and shock index', () => {
+    document.body.innerHTML = `
+      <input id="patient_age"><input id="patient_sex"><input id="patient_history">
+      <input id="gmp_hr"><input id="gmp_rr"><input id="gmp_spo2"><input id="gmp_sbp"><input id="gmp_dbp">
+      <input id="gmp_gksa"><input id="gmp_gksk"><input id="gmp_gksm"><input id="gmp_time"><input id="gmp_mechanism"><input id="gmp_notes">
+      <input id="a_notes">
+      <input id="b_rr"><input id="b_spo2"><input id="b_oxygen_liters"><input id="b_oxygen_type"><input id="b_dpv_fio2">
+      <input id="c_hr"><input id="c_sbp"><input id="c_dbp"><input id="c_caprefill">
+      <input id="d_gksa"><input id="d_gksk"><input id="d_gksm"><input id="d_notes">
+      <input id="e_temp"><input id="e_back_notes"><input id="e_other">
+      <div id="imaging_ct"></div><div id="imaging_xray"></div><div id="imaging_other_group"></div><input id="imaging_other">
+      <div id="pain_meds"></div><div id="bleeding_meds"></div><div id="other_meds"></div><div id="procedures"></div>
+      <div id="labs_basic"></div>
+      <input id="spr_time"><input id="spr_hr"><input id="spr_rr"><input id="spr_spo2"><input id="spr_sbp"><input id="spr_dbp">
+      <input id="spr_gksa"><input id="spr_gksk"><input id="spr_gksm">
+      <textarea id="output"></textarea>
+    `;
+    bodyMap.zoneCounts = () => ({ });
+    document.querySelector('#c_hr').value = '90';
+    document.querySelector('#c_sbp').value = '120';
+    document.querySelector('#c_dbp').value = '60';
+    generateReport();
+    const out = document.querySelector('#output').value;
+    expect(out).toContain('MAP 80');
+    expect(out).toContain('SI 0.75');
   });
 });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -290,6 +290,23 @@ async function init(){
     const el=$(sel);
     if(el) el.addEventListener('change',()=>{ if(el.value) logEvent('vital', label, el.value); });
   });
+
+  const updateCirculationMetrics=()=>{
+    const hr=parseFloat($('#c_hr')?.value);
+    const sbp=parseFloat($('#c_sbp')?.value);
+    const dbp=parseFloat($('#c_dbp')?.value);
+    const mapEl=$('#c_map');
+    const siEl=$('#c_si');
+    const map = !isNaN(sbp) && !isNaN(dbp) ? Math.round((sbp + 2*dbp)/3) : '';
+    const si = !isNaN(hr) && !isNaN(sbp) && sbp>0 ? (hr/sbp).toFixed(2) : '';
+    if(mapEl) mapEl.textContent=map;
+    if(siEl) siEl.textContent=si;
+  };
+  ['#c_hr','#c_sbp','#c_dbp'].forEach(sel=>{
+    const el=$(sel);
+    if(el) el.addEventListener('input', updateCirculationMetrics);
+  });
+  updateCirculationMetrics();
     const updateDGksTotal=()=>{
       $('#d_gks_total').textContent=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value);
     };

--- a/public/js/report.js
+++ b/public/js/report.js
@@ -49,7 +49,16 @@ export function generateReport(){
     $('#b_dpv_fio2').value?('DPV FiO₂ '+$('#b_dpv_fio2').value):null
   ].filter(Boolean).join('; '));
 
-  out.push('\n--- C Kraujotaka ---'); out.push([$('#c_hr').value?('ŠSD '+$('#c_hr').value+'/min'):null, ($('#c_sbp').value||$('#c_dbp').value)?('AKS '+$('#c_sbp').value+'/'+$('#c_dbp').value):null, $('#c_caprefill').value?('KPL '+$('#c_caprefill').value+'s'):null].filter(Boolean).join('; '));
+  const chr=$('#c_hr').value, csbp=$('#c_sbp').value, cdbp=$('#c_dbp').value;
+  const cmap = (csbp && cdbp) ? Math.round((+csbp + 2*+cdbp)/3) : '';
+  const csi = (chr && csbp) ? (+chr / +csbp).toFixed(2) : '';
+  out.push('\n--- C Kraujotaka ---'); out.push([
+    chr?('ŠSD '+chr+'/min'):null,
+    (csbp||cdbp)?('AKS '+csbp+'/'+cdbp):null,
+    cmap?('MAP '+cmap):null,
+    csi?('SI '+csi):null,
+    $('#c_caprefill').value?('KPL '+$('#c_caprefill').value+'s'):null
+  ].filter(Boolean).join('; '));
 
   const dgks=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value); const left=getSingleValue('#d_pupil_left_group'); const right=getSingleValue('#d_pupil_right_group');
   out.push('\n--- D Sąmonė ---'); out.push([dgks?('GKS '+dgks+' (A'+$('#d_gksa').value+'-K'+$('#d_gksk').value+'-M'+$('#d_gksm').value+')'):null, left?('Vyzdžiai kairė: '+left+ (left==='kita'&&$('#d_pupil_left_note').value?(' ('+$('#d_pupil_left_note').value+')'):'') ):null, right?('Vyzdžiai dešinė: '+right+ (right==='kita'&&$('#d_pupil_right_note').value?(' ('+$('#d_pupil_right_note').value+')'):'') ):null, $('#d_notes').value?('Pastabos: '+$('#d_notes').value):null].filter(Boolean).join(' | '));


### PR DESCRIPTION
## Summary
- Show calculated MAP and shock index next to circulation vital inputs
- Compute MAP `(SBP + 2*DBP)/3` and shock index `HR/SBP` on input changes
- Include MAP and shock index in generated patient reports and add Jest tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68addf036c888320a05ff77e3ad426d4