### PR TITLE
Add pulse and skin vitals to circulation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -194,9 +194,37 @@
       <div class="grid cols-3 cols-auto">
         <div><label for="c_hr">ŠSD (k./min)</label><input id="c_hr" type="number" min="0" max="250"></div>
         <div class="row"><div class="flex-1"><label for="c_sbp">AKS s</label><input id="c_sbp" type="number" min="0" max="300"></div><div class="flex-1"><label for="c_dbp">AKS d</label><input id="c_dbp" type="number" min="0" max="200"></div></div>
-        <div><label for="c_caprefill">KPL (sek.)</label><input id="c_caprefill" type="number" step="0.1" min="0" max="20"></div>
-      </div>
-    </section>
+          <div><label for="c_caprefill">KPL (sek.)</label><input id="c_caprefill" type="number" step="0.1" min="0" max="20"></div>
+          <div>
+            <label>Radialinis pulsas</label>
+            <div class="chip-group" id="c_pulse_radial_group" data-single="true">
+              <button type="button" class="chip" data-value="Stiprus" aria-pressed="false">Stiprus</button>
+              <button type="button" class="chip red" data-value="Silpnas" aria-pressed="false">Silpnas</button>
+            </div>
+          </div>
+          <div>
+            <label>Femoralis pulsas</label>
+            <div class="chip-group" id="c_pulse_femoral_group" data-single="true">
+              <button type="button" class="chip" data-value="Stiprus" aria-pressed="false">Stiprus</button>
+              <button type="button" class="chip red" data-value="Silpnas" aria-pressed="false">Silpnas</button>
+            </div>
+          </div>
+          <div>
+            <label>Odos temp.</label>
+            <div class="chip-group" id="c_skin_temp_group" data-single="true">
+              <button type="button" class="chip" data-value="Šilta" aria-pressed="false">Šilta</button>
+              <button type="button" class="chip red" data-value="Šalta" aria-pressed="false">Šalta</button>
+            </div>
+          </div>
+          <div>
+            <label>Odos spalva</label>
+            <div class="chip-group" id="c_skin_color_group" data-single="true">
+              <button type="button" class="chip" data-value="Blyški" aria-pressed="false">Blyški</button>
+              <button type="button" class="chip red" data-value="Paraudusi" aria-pressed="false">Paraudusi</button>
+            </div>
+          </div>
+        </div>
+      </section>
 
     <!-- D -->
     <section class="card view" id="view-d" data-tab="D – Sąmonė">

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -249,6 +249,20 @@ async function init(){
     const el=$(sel);
     if(el) el.addEventListener('change',()=>{ if(el.value) logEvent('vital', label, el.value); });
   });
+
+  const chipVitals = {
+    '#c_pulse_radial_group': 'Radialinis pulsas',
+    '#c_pulse_femoral_group': 'Femoralis pulsas',
+    '#c_skin_temp_group': 'Odos temp.',
+    '#c_skin_color_group': 'Odos spalva'
+  };
+  Object.entries(chipVitals).forEach(([sel,label])=>{
+    const group=$(sel);
+    if(group) group.addEventListener('click',e=>{
+      const chip=e.target.closest('.chip');
+      if(chip && isChipActive(chip)) logEvent('vital', label, chip.dataset.value);
+    });
+  });
     const updateDGksTotal=()=>{
       $('#d_gks_total').textContent=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value);
     };

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -52,12 +52,21 @@ export function generateReport(){
   const chr=$('#c_hr').value, csbp=$('#c_sbp').value, cdbp=$('#c_dbp').value;
   const cmap = (csbp && cdbp) ? Math.round((+csbp + 2*+cdbp)/3) : '';
   const csi = (chr && csbp) ? (+chr / +csbp).toFixed(2) : '';
+  const radial=getSingleValue('#c_pulse_radial_group');
+  const femoral=getSingleValue('#c_pulse_femoral_group');
+  const skinTemp=getSingleValue('#c_skin_temp_group');
+  const skinColor=getSingleValue('#c_skin_color_group');
+  const skinParts=[skinTemp, skinColor].filter(Boolean);
+  const skin=skinParts.length?('Oda: '+skinParts.join(', ')):null;
   out.push('\n--- C Kraujotaka ---'); out.push([
     chr?('ŠSD '+chr+'/min'):null,
     (csbp||cdbp)?('AKS '+csbp+'/'+cdbp):null,
     cmap?('MAP '+cmap):null,
     csi?('SI '+csi):null,
-    $('#c_caprefill').value?('KPL '+$('#c_caprefill').value+'s'):null
+    $('#c_caprefill').value?('KPL '+$('#c_caprefill').value+'s'):null,
+    radial?('Radialinis pulsas '+radial):null,
+    femoral?('Femoralis pulsas '+femoral):null,
+    skin
   ].filter(Boolean).join('; '));
 
   const dgks=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value); const left=getSingleValue('#d_pupil_left_group'); const right=getSingleValue('#d_pupil_right_group');

--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -195,7 +195,7 @@ export async function initSessions(){
 }
 
 const IMAGING_GROUPS=['#imaging_ct','#imaging_xray','#imaging_other_group'];
-const CHIP_GROUPS=['#chips_red','#chips_yellow',...IMAGING_GROUPS,'#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group'];
+const CHIP_GROUPS=['#chips_red','#chips_yellow',...IMAGING_GROUPS,'#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#c_pulse_radial_group','#c_pulse_femoral_group','#c_skin_temp_group','#c_skin_color_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group'];
 const FIELD_SELECTORS='input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select';
 
 export function saveAll(){

--- a/public/index.html
+++ b/public/index.html
@@ -203,6 +203,34 @@
         <div><label for="c_hr">ŠSD (k./min)</label><input id="c_hr" type="number" min="0" max="250" title="ŠSD – beats per minute, 0–250"></div>
         <div class="row"><div class="flex-1"><label for="c_sbp">AKS s</label><input id="c_sbp" type="number" min="0" max="300" title="AKS s – mmHg, 0–300"></div><div class="flex-1"><label for="c_dbp">AKS d</label><input id="c_dbp" type="number" min="0" max="200" title="AKS d – mmHg, 0–200"></div><div class="flex-1"><label>MAP</label><span id="c_map"></span></div><div class="flex-1"><label>SI</label><span id="c_si"></span></div></div>
         <div><label for="c_caprefill">KPL (sek.)</label><input id="c_caprefill" type="number" step="0.1" min="0" max="20" title="KPL – seconds, 0–20"></div>
+        <div>
+          <label>Radialinis pulsas</label>
+          <div class="chip-group" id="c_pulse_radial_group" data-single="true">
+            <button type="button" class="chip" data-value="Stiprus" aria-pressed="false">Stiprus</button>
+            <button type="button" class="chip red" data-value="Silpnas" aria-pressed="false">Silpnas</button>
+          </div>
+        </div>
+        <div>
+          <label>Femoralis pulsas</label>
+          <div class="chip-group" id="c_pulse_femoral_group" data-single="true">
+            <button type="button" class="chip" data-value="Stiprus" aria-pressed="false">Stiprus</button>
+            <button type="button" class="chip red" data-value="Silpnas" aria-pressed="false">Silpnas</button>
+          </div>
+        </div>
+        <div>
+          <label>Odos temp.</label>
+          <div class="chip-group" id="c_skin_temp_group" data-single="true">
+            <button type="button" class="chip" data-value="Šilta" aria-pressed="false">Šilta</button>
+            <button type="button" class="chip red" data-value="Šalta" aria-pressed="false">Šalta</button>
+          </div>
+        </div>
+        <div>
+          <label>Odos spalva</label>
+          <div class="chip-group" id="c_skin_color_group" data-single="true">
+            <button type="button" class="chip" data-value="Blyški" aria-pressed="false">Blyški</button>
+            <button type="button" class="chip red" data-value="Paraudusi" aria-pressed="false">Paraudusi</button>
+          </div>
+        </div>
       </div>
     </section>
 

--- a/public/js/__tests__/patient.test.js
+++ b/public/js/__tests__/patient.test.js
@@ -38,11 +38,29 @@ const setupDom = () => {
   `;
   const divIds = [
     'chips_red','chips_yellow','imaging_ct','imaging_xray','imaging_other_group','labs_basic',
-    'a_airway_group','b_breath_left_group','b_breath_right_group','d_pupil_left_group','d_pupil_right_group','spr_decision_group',
+    'a_airway_group','b_breath_left_group','b_breath_right_group',
+    'c_pulse_radial_group','c_pulse_femoral_group','c_skin_temp_group','c_skin_color_group',
+    'd_pupil_left_group','d_pupil_right_group','spr_decision_group',
     'pain_meds','bleeding_meds','other_meds','procedures','fastGrid','teamGrid','oxygenFields','dpvFields',
     'spr_skyrius_container','spr_ligonine_container','imaging_other'
   ];
   divIds.forEach(id=>{ const d=document.createElement('div'); d.id=id; document.body.appendChild(d); });
+  const radial=document.getElementById('c_pulse_radial_group');
+  radial.className='chip-group';
+  radial.dataset.single='true';
+  radial.innerHTML='<button class="chip" data-value="Stiprus"></button><button class="chip" data-value="Silpnas"></button>';
+  const femoral=document.getElementById('c_pulse_femoral_group');
+  femoral.className='chip-group';
+  femoral.dataset.single='true';
+  femoral.innerHTML='<button class="chip" data-value="Stiprus"></button><button class="chip" data-value="Silpnas"></button>';
+  const skinTemp=document.getElementById('c_skin_temp_group');
+  skinTemp.className='chip-group';
+  skinTemp.dataset.single='true';
+  skinTemp.innerHTML='<button class="chip" data-value="Šilta"></button><button class="chip" data-value="Šalta"></button>';
+  const skinColor=document.getElementById('c_skin_color_group');
+  skinColor.className='chip-group';
+  skinColor.dataset.single='true';
+  skinColor.innerHTML='<button class="chip" data-value="Blyški"></button><button class="chip" data-value="Paraudusi"></button>';
   const textInputs=['a_notes','gmp_mechanism','gmp_notes','b_oxygen_type','b_dpv_fio2','d_pupil_left_note','d_pupil_right_note','d_notes','e_back_notes','e_other','spr_skyrius_kita','spr_ligonine','patient_history'];
   textInputs.forEach(id=>{ const i=document.createElement('input'); i.id=id; i.type='text'; document.body.appendChild(i); });
   const numberInputs=['b_rr','b_spo2','b_oxygen_liters','c_hr','c_sbp','c_dbp','c_caprefill','d_gksa','d_gksk','d_gksm','e_temp',
@@ -105,6 +123,35 @@ describe('patient fields', () => {
     expect(report).toContain('25');
     expect(report).toContain('M');
     expect(report).toContain('H123');
+  });
+
+  test('new circulation fields persist and report', () => {
+    const { setChipActive } = require('../chips.js');
+    const radial=document.querySelector('#c_pulse_radial_group .chip[data-value="Stiprus"]');
+    const femoral=document.querySelector('#c_pulse_femoral_group .chip[data-value="Silpnas"]');
+    const skinT=document.querySelector('#c_skin_temp_group .chip[data-value="Šilta"]');
+    const skinC=document.querySelector('#c_skin_color_group .chip[data-value="Blyški"]');
+    setChipActive(radial,true);
+    setChipActive(femoral,true);
+    setChipActive(skinT,true);
+    setChipActive(skinC,true);
+    saveAll();
+    const stored=JSON.parse(localStorage.getItem('trauma_v10_test'));
+    expect(stored['chips:#c_pulse_radial_group']).toEqual(['Stiprus']);
+    expect(stored['chips:#c_pulse_femoral_group']).toEqual(['Silpnas']);
+    expect(stored['chips:#c_skin_temp_group']).toEqual(['Šilta']);
+    expect(stored['chips:#c_skin_color_group']).toEqual(['Blyški']);
+    document.querySelectorAll('.chip.active').forEach(c=>c.classList.remove('active'));
+    loadAll();
+    expect(document.querySelector('#c_pulse_radial_group .chip.active').dataset.value).toBe('Stiprus');
+    expect(document.querySelector('#c_pulse_femoral_group .chip.active').dataset.value).toBe('Silpnas');
+    expect(document.querySelector('#c_skin_temp_group .chip.active').dataset.value).toBe('Šilta');
+    expect(document.querySelector('#c_skin_color_group .chip.active').dataset.value).toBe('Blyški');
+    generateReport();
+    const report=document.getElementById('output').value;
+    expect(report).toContain('Radialinis pulsas Stiprus');
+    expect(report).toContain('Femoralis pulsas Silpnas');
+    expect(report).toContain('Oda: Šilta, Blyški');
   });
 
   test('GCS panel focuses first select and closes on Escape', () => {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -291,6 +291,20 @@ async function init(){
     if(el) el.addEventListener('change',()=>{ if(el.value) logEvent('vital', label, el.value); });
   });
 
+  const chipVitals = {
+    '#c_pulse_radial_group': 'Radialinis pulsas',
+    '#c_pulse_femoral_group': 'Femoralis pulsas',
+    '#c_skin_temp_group': 'Odos temp.',
+    '#c_skin_color_group': 'Odos spalva'
+  };
+  Object.entries(chipVitals).forEach(([sel,label])=>{
+    const group=$(sel);
+    if(group) group.addEventListener('click',e=>{
+      const chip=e.target.closest('.chip');
+      if(chip && isChipActive(chip)) logEvent('vital', label, chip.dataset.value);
+    });
+  });
+
   const updateCirculationMetrics=()=>{
     const hr=parseFloat($('#c_hr')?.value);
     const sbp=parseFloat($('#c_sbp')?.value);

--- a/public/js/report.js
+++ b/public/js/report.js
@@ -52,12 +52,21 @@ export function generateReport(){
   const chr=$('#c_hr').value, csbp=$('#c_sbp').value, cdbp=$('#c_dbp').value;
   const cmap = (csbp && cdbp) ? Math.round((+csbp + 2*+cdbp)/3) : '';
   const csi = (chr && csbp) ? (+chr / +csbp).toFixed(2) : '';
+  const radial=getSingleValue('#c_pulse_radial_group');
+  const femoral=getSingleValue('#c_pulse_femoral_group');
+  const skinTemp=getSingleValue('#c_skin_temp_group');
+  const skinColor=getSingleValue('#c_skin_color_group');
+  const skinParts=[skinTemp, skinColor].filter(Boolean);
+  const skin=skinParts.length?('Oda: '+skinParts.join(', ')):null;
   out.push('\n--- C Kraujotaka ---'); out.push([
     chr?('ŠSD '+chr+'/min'):null,
     (csbp||cdbp)?('AKS '+csbp+'/'+cdbp):null,
     cmap?('MAP '+cmap):null,
     csi?('SI '+csi):null,
-    $('#c_caprefill').value?('KPL '+$('#c_caprefill').value+'s'):null
+    $('#c_caprefill').value?('KPL '+$('#c_caprefill').value+'s'):null,
+    radial?('Radialinis pulsas '+radial):null,
+    femoral?('Femoralis pulsas '+femoral):null,
+    skin
   ].filter(Boolean).join('; '));
 
   const dgks=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value); const left=getSingleValue('#d_pupil_left_group'); const right=getSingleValue('#d_pupil_right_group');

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -266,7 +266,7 @@ export async function initSessions(){
 }
 
 const IMAGING_GROUPS=['#imaging_ct','#imaging_xray','#imaging_other_group'];
-const CHIP_GROUPS=['#chips_red','#chips_yellow',...IMAGING_GROUPS,'#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group'];
+const CHIP_GROUPS=['#chips_red','#chips_yellow',...IMAGING_GROUPS,'#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#c_pulse_radial_group','#c_pulse_femoral_group','#c_skin_temp_group','#c_skin_color_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group'];
 const FIELD_SELECTORS='input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select';
 
 export function saveAll(){


### PR DESCRIPTION
## Summary
- capture radial and femoral pulse strength plus skin descriptors in the circulation section
- log and report new pulse and skin vitals
- test persistence and reporting of added circulation fields

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ade1d4ff088320aca7573d0f148438