### PR TITLE
Warn on abnormal circulation metrics

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -14,6 +14,7 @@ import bodyMap from './bodyMap.js';
 import { generateReport, gksSum } from './report.js';
 import { setupHeaderActions } from './headerActions.js';
 import { TEAM_ROLES } from './constants.js';
+import { initCirculationChecks } from './circulation.js';
 export { validateVitals };
 
 /* ===== Imaging / Labs / Team ===== */
@@ -263,6 +264,19 @@ async function init(){
       if(chip && isChipActive(chip)) logEvent('vital', label, chip.dataset.value);
     });
   });
+  const updateCirculationMetrics=()=>{
+    const hr=parseFloat($('#c_hr')?.value);
+    const sbp=parseFloat($('#c_sbp')?.value);
+    const dbp=parseFloat($('#c_dbp')?.value);
+    const mapEl=$('#c_map');
+    const siEl=$('#c_si');
+    const map=!isNaN(sbp)&&!isNaN(dbp)?Math.round((sbp+2*dbp)/3):'';
+    const si=!isNaN(hr)&&!isNaN(sbp)&&sbp>0?(hr/sbp).toFixed(2):'';
+    if(mapEl) mapEl.textContent=map;
+    if(siEl) siEl.textContent=si;
+  };
+  initCirculationChecks(updateCirculationMetrics);
+  updateCirculationMetrics();
     const updateDGksTotal=()=>{
       $('#d_gks_total').textContent=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value);
     };

--- a/docs/js/circulation.js
+++ b/docs/js/circulation.js
@@ -1,0 +1,32 @@
+import { notify } from './alerts.js';
+import { $ } from './utils.js';
+
+export const CIRC_THRESHOLDS = {
+  '#c_hr': { min: 60, max: 100, label: 'ŠSD' },
+  '#c_sbp': { min: 90, max: 180, label: 'AKS s' },
+  '#c_dbp': { min: 60, max: 110, label: 'AKS d' }
+};
+
+export function checkField(sel) {
+  const cfg = CIRC_THRESHOLDS[sel];
+  const el = $(sel);
+  if (!cfg || !el) return false;
+  const val = parseFloat(el.value);
+  if (isNaN(val)) return false;
+  if ((cfg.min !== undefined && val < cfg.min) || (cfg.max !== undefined && val > cfg.max)) {
+    notify({ type: 'warning', message: `${cfg.label} už ribų` });
+    return true;
+  }
+  return false;
+}
+
+export function initCirculationChecks(updateMetrics) {
+  Object.keys(CIRC_THRESHOLDS).forEach(sel => {
+    const el = $(sel);
+    if (!el) return;
+    el.addEventListener('input', () => {
+      if (typeof updateMetrics === 'function') updateMetrics();
+      checkField(sel);
+    });
+  });
+}

--- a/public/js/__tests__/circulation.test.js
+++ b/public/js/__tests__/circulation.test.js
@@ -1,0 +1,27 @@
+import { initCirculationChecks } from '../circulation.js';
+import { notify } from '../alerts.js';
+
+jest.mock('../alerts.js', () => ({ notify: jest.fn() }));
+
+describe('circulation thresholds', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input id="c_hr" />
+      <input id="c_sbp" />
+      <input id="c_dbp" />
+    `;
+    initCirculationChecks(() => {});
+    notify.mockClear();
+  });
+
+  test.each([
+    ['#c_hr', '50'],
+    ['#c_sbp', '80'],
+    ['#c_dbp', '50']
+  ])('notifies when %s value %s out of range', (sel, value) => {
+    const el = document.querySelector(sel);
+    el.value = value;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(notify).toHaveBeenCalled();
+  });
+});

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -14,6 +14,7 @@ import bodyMap from './bodyMap.js';
 import { generateReport, gksSum } from './report.js';
 import { setupHeaderActions } from './headerActions.js';
 import { TEAM_ROLES } from './constants.js';
+import { initCirculationChecks } from './circulation.js';
 export { validateVitals };
 
 /* ===== Imaging / Labs / Team ===== */
@@ -316,10 +317,7 @@ async function init(){
     if(mapEl) mapEl.textContent=map;
     if(siEl) siEl.textContent=si;
   };
-  ['#c_hr','#c_sbp','#c_dbp'].forEach(sel=>{
-    const el=$(sel);
-    if(el) el.addEventListener('input', updateCirculationMetrics);
-  });
+  initCirculationChecks(updateCirculationMetrics);
   updateCirculationMetrics();
     const updateDGksTotal=()=>{
       $('#d_gks_total').textContent=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value);

--- a/public/js/circulation.js
+++ b/public/js/circulation.js
@@ -1,0 +1,32 @@
+import { notify } from './alerts.js';
+import { $ } from './utils.js';
+
+export const CIRC_THRESHOLDS = {
+  '#c_hr': { min: 60, max: 100, label: 'ŠSD' },
+  '#c_sbp': { min: 90, max: 180, label: 'AKS s' },
+  '#c_dbp': { min: 60, max: 110, label: 'AKS d' }
+};
+
+export function checkField(sel) {
+  const cfg = CIRC_THRESHOLDS[sel];
+  const el = $(sel);
+  if (!cfg || !el) return false;
+  const val = parseFloat(el.value);
+  if (isNaN(val)) return false;
+  if ((cfg.min !== undefined && val < cfg.min) || (cfg.max !== undefined && val > cfg.max)) {
+    notify({ type: 'warning', message: `${cfg.label} už ribų` });
+    return true;
+  }
+  return false;
+}
+
+export function initCirculationChecks(updateMetrics) {
+  Object.keys(CIRC_THRESHOLDS).forEach(sel => {
+    const el = $(sel);
+    if (!el) return;
+    el.addEventListener('input', () => {
+      if (typeof updateMetrics === 'function') updateMetrics();
+      checkField(sel);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add circulation thresholds and warnings for heart rate and blood pressure
- surface circulation alerts in documentation build
- cover circulation alerts with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ade4c5e0a0832085035351b35fac46