### PR TITLE
feat: add accessible GCS calculator dialog

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -248,44 +248,48 @@
             <span id="d_gks_total"></span>
         </div>
         <div id="d_gcs_calc" class="gcs-calc hidden">
-          <div class="grid cols-3 cols-auto">
-            <div>
-              <label for="d_gcs_calc_a">Akių atmerkimas (A)</label>
-              <select id="d_gcs_calc_a">
-                <option value=""></option>
-                <option value="4">akys atmerktos spontaniškai</option>
-                <option value="3" class="red">akys atveriamos į garsą</option>
-                <option value="2" class="red">akys atveriamos į skausmą</option>
-                <option value="1" class="red">akys neatveriamos</option>
-              </select>
+          <div role="dialog" aria-modal="true" aria-labelledby="d_gcs_calc_title">
+            <h3 id="d_gcs_calc_title" class="sr-only">GKS skaičiuoklė</h3>
+            <button type="button" class="btn ghost" id="d_gcs_close">Uždaryti</button>
+            <div class="grid cols-3 cols-auto">
+              <div>
+                <label for="d_gcs_calc_a">Akių atmerkimas (A)</label>
+                <select id="d_gcs_calc_a">
+                  <option value=""></option>
+                  <option value="4">akys atmerktos spontaniškai</option>
+                  <option value="3" class="red">akys atveriamos į garsą</option>
+                  <option value="2" class="red">akys atveriamos į skausmą</option>
+                  <option value="1" class="red">akys neatveriamos</option>
+                </select>
+              </div>
+              <div>
+                <label for="d_gcs_calc_k">Kalba (K)</label>
+                <select id="d_gcs_calc_k">
+                  <option value=""></option>
+                  <option value="5">orientuota kalba</option>
+                  <option value="4" class="red">paini kalba</option>
+                  <option value="3" class="red">atskiri žodžiai</option>
+                  <option value="2" class="red">neaiškūs garsai</option>
+                  <option value="1" class="red">nereaguoja</option>
+                </select>
+              </div>
+              <div>
+                <label for="d_gcs_calc_m">Judesių reakcija (M)</label>
+                <select id="d_gcs_calc_m">
+                  <option value=""></option>
+                  <option value="6">vykdo komandas</option>
+                  <option value="5" class="red">lokalizuoja skausmą</option>
+                  <option value="4" class="red">atitraukia nuo skausmo</option>
+                  <option value="3" class="red">nenormali fleksija (lenkia į skausmą)</option>
+                  <option value="2" class="red">nenormali ekstensija (ištiesia į skausmą)</option>
+                  <option value="1" class="red">nereaguoja</option>
+                </select>
+              </div>
             </div>
-            <div>
-              <label for="d_gcs_calc_k">Kalba (K)</label>
-              <select id="d_gcs_calc_k">
-                <option value=""></option>
-                <option value="5">orientuota kalba</option>
-                <option value="4" class="red">paini kalba</option>
-                <option value="3" class="red">atskiri žodžiai</option>
-                <option value="2" class="red">neaiškūs garsai</option>
-                <option value="1" class="red">nereaguoja</option>
-              </select>
+            <div class="row mt-8">
+              <button type="button" class="btn" id="d_gcs_apply">Taikyti</button>
+              <span id="d_gcs_calc_total"></span>
             </div>
-            <div>
-              <label for="d_gcs_calc_m">Judesių reakcija (M)</label>
-              <select id="d_gcs_calc_m">
-                <option value=""></option>
-                <option value="6">vykdo komandas</option>
-                <option value="5" class="red">lokalizuoja skausmą</option>
-                <option value="4" class="red">atitraukia nuo skausmo</option>
-                <option value="3" class="red">nenormali fleksija (lenkia į skausmą)</option>
-                <option value="2" class="red">nenormali ekstensija (ištiesia į skausmą)</option>
-                <option value="1" class="red">nereaguoja</option>
-              </select>
-            </div>
-          </div>
-          <div class="row mt-8">
-            <button type="button" class="btn" id="d_gcs_apply">Taikyti</button>
-            <span id="d_gcs_calc_total"></span>
           </div>
         </div>
       </div>
@@ -457,44 +461,48 @@
           <span id="spr_gks_total"></span>
         </div>
         <div id="spr_gcs_calc" class="gcs-calc hidden">
-          <div class="grid cols-3 cols-auto">
-            <div>
-              <label for="spr_gcs_calc_a">Akių atmerkimas (A)</label>
-              <select id="spr_gcs_calc_a">
-                <option value=""></option>
-                <option value="4">akys atmerktos spontaniškai</option>
-                <option value="3">akys atveriamos į garsą</option>
-                <option value="2">akys atveriamos į skausmą</option>
-                <option value="1">akys neatveriamos</option>
-              </select>
+          <div role="dialog" aria-modal="true" aria-labelledby="spr_gcs_calc_title">
+            <h3 id="spr_gcs_calc_title" class="sr-only">GKS skaičiuoklė</h3>
+            <button type="button" class="btn ghost" id="spr_gcs_close">Uždaryti</button>
+            <div class="grid cols-3 cols-auto">
+              <div>
+                <label for="spr_gcs_calc_a">Akių atmerkimas (A)</label>
+                <select id="spr_gcs_calc_a">
+                  <option value=""></option>
+                  <option value="4">akys atmerktos spontaniškai</option>
+                  <option value="3">akys atveriamos į garsą</option>
+                  <option value="2">akys atveriamos į skausmą</option>
+                  <option value="1">akys neatveriamos</option>
+                </select>
+              </div>
+              <div>
+                <label for="spr_gcs_calc_k">Kalba (K)</label>
+                <select id="spr_gcs_calc_k">
+                  <option value=""></option>
+                  <option value="5">orientuota kalba</option>
+                  <option value="4">paini kalba</option>
+                  <option value="3">atskiri žodžiai</option>
+                  <option value="2">neaiškūs garsai</option>
+                  <option value="1">nereaguoja</option>
+                </select>
+              </div>
+              <div>
+                <label for="spr_gcs_calc_m">Judesių reakcija (M)</label>
+                <select id="spr_gcs_calc_m">
+                  <option value=""></option>
+                  <option value="6">vykdo komandas</option>
+                  <option value="5">lokalizuoja skausmą</option>
+                  <option value="4">atitraukia nuo skausmo</option>
+                  <option value="3">nenormali fleksija (lenkia į skausmą)</option>
+                  <option value="2">nenormali ekstensija (ištiesia į skausmą)</option>
+                  <option value="1">nereaguoja</option>
+                </select>
+              </div>
             </div>
-            <div>
-              <label for="spr_gcs_calc_k">Kalba (K)</label>
-              <select id="spr_gcs_calc_k">
-                <option value=""></option>
-                <option value="5">orientuota kalba</option>
-                <option value="4">paini kalba</option>
-                <option value="3">atskiri žodžiai</option>
-                <option value="2">neaiškūs garsai</option>
-                <option value="1">nereaguoja</option>
-              </select>
+            <div class="row mt-8">
+              <button type="button" class="btn" id="spr_gcs_apply">Taikyti</button>
+              <span id="spr_gcs_calc_total"></span>
             </div>
-            <div>
-              <label for="spr_gcs_calc_m">Judesių reakcija (M)</label>
-              <select id="spr_gcs_calc_m">
-                <option value=""></option>
-                <option value="6">vykdo komandas</option>
-                <option value="5">lokalizuoja skausmą</option>
-                <option value="4">atitraukia nuo skausmo</option>
-                <option value="3">nenormali fleksija (lenkia į skausmą)</option>
-                <option value="2">nenormali ekstensija (ištiesia į skausmą)</option>
-                <option value="1">nereaguoja</option>
-              </select>
-            </div>
-          </div>
-          <div class="row mt-8">
-            <button type="button" class="btn" id="spr_gcs_apply">Taikyti</button>
-            <span id="spr_gcs_calc_total"></span>
           </div>
         </div>
       </div>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -145,19 +145,32 @@ function setupGcsCalc(prefix){
   const selM=$(`#${prefix}_gcs_calc_m`);
   const apply=$(`#${prefix}_gcs_apply`);
   const total=$(`#${prefix}_gcs_calc_total`);
+  const btnClose=$(`#${prefix}_gcs_close`);
   const btn = prefix==='spr' ? $('#btnSprGCSCalc') : $('#btnGCSCalc');
   if(!panel||!selA||!selK||!selM||!apply||!total) return ()=>{};
 
   const update=()=>{ total.textContent=gksSum(selA.value,selK.value,selM.value); };
   [selA,selK,selM].forEach(sel=>sel.addEventListener('change',update));
 
+  let firstFocusable, lastFocusable;
   const close=()=>{
     panel.style.display='none';
     document.removeEventListener('keydown',onKey);
     document.removeEventListener('click',onDocClick);
     if(btn) btn.focus();
   };
-  const onKey=e=>{ if(e.key==='Escape') close(); };
+  const onKey=e=>{
+    if(e.key==='Escape') return close();
+    if(e.key==='Tab'){
+      if(e.shiftKey && document.activeElement===firstFocusable){
+        e.preventDefault();
+        lastFocusable.focus();
+      }else if(!e.shiftKey && document.activeElement===lastFocusable){
+        e.preventDefault();
+        firstFocusable.focus();
+      }
+    }
+  };
   const onDocClick=e=>{ if(!panel.contains(e.target) && e.target!==btn) close(); };
 
   apply.addEventListener('click',()=>{
@@ -169,10 +182,15 @@ function setupGcsCalc(prefix){
     saveAll();
   });
 
+  if(btnClose) btnClose.addEventListener('click',close);
+
   return ()=>{
     const hidden=panel.style.display==='none';
     if(hidden){
       panel.style.display='block';
+      const focusables=panel.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      firstFocusable=focusables[0];
+      lastFocusable=focusables[focusables.length-1];
       document.addEventListener('keydown',onKey);
       document.addEventListener('click',onDocClick);
       selA.focus();

--- a/public/index.html
+++ b/public/index.html
@@ -248,44 +248,48 @@
             <span id="d_gks_total"></span>
         </div>
         <div id="d_gcs_calc" class="gcs-calc hidden">
-          <div class="grid cols-3 cols-auto">
-            <div>
-              <label for="d_gcs_calc_a">Akių atmerkimas (A)</label>
-              <select id="d_gcs_calc_a">
-                <option value=""></option>
-                <option value="4">akys atmerktos spontaniškai</option>
-                <option value="3" class="red">akys atveriamos į garsą</option>
-                <option value="2" class="red">akys atveriamos į skausmą</option>
-                <option value="1" class="red">akys neatveriamos</option>
-              </select>
+          <div role="dialog" aria-modal="true" aria-labelledby="d_gcs_calc_title">
+            <h3 id="d_gcs_calc_title" class="sr-only">GKS skaičiuoklė</h3>
+            <button type="button" class="btn ghost" id="d_gcs_close">Uždaryti</button>
+            <div class="grid cols-3 cols-auto">
+              <div>
+                <label for="d_gcs_calc_a">Akių atmerkimas (A)</label>
+                <select id="d_gcs_calc_a">
+                  <option value=""></option>
+                  <option value="4">akys atmerktos spontaniškai</option>
+                  <option value="3" class="red">akys atveriamos į garsą</option>
+                  <option value="2" class="red">akys atveriamos į skausmą</option>
+                  <option value="1" class="red">akys neatveriamos</option>
+                </select>
+              </div>
+              <div>
+                <label for="d_gcs_calc_k">Kalba (K)</label>
+                <select id="d_gcs_calc_k">
+                  <option value=""></option>
+                  <option value="5">orientuota kalba</option>
+                  <option value="4" class="red">paini kalba</option>
+                  <option value="3" class="red">atskiri žodžiai</option>
+                  <option value="2" class="red">neaiškūs garsai</option>
+                  <option value="1" class="red">nereaguoja</option>
+                </select>
+              </div>
+              <div>
+                <label for="d_gcs_calc_m">Judesių reakcija (M)</label>
+                <select id="d_gcs_calc_m">
+                  <option value=""></option>
+                  <option value="6">vykdo komandas</option>
+                  <option value="5" class="red">lokalizuoja skausmą</option>
+                  <option value="4" class="red">atitraukia nuo skausmo</option>
+                  <option value="3" class="red">nenormali fleksija (lenkia į skausmą)</option>
+                  <option value="2" class="red">nenormali ekstensija (ištiesia į skausmą)</option>
+                  <option value="1" class="red">nereaguoja</option>
+                </select>
+              </div>
             </div>
-            <div>
-              <label for="d_gcs_calc_k">Kalba (K)</label>
-              <select id="d_gcs_calc_k">
-                <option value=""></option>
-                <option value="5">orientuota kalba</option>
-                <option value="4" class="red">paini kalba</option>
-                <option value="3" class="red">atskiri žodžiai</option>
-                <option value="2" class="red">neaiškūs garsai</option>
-                <option value="1" class="red">nereaguoja</option>
-              </select>
+            <div class="row mt-8">
+              <button type="button" class="btn" id="d_gcs_apply">Taikyti</button>
+              <span id="d_gcs_calc_total"></span>
             </div>
-            <div>
-              <label for="d_gcs_calc_m">Judesių reakcija (M)</label>
-              <select id="d_gcs_calc_m">
-                <option value=""></option>
-                <option value="6">vykdo komandas</option>
-                <option value="5" class="red">lokalizuoja skausmą</option>
-                <option value="4" class="red">atitraukia nuo skausmo</option>
-                <option value="3" class="red">nenormali fleksija (lenkia į skausmą)</option>
-                <option value="2" class="red">nenormali ekstensija (ištiesia į skausmą)</option>
-                <option value="1" class="red">nereaguoja</option>
-              </select>
-            </div>
-          </div>
-          <div class="row mt-8">
-            <button type="button" class="btn" id="d_gcs_apply">Taikyti</button>
-            <span id="d_gcs_calc_total"></span>
           </div>
         </div>
       </div>
@@ -457,44 +461,48 @@
           <span id="spr_gks_total"></span>
         </div>
         <div id="spr_gcs_calc" class="gcs-calc hidden">
-          <div class="grid cols-3 cols-auto">
-            <div>
-              <label for="spr_gcs_calc_a">Akių atmerkimas (A)</label>
-              <select id="spr_gcs_calc_a">
-                <option value=""></option>
-                <option value="4">akys atmerktos spontaniškai</option>
-                <option value="3">akys atveriamos į garsą</option>
-                <option value="2">akys atveriamos į skausmą</option>
-                <option value="1">akys neatveriamos</option>
-              </select>
+          <div role="dialog" aria-modal="true" aria-labelledby="spr_gcs_calc_title">
+            <h3 id="spr_gcs_calc_title" class="sr-only">GKS skaičiuoklė</h3>
+            <button type="button" class="btn ghost" id="spr_gcs_close">Uždaryti</button>
+            <div class="grid cols-3 cols-auto">
+              <div>
+                <label for="spr_gcs_calc_a">Akių atmerkimas (A)</label>
+                <select id="spr_gcs_calc_a">
+                  <option value=""></option>
+                  <option value="4">akys atmerktos spontaniškai</option>
+                  <option value="3">akys atveriamos į garsą</option>
+                  <option value="2">akys atveriamos į skausmą</option>
+                  <option value="1">akys neatveriamos</option>
+                </select>
+              </div>
+              <div>
+                <label for="spr_gcs_calc_k">Kalba (K)</label>
+                <select id="spr_gcs_calc_k">
+                  <option value=""></option>
+                  <option value="5">orientuota kalba</option>
+                  <option value="4">paini kalba</option>
+                  <option value="3">atskiri žodžiai</option>
+                  <option value="2">neaiškūs garsai</option>
+                  <option value="1">nereaguoja</option>
+                </select>
+              </div>
+              <div>
+                <label for="spr_gcs_calc_m">Judesių reakcija (M)</label>
+                <select id="spr_gcs_calc_m">
+                  <option value=""></option>
+                  <option value="6">vykdo komandas</option>
+                  <option value="5">lokalizuoja skausmą</option>
+                  <option value="4">atitraukia nuo skausmo</option>
+                  <option value="3">nenormali fleksija (lenkia į skausmą)</option>
+                  <option value="2">nenormali ekstensija (ištiesia į skausmą)</option>
+                  <option value="1">nereaguoja</option>
+                </select>
+              </div>
             </div>
-            <div>
-              <label for="spr_gcs_calc_k">Kalba (K)</label>
-              <select id="spr_gcs_calc_k">
-                <option value=""></option>
-                <option value="5">orientuota kalba</option>
-                <option value="4">paini kalba</option>
-                <option value="3">atskiri žodžiai</option>
-                <option value="2">neaiškūs garsai</option>
-                <option value="1">nereaguoja</option>
-              </select>
+            <div class="row mt-8">
+              <button type="button" class="btn" id="spr_gcs_apply">Taikyti</button>
+              <span id="spr_gcs_calc_total"></span>
             </div>
-            <div>
-              <label for="spr_gcs_calc_m">Judesių reakcija (M)</label>
-              <select id="spr_gcs_calc_m">
-                <option value=""></option>
-                <option value="6">vykdo komandas</option>
-                <option value="5">lokalizuoja skausmą</option>
-                <option value="4">atitraukia nuo skausmo</option>
-                <option value="3">nenormali fleksija (lenkia į skausmą)</option>
-                <option value="2">nenormali ekstensija (ištiesia į skausmą)</option>
-                <option value="1">nereaguoja</option>
-              </select>
-            </div>
-          </div>
-          <div class="row mt-8">
-            <button type="button" class="btn" id="spr_gcs_apply">Taikyti</button>
-            <span id="spr_gcs_calc_total"></span>
           </div>
         </div>
       </div>

--- a/public/js/__tests__/patient.test.js
+++ b/public/js/__tests__/patient.test.js
@@ -19,11 +19,15 @@ const setupDom = () => {
     <button id="btnGCS15"></button>
     <button id="btnGCSCalc"></button>
     <div id="d_gcs_calc" style="display:none">
-      <select id="d_gcs_calc_a"></select>
-      <select id="d_gcs_calc_k"></select>
-      <select id="d_gcs_calc_m"></select>
-      <button id="d_gcs_apply"></button>
-      <span id="d_gcs_calc_total"></span>
+      <div role="dialog" aria-modal="true" aria-labelledby="d_gcs_calc_title">
+        <h3 id="d_gcs_calc_title" class="sr-only">GKS skaičiuoklė</h3>
+        <button id="d_gcs_close"></button>
+        <select id="d_gcs_calc_a"></select>
+        <select id="d_gcs_calc_k"></select>
+        <select id="d_gcs_calc_m"></select>
+        <button id="d_gcs_apply"></button>
+        <span id="d_gcs_calc_total"></span>
+      </div>
     </div>
     <div id="e_back_group" class="chip-group" data-single="true"><button class="chip" data-value="Be pakitimų"></button><button class="chip" data-value="Pakitimai"></button></div>
     <textarea id="output"></textarea>
@@ -178,6 +182,23 @@ describe('patient fields', () => {
     document.body.click();
     expect(panel.style.display).toBe('none');
     expect(document.activeElement).toBe(btn);
+  });
+
+  test('GCS panel traps focus within dialog', () => {
+    const btn=document.getElementById('btnGCSCalc');
+    const close=document.getElementById('d_gcs_close');
+    const apply=document.getElementById('d_gcs_apply');
+
+    btn.click();
+    apply.focus();
+    document.dispatchEvent(new KeyboardEvent('keydown',{key:'Tab'}));
+    expect(document.activeElement).toBe(close);
+
+    close.focus();
+    document.dispatchEvent(new KeyboardEvent('keydown',{key:'Tab',shiftKey:true}));
+    expect(document.activeElement).toBe(apply);
+
+    document.dispatchEvent(new KeyboardEvent('keydown',{key:'Escape'}));
   });
 
   test('PDF button generates file via jsPDF', async () => {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -185,19 +185,32 @@ function setupGcsCalc(prefix){
   const selM=$(`#${prefix}_gcs_calc_m`);
   const apply=$(`#${prefix}_gcs_apply`);
   const total=$(`#${prefix}_gcs_calc_total`);
+  const btnClose=$(`#${prefix}_gcs_close`);
   const btn = prefix==='spr' ? $('#btnSprGCSCalc') : $('#btnGCSCalc');
   if(!panel||!selA||!selK||!selM||!apply||!total) return ()=>{};
 
   const update=()=>{ total.textContent=gksSum(selA.value,selK.value,selM.value); };
   [selA,selK,selM].forEach(sel=>sel.addEventListener('change',update));
 
+  let firstFocusable, lastFocusable;
   const close=()=>{
     panel.style.display='none';
     document.removeEventListener('keydown',onKey);
     document.removeEventListener('click',onDocClick);
     if(btn) btn.focus();
   };
-  const onKey=e=>{ if(e.key==='Escape') close(); };
+  const onKey=e=>{
+    if(e.key==='Escape') return close();
+    if(e.key==='Tab'){
+      if(e.shiftKey && document.activeElement===firstFocusable){
+        e.preventDefault();
+        lastFocusable.focus();
+      }else if(!e.shiftKey && document.activeElement===lastFocusable){
+        e.preventDefault();
+        firstFocusable.focus();
+      }
+    }
+  };
   const onDocClick=e=>{ if(!panel.contains(e.target) && e.target!==btn) close(); };
 
   apply.addEventListener('click',()=>{
@@ -209,10 +222,15 @@ function setupGcsCalc(prefix){
     saveAll();
   });
 
+  if(btnClose) btnClose.addEventListener('click',close);
+
   return ()=>{
     const hidden=panel.style.display==='none';
     if(hidden){
       panel.style.display='block';
+      const focusables=panel.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      firstFocusable=focusables[0];
+      lastFocusable=focusables[focusables.length-1];
       document.addEventListener('keydown',onKey);
       document.addEventListener('click',onDocClick);
       selA.focus();


### PR DESCRIPTION
## Summary
- wrap GCS calculators in modal dialog with screen-reader heading
- add visible close button and focus-trap logic
- extend tests for dialog accessibility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adec0ac5a48320aaa0a10ddbd76488