### PR TITLE
Improve pupil note accessibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -295,13 +295,19 @@
       </div>
       <div class="mt-8">
         <label>Vyzdžiai – Kairė</label>
-        <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
-        <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="hidden mt-6">
+        <div id="d_pupil_left_wrapper" aria-expanded="false">
+          <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
+          <label for="d_pupil_left_note" class="mt-6" hidden>Pastabos</label>
+          <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="mt-6" hidden>
+        </div>
       </div>
       <div class="mt-8">
         <label>Vyzdžiai – Dešinė</label>
-        <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
-        <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="hidden mt-6">
+        <div id="d_pupil_right_wrapper" aria-expanded="false">
+          <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
+          <label for="d_pupil_right_note" class="mt-6" hidden>Pastabos</label>
+          <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="mt-6" hidden>
+        </div>
       </div>
       <div class="row mt-8"><label class="m-0" for="d_notes">Pastabos</label><input id="d_notes" type="text" placeholder="Trumpai..."></div>
     </section>

--- a/public/js/__tests__/chips.test.js
+++ b/public/js/__tests__/chips.test.js
@@ -150,21 +150,26 @@ describe('chips', () => {
 
   test('toggles pupil note visibility and clears value when switching options', () => {
     document.body.innerHTML = `
-      <div id="d_pupil_left_group" data-single="true">
-        <button type="button" class="chip" data-value="n.y." aria-pressed="false"></button>
-        <button type="button" class="chip" data-value="kita" aria-pressed="false"></button>
+      <div id="d_pupil_left_wrapper" aria-expanded="false">
+        <div id="d_pupil_left_group" data-single="true">
+          <button type="button" class="chip" data-value="n.y." aria-pressed="false"></button>
+          <button type="button" class="chip" data-value="kita" aria-pressed="false"></button>
+        </div>
+        <label for="d_pupil_left_note" hidden>Pastabos</label>
+        <input id="d_pupil_left_note" hidden />
       </div>
-      <input id="d_pupil_left_note" style="display:none;" />
     `;
     const { initChips } = require('../chips.js');
     initChips();
     const [nyChip, otherChip] = document.querySelectorAll('#d_pupil_left_group .chip');
     const note = document.getElementById('d_pupil_left_note');
     otherChip.click();
-    expect(note.style.display).toBe('block');
+    expect(note.hidden).toBe(false);
+    expect(document.getElementById('d_pupil_left_wrapper').getAttribute('aria-expanded')).toBe('true');
     note.value = 'test';
     nyChip.click();
-    expect(note.style.display).toBe('none');
+    expect(note.hidden).toBe(true);
+    expect(document.getElementById('d_pupil_left_wrapper').getAttribute('aria-expanded')).toBe('false');
     expect(note.value).toBe('');
   });
 });

--- a/public/js/chips.js
+++ b/public/js/chips.js
@@ -52,9 +52,13 @@ function togglePupilNote(side, chip){
   const groupId = `d_pupil_${side}_group`;
   if(chip.parentElement?.id !== groupId) return;
   const note = $(`#d_pupil_${side}_note`);
+  const group = note.parentElement;
   const show = chip.dataset.value==='kita' && isChipActive(chip);
-  note.style.display = show ? 'block' : 'none';
+  note.hidden = !show;
+  const label = group.querySelector(`label[for="d_pupil_${side}_note"]`);
+  if(label) label.hidden = !show;
   if(!show) note.value='';
+  group.setAttribute('aria-expanded', show);
 }
 
 function toggleBackNote(chip){


### PR DESCRIPTION
## Summary
- Wrap pupil chip groups and notes in containers with `aria-expanded`
- Add visible labels for pupil note fields
- Toggle pupil note visibility via `hidden` attribute and track `aria-expanded`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adedc8220883208e7094acdbd1e463