### PR TITLE
feat: centralize request validation and error handling

### DIFF
--- a/server/validate.js
+++ b/server/validate.js
@@ -1,0 +1,11 @@
+module.exports = function validate(schema) {
+  return function (req, res, next) {
+    const { error, value } = schema.validate(req.body);
+    if (error) {
+      error.status = 400;
+      return next(error);
+    }
+    req.body = value;
+    next();
+  };
+};


### PR DESCRIPTION
## Summary
- add reusable Joi validation middleware
- replace inline request validation with middleware across routes
- add global error handler returning `{ error: message }`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae84adf480832097f808ba7c17bd82