### PR TITLE
Refine circulation skin color options and metric labels

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -201,7 +201,7 @@
       <h2>C – Kraujotaka</h2>
       <div class="grid cols-3 cols-auto">
         <div><label for="c_hr">ŠSD (k./min)</label><input id="c_hr" type="number" min="0" max="250" title="ŠSD – beats per minute, 0–250"></div>
-        <div class="row"><div class="flex-1"><label for="c_sbp">AKS s</label><input id="c_sbp" type="number" min="0" max="300" title="AKS s – mmHg, 0–300"></div><div class="flex-1"><label for="c_dbp">AKS d</label><input id="c_dbp" type="number" min="0" max="200" title="AKS d – mmHg, 0–200"></div><div class="flex-1"><label>MAP</label><span id="c_map"></span></div><div class="flex-1"><label>SI</label><span id="c_si"></span></div></div>
+        <div class="row"><div class="flex-1"><label for="c_sbp">AKS s</label><input id="c_sbp" type="number" min="0" max="300" title="AKS s – mmHg, 0–300"></div><div class="flex-1"><label for="c_dbp">AKS d</label><input id="c_dbp" type="number" min="0" max="200" title="AKS d – mmHg, 0–200"></div><div class="flex-1"><label>VAS</label><span id="c_map"></span></div><div class="flex-1"><label>ŠI</label><span id="c_si"></span></div></div>
         <div><label for="c_caprefill">KPL (sek.)</label><input id="c_caprefill" type="number" step="0.1" min="0" max="20" title="KPL – seconds, 0–20"></div>
         <div>
           <label>Radialinis pulsas</label>
@@ -226,9 +226,13 @@
         </div>
         <div>
           <label>Odos spalva</label>
-          <div class="chip-group" id="c_skin_color_group" data-single="true">
-            <button type="button" class="chip" data-value="Blyški" aria-pressed="false">Blyški</button>
-            <button type="button" class="chip red" data-value="Paraudusi" aria-pressed="false">Paraudusi</button>
+          <div class="row">
+            <div class="chip-group" id="c_skin_color_group" data-single="true">
+              <button type="button" class="chip" data-value="Rausva" aria-pressed="false">Rausva</button>
+              <button type="button" class="chip red" data-value="Blyški" aria-pressed="false">Blyški</button>
+              <button type="button" class="chip red" data-value="Kita" aria-pressed="false">Kita</button>
+            </div>
+            <input id="c_skin_color_other" type="text" placeholder="Kita..." class="hidden">
           </div>
         </div>
       </div>
@@ -295,13 +299,19 @@
       </div>
       <div class="mt-8">
         <label>Vyzdžiai – Kairė</label>
-        <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
-        <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="hidden mt-6">
+        <div id="d_pupil_left_wrapper" aria-expanded="false">
+          <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
+          <label for="d_pupil_left_note" class="mt-6" hidden>Pastabos</label>
+          <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="mt-6" hidden>
+        </div>
       </div>
       <div class="mt-8">
         <label>Vyzdžiai – Dešinė</label>
-        <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
-        <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="hidden mt-6">
+        <div id="d_pupil_right_wrapper" aria-expanded="false">
+          <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
+          <label for="d_pupil_right_note" class="mt-6" hidden>Pastabos</label>
+          <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="mt-6" hidden>
+        </div>
       </div>
       <div class="row mt-8"><label class="m-0" for="d_notes">Pastabos</label><input id="d_notes" type="text" placeholder="Trumpai..."></div>
     </section>

--- a/docs/js/chips.js
+++ b/docs/js/chips.js
@@ -52,15 +52,27 @@ function togglePupilNote(side, chip){
   const groupId = `d_pupil_${side}_group`;
   if(chip.parentElement?.id !== groupId) return;
   const note = $(`#d_pupil_${side}_note`);
+  const group = note.parentElement;
   const show = chip.dataset.value==='kita' && isChipActive(chip);
-  note.style.display = show ? 'block' : 'none';
+  note.hidden = !show;
+  const label = group.querySelector(`label[for="d_pupil_${side}_note"]`);
+  if(label) label.hidden = !show;
   if(!show) note.value='';
+  group.setAttribute('aria-expanded', show);
 }
 
 function toggleBackNote(chip){
   if(chip.parentElement?.id !== 'e_back_group') return;
   const note = $('#e_back_notes');
   const show = chip.dataset.value==='Pakitimai' && isChipActive(chip);
+  note.style.display = show ? 'block' : 'none';
+  if(!show) note.value='';
+}
+
+function toggleSkinColorNote(chip){
+  if(chip.parentElement?.id !== 'c_skin_color_group') return;
+  const note = $('#c_skin_color_other');
+  const show = chip.dataset.value==='Kita' && isChipActive(chip);
   note.style.display = show ? 'block' : 'none';
   if(!show) note.value='';
 }
@@ -112,6 +124,7 @@ export function initChips(saveAll){
     togglePupilNote('left', chip);
     togglePupilNote('right', chip);
     toggleBackNote(chip);
+    toggleSkinColorNote(chip);
     if(group.id.startsWith('imaging_')){
       const box=$('#imaging_other');
       const show=!!document.querySelector('[id^="imaging_"] .chip.active[data-value="Kita"]');

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -55,14 +55,15 @@ export function generateReport(){
   const radial=getSingleValue('#c_pulse_radial_group');
   const femoral=getSingleValue('#c_pulse_femoral_group');
   const skinTemp=getSingleValue('#c_skin_temp_group');
-  const skinColor=getSingleValue('#c_skin_color_group');
+  const skinColorChip=getSingleValue('#c_skin_color_group');
+  const skinColor=skinColorChip==='Kita'?$('#c_skin_color_other').value:skinColorChip;
   const skinParts=[skinTemp, skinColor].filter(Boolean);
   const skin=skinParts.length?('Oda: '+skinParts.join(', ')):null;
   out.push('\n--- C Kraujotaka ---'); out.push([
     chr?('ŠSD '+chr+'/min'):null,
     (csbp||cdbp)?('AKS '+csbp+'/'+cdbp):null,
-    cmap?('MAP '+cmap):null,
-    csi?('SI '+csi):null,
+    cmap?('VAS '+cmap):null,
+    csi?('ŠI '+csi):null,
     $('#c_caprefill').value?('KPL '+$('#c_caprefill').value+'s'):null,
     radial?('Radialinis pulsas '+radial):null,
     femoral?('Femoralis pulsas '+femoral):null,

--- a/public/index.html
+++ b/public/index.html
@@ -201,7 +201,7 @@
       <h2>C – Kraujotaka</h2>
       <div class="grid cols-3 cols-auto">
         <div><label for="c_hr">ŠSD (k./min)</label><input id="c_hr" type="number" min="0" max="250" title="ŠSD – beats per minute, 0–250"></div>
-        <div class="row"><div class="flex-1"><label for="c_sbp">AKS s</label><input id="c_sbp" type="number" min="0" max="300" title="AKS s – mmHg, 0–300"></div><div class="flex-1"><label for="c_dbp">AKS d</label><input id="c_dbp" type="number" min="0" max="200" title="AKS d – mmHg, 0–200"></div><div class="flex-1"><label>MAP</label><span id="c_map"></span></div><div class="flex-1"><label>SI</label><span id="c_si"></span></div></div>
+        <div class="row"><div class="flex-1"><label for="c_sbp">AKS s</label><input id="c_sbp" type="number" min="0" max="300" title="AKS s – mmHg, 0–300"></div><div class="flex-1"><label for="c_dbp">AKS d</label><input id="c_dbp" type="number" min="0" max="200" title="AKS d – mmHg, 0–200"></div><div class="flex-1"><label>VAS</label><span id="c_map"></span></div><div class="flex-1"><label>ŠI</label><span id="c_si"></span></div></div>
         <div><label for="c_caprefill">KPL (sek.)</label><input id="c_caprefill" type="number" step="0.1" min="0" max="20" title="KPL – seconds, 0–20"></div>
         <div>
           <label>Radialinis pulsas</label>
@@ -226,9 +226,13 @@
         </div>
         <div>
           <label>Odos spalva</label>
-          <div class="chip-group" id="c_skin_color_group" data-single="true">
-            <button type="button" class="chip" data-value="Blyški" aria-pressed="false">Blyški</button>
-            <button type="button" class="chip red" data-value="Paraudusi" aria-pressed="false">Paraudusi</button>
+          <div class="row">
+            <div class="chip-group" id="c_skin_color_group" data-single="true">
+              <button type="button" class="chip" data-value="Rausva" aria-pressed="false">Rausva</button>
+              <button type="button" class="chip red" data-value="Blyški" aria-pressed="false">Blyški</button>
+              <button type="button" class="chip red" data-value="Kita" aria-pressed="false">Kita</button>
+            </div>
+            <input id="c_skin_color_other" type="text" placeholder="Kita..." class="hidden">
           </div>
         </div>
       </div>

--- a/public/js/__tests__/patient.test.js
+++ b/public/js/__tests__/patient.test.js
@@ -64,8 +64,8 @@ const setupDom = () => {
   const skinColor=document.getElementById('c_skin_color_group');
   skinColor.className='chip-group';
   skinColor.dataset.single='true';
-  skinColor.innerHTML='<button class="chip" data-value="Blyški"></button><button class="chip" data-value="Paraudusi"></button>';
-  const textInputs=['a_notes','gmp_mechanism','gmp_notes','b_oxygen_type','b_dpv_fio2','d_pupil_left_note','d_pupil_right_note','d_notes','e_back_notes','e_other','spr_skyrius_kita','spr_ligonine','patient_history'];
+  skinColor.innerHTML='<button class="chip" data-value="Rausva"></button><button class="chip" data-value="Blyški"></button><button class="chip" data-value="Kita"></button>';
+  const textInputs=['a_notes','gmp_mechanism','gmp_notes','b_oxygen_type','b_dpv_fio2','d_pupil_left_note','d_pupil_right_note','d_notes','e_back_notes','e_other','spr_skyrius_kita','spr_ligonine','patient_history','c_skin_color_other'];
   textInputs.forEach(id=>{ const i=document.createElement('input'); i.id=id; i.type='text'; document.body.appendChild(i); });
   const numberInputs=['b_rr','b_spo2','b_oxygen_liters','c_hr','c_sbp','c_dbp','c_caprefill','d_gksa','d_gksk','d_gksm','e_temp',
     'spr_hr','spr_rr','spr_spo2','spr_sbp','spr_dbp','spr_gksa','spr_gksk','spr_gksm','patient_age','gmp_hr','gmp_rr','gmp_spo2',

--- a/public/js/__tests__/report.test.js
+++ b/public/js/__tests__/report.test.js
@@ -11,7 +11,7 @@ describe('gksSum', () => {
 });
 
 describe('generateReport circulation metrics', () => {
-  test('includes MAP and shock index', () => {
+  test('includes VAS and shock index', () => {
     document.body.innerHTML = `
       <input id="patient_age"><input id="patient_sex"><input id="patient_history">
       <input id="gmp_hr"><input id="gmp_rr"><input id="gmp_spo2"><input id="gmp_sbp"><input id="gmp_dbp">
@@ -34,7 +34,7 @@ describe('generateReport circulation metrics', () => {
     document.querySelector('#c_dbp').value = '60';
     generateReport();
     const out = document.querySelector('#output').value;
-    expect(out).toContain('MAP 80');
-    expect(out).toContain('SI 0.75');
+    expect(out).toContain('VAS 80');
+    expect(out).toContain('ŠI 0.75');
   });
 });

--- a/public/js/chips.js
+++ b/public/js/chips.js
@@ -69,6 +69,14 @@ function toggleBackNote(chip){
   if(!show) note.value='';
 }
 
+function toggleSkinColorNote(chip){
+  if(chip.parentElement?.id !== 'c_skin_color_group') return;
+  const note = $('#c_skin_color_other');
+  const show = chip.dataset.value==='Kita' && isChipActive(chip);
+  note.style.display = show ? 'block' : 'none';
+  if(!show) note.value='';
+}
+
 function updateBreathGroups(){
   ['b_breath_left_group','b_breath_right_group'].forEach(id=>{
     const group = $('#'+id);
@@ -116,6 +124,7 @@ export function initChips(saveAll){
     togglePupilNote('left', chip);
     togglePupilNote('right', chip);
     toggleBackNote(chip);
+    toggleSkinColorNote(chip);
     if(group.id.startsWith('imaging_')){
       const box=$('#imaging_other');
       const show=!!document.querySelector('[id^="imaging_"] .chip.active[data-value="Kita"]');

--- a/public/js/report.js
+++ b/public/js/report.js
@@ -55,14 +55,15 @@ export function generateReport(){
   const radial=getSingleValue('#c_pulse_radial_group');
   const femoral=getSingleValue('#c_pulse_femoral_group');
   const skinTemp=getSingleValue('#c_skin_temp_group');
-  const skinColor=getSingleValue('#c_skin_color_group');
+  const skinColorChip=getSingleValue('#c_skin_color_group');
+  const skinColor=skinColorChip==='Kita'?$('#c_skin_color_other').value:skinColorChip;
   const skinParts=[skinTemp, skinColor].filter(Boolean);
   const skin=skinParts.length?('Oda: '+skinParts.join(', ')):null;
   out.push('\n--- C Kraujotaka ---'); out.push([
     chr?('ŠSD '+chr+'/min'):null,
     (csbp||cdbp)?('AKS '+csbp+'/'+cdbp):null,
-    cmap?('MAP '+cmap):null,
-    csi?('SI '+csi):null,
+    cmap?('VAS '+cmap):null,
+    csi?('ŠI '+csi):null,
     $('#c_caprefill').value?('KPL '+$('#c_caprefill').value+'s'):null,
     radial?('Radialinis pulsas '+radial):null,
     femoral?('Femoralis pulsas '+femoral):null,

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -334,6 +334,7 @@ export function loadAll(){
       $('#d_pupil_left_note').style.display = ($$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
       $('#d_pupil_right_note').style.display = ($$('.chip.active', $('#d_pupil_right_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
       $('#e_back_notes').style.display = ($$('.chip.active', $('#e_back_group')).some(c=>c.dataset.value==='Pakitimai'))?'block':'none';
+      $('#c_skin_color_other').style.display = ($$('.chip.active', $('#c_skin_color_group')).some(c=>c.dataset.value==='Kita'))?'block':'none';
       $('#oxygenFields').style.display = ($('#b_oxygen_liters').value || $('#b_oxygen_type').value) ? 'flex' : 'none';
     $('#dpvFields').style.display = $('#b_dpv_fio2').value ? 'flex' : 'none';
     $('#spr_skyrius_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Stacionarizavimas'))?'block':'none';


### PR DESCRIPTION
## Summary
- Replace circulation MAP/SI labels with Lithuanian equivalents VAS and ŠI
- Expand circulation skin color with Rausva, Blyški, and a custom "Kita" option
- Persist and report custom skin color text selections

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9494bfec832087cd7ae7eecf46c4