### PR TITLE
Fix toggling for pupil notes and ventilation fields

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -301,16 +301,16 @@
         <label>Vyzdžiai – Kairė</label>
         <div id="d_pupil_left_wrapper" aria-expanded="false">
           <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
-          <label for="d_pupil_left_note" class="mt-6" hidden>Pastabos</label>
-          <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="mt-6" hidden>
+          <label for="d_pupil_left_note" class="mt-6 hidden" hidden>Pastabos</label>
+          <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
         </div>
       </div>
       <div class="mt-8">
         <label>Vyzdžiai – Dešinė</label>
         <div id="d_pupil_right_wrapper" aria-expanded="false">
           <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
-          <label for="d_pupil_right_note" class="mt-6" hidden>Pastabos</label>
-          <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="mt-6" hidden>
+          <label for="d_pupil_right_note" class="mt-6 hidden" hidden>Pastabos</label>
+          <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
         </div>
       </div>
       <div class="row mt-8"><label class="m-0" for="d_notes">Pastabos</label><input id="d_notes" type="text" placeholder="Trumpai..."></div>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -313,14 +313,12 @@ async function init(){
     $('#btnSprNow').addEventListener('click', ()=>{ $('#spr_time').value=nowHM(); saveAll(); });
   $('#btnOxygen').addEventListener('click', ()=>{
     const box = $('#oxygenFields');
-    const show = getComputedStyle(box).display === 'none';
-    box.style.display = show ? 'flex' : 'none';
+    box.classList.toggle('hidden');
     saveAll();
   });
   $('#btnDPV').addEventListener('click', ()=>{
     const box = $('#dpvFields');
-    const show = getComputedStyle(box).display === 'none';
-    box.style.display = show ? 'flex' : 'none';
+    box.classList.toggle('hidden');
     saveAll();
   });
     $('#spr_skyrius').addEventListener('change', e=>{

--- a/docs/js/chips.js
+++ b/docs/js/chips.js
@@ -55,8 +55,12 @@ function togglePupilNote(side, chip){
   const group = note.parentElement;
   const show = chip.dataset.value==='kita' && isChipActive(chip);
   note.hidden = !show;
+  note.classList.toggle('hidden', !show);
   const label = group.querySelector(`label[for="d_pupil_${side}_note"]`);
-  if(label) label.hidden = !show;
+  if(label){
+    label.hidden = !show;
+    label.classList.toggle('hidden', !show);
+  }
   if(!show) note.value='';
   group.setAttribute('aria-expanded', show);
 }

--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -331,12 +331,26 @@ export function loadAll(){
     function unpack(container,records){ if(!Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; const d=card.querySelector('.act_dose'); if(d) d.value=r.dose||''; card.querySelector('.act_note').value=r.note||''; const cn=card.querySelector('.act_custom_name'); if(cn) cn.value=r.name||'';});}
     unpack($('#pain_meds'),data['pain_meds']); unpack($('#bleeding_meds'),data['bleeding_meds']); unpack($('#other_meds'),data['other_meds']); unpack($('#procedures'),data['procs']);
     if(data['bodymap_svg']) bodyMap.load(data['bodymap_svg']);
-      $('#d_pupil_left_note').style.display = ($$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
-      $('#d_pupil_right_note').style.display = ($$('.chip.active', $('#d_pupil_right_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
+      const showLeftNote = $$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita');
+      const leftNote = $('#d_pupil_left_note');
+      const leftLabel = $('#d_pupil_left_wrapper label[for="d_pupil_left_note"]');
+      leftNote.hidden = !showLeftNote;
+      leftNote.classList.toggle('hidden', !showLeftNote);
+      if(leftLabel){ leftLabel.hidden = !showLeftNote; leftLabel.classList.toggle('hidden', !showLeftNote); }
+      const leftWrapper = $('#d_pupil_left_wrapper');
+      if(leftWrapper) leftWrapper.setAttribute('aria-expanded', showLeftNote);
+      const showRightNote = $$('.chip.active', $('#d_pupil_right_group')).some(c=>c.dataset.value==='kita');
+      const rightNote = $('#d_pupil_right_note');
+      const rightLabel = $('#d_pupil_right_wrapper label[for="d_pupil_right_note"]');
+      rightNote.hidden = !showRightNote;
+      rightNote.classList.toggle('hidden', !showRightNote);
+      if(rightLabel){ rightLabel.hidden = !showRightNote; rightLabel.classList.toggle('hidden', !showRightNote); }
+      const rightWrapper = $('#d_pupil_right_wrapper');
+      if(rightWrapper) rightWrapper.setAttribute('aria-expanded', showRightNote);
       $('#e_back_notes').style.display = ($$('.chip.active', $('#e_back_group')).some(c=>c.dataset.value==='Pakitimai'))?'block':'none';
       $('#c_skin_color_other').style.display = ($$('.chip.active', $('#c_skin_color_group')).some(c=>c.dataset.value==='Kita'))?'block':'none';
-      $('#oxygenFields').style.display = ($('#b_oxygen_liters').value || $('#b_oxygen_type').value) ? 'flex' : 'none';
-    $('#dpvFields').style.display = $('#b_dpv_fio2').value ? 'flex' : 'none';
+      $('#oxygenFields').classList.toggle('hidden', !($('#b_oxygen_liters').value || $('#b_oxygen_type').value));
+      $('#dpvFields').classList.toggle('hidden', !$('#b_dpv_fio2').value);
     $('#spr_skyrius_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Stacionarizavimas'))?'block':'none';
     $('#spr_ligonine_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Pervežimas į kitą ligoninę'))?'block':'none';
     $('#spr_skyrius_kita').style.display = ($('#spr_skyrius').value === 'Kita') ? 'block' : 'none';

--- a/public/index.html
+++ b/public/index.html
@@ -301,16 +301,16 @@
         <label>Vyzdžiai – Kairė</label>
         <div id="d_pupil_left_wrapper" aria-expanded="false">
           <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
-          <label for="d_pupil_left_note" class="mt-6" hidden>Pastabos</label>
-          <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="mt-6" hidden>
+          <label for="d_pupil_left_note" class="mt-6 hidden" hidden>Pastabos</label>
+          <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
         </div>
       </div>
       <div class="mt-8">
         <label>Vyzdžiai – Dešinė</label>
         <div id="d_pupil_right_wrapper" aria-expanded="false">
           <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
-          <label for="d_pupil_right_note" class="mt-6" hidden>Pastabos</label>
-          <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="mt-6" hidden>
+          <label for="d_pupil_right_note" class="mt-6 hidden" hidden>Pastabos</label>
+          <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
         </div>
       </div>
       <div class="row mt-8"><label class="m-0" for="d_notes">Pastabos</label><input id="d_notes" type="text" placeholder="Trumpai..."></div>

--- a/public/js/__tests__/chips.test.js
+++ b/public/js/__tests__/chips.test.js
@@ -155,8 +155,8 @@ describe('chips', () => {
           <button type="button" class="chip" data-value="n.y." aria-pressed="false"></button>
           <button type="button" class="chip" data-value="kita" aria-pressed="false"></button>
         </div>
-        <label for="d_pupil_left_note" hidden>Pastabos</label>
-        <input id="d_pupil_left_note" hidden />
+        <label for="d_pupil_left_note" class="hidden" hidden>Pastabos</label>
+        <input id="d_pupil_left_note" class="hidden" hidden />
       </div>
     `;
     const { initChips } = require('../chips.js');
@@ -164,11 +164,11 @@ describe('chips', () => {
     const [nyChip, otherChip] = document.querySelectorAll('#d_pupil_left_group .chip');
     const note = document.getElementById('d_pupil_left_note');
     otherChip.click();
-    expect(note.hidden).toBe(false);
+    expect(note.classList.contains('hidden')).toBe(false);
     expect(document.getElementById('d_pupil_left_wrapper').getAttribute('aria-expanded')).toBe('true');
     note.value = 'test';
     nyChip.click();
-    expect(note.hidden).toBe(true);
+    expect(note.classList.contains('hidden')).toBe(true);
     expect(document.getElementById('d_pupil_left_wrapper').getAttribute('aria-expanded')).toBe('false');
     expect(note.value).toBe('');
   });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -358,15 +358,13 @@ async function init(){
   const btnOxygen=$('#btnOxygen');
   if(btnOxygen) btnOxygen.addEventListener('click',()=>{
     const box=$('#oxygenFields');
-    const show=getComputedStyle(box).display==='none';
-    box.style.display=show?'flex':'none';
+    box.classList.toggle('hidden');
     saveAll();
   });
   const btnDPV=$('#btnDPV');
   if(btnDPV) btnDPV.addEventListener('click',()=>{
     const box=$('#dpvFields');
-    const show=getComputedStyle(box).display==='none';
-    box.style.display=show?'flex':'none';
+    box.classList.toggle('hidden');
     saveAll();
   });
     $('#spr_skyrius').addEventListener('change', e=>{

--- a/public/js/chips.js
+++ b/public/js/chips.js
@@ -55,8 +55,12 @@ function togglePupilNote(side, chip){
   const group = note.parentElement;
   const show = chip.dataset.value==='kita' && isChipActive(chip);
   note.hidden = !show;
+  note.classList.toggle('hidden', !show);
   const label = group.querySelector(`label[for="d_pupil_${side}_note"]`);
-  if(label) label.hidden = !show;
+  if(label){
+    label.hidden = !show;
+    label.classList.toggle('hidden', !show);
+  }
   if(!show) note.value='';
   group.setAttribute('aria-expanded', show);
 }

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -331,12 +331,26 @@ export function loadAll(){
     function unpack(container,records){ if(!Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; const d=card.querySelector('.act_dose'); if(d) d.value=r.dose||''; card.querySelector('.act_note').value=r.note||''; const cn=card.querySelector('.act_custom_name'); if(cn) cn.value=r.name||'';});}
     unpack($('#pain_meds'),data['pain_meds']); unpack($('#bleeding_meds'),data['bleeding_meds']); unpack($('#other_meds'),data['other_meds']); unpack($('#procedures'),data['procs']);
     if(data['bodymap_svg']) bodyMap.load(data['bodymap_svg']);
-      $('#d_pupil_left_note').style.display = ($$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
-      $('#d_pupil_right_note').style.display = ($$('.chip.active', $('#d_pupil_right_group')).some(c=>c.dataset.value==='kita'))?'block':'none';
+      const showLeftNote = $$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita');
+      const leftNote = $('#d_pupil_left_note');
+      const leftLabel = $('#d_pupil_left_wrapper label[for="d_pupil_left_note"]');
+      leftNote.hidden = !showLeftNote;
+      leftNote.classList.toggle('hidden', !showLeftNote);
+      if(leftLabel){ leftLabel.hidden = !showLeftNote; leftLabel.classList.toggle('hidden', !showLeftNote); }
+      const leftWrapper = $('#d_pupil_left_wrapper');
+      if(leftWrapper) leftWrapper.setAttribute('aria-expanded', showLeftNote);
+      const showRightNote = $$('.chip.active', $('#d_pupil_right_group')).some(c=>c.dataset.value==='kita');
+      const rightNote = $('#d_pupil_right_note');
+      const rightLabel = $('#d_pupil_right_wrapper label[for="d_pupil_right_note"]');
+      rightNote.hidden = !showRightNote;
+      rightNote.classList.toggle('hidden', !showRightNote);
+      if(rightLabel){ rightLabel.hidden = !showRightNote; rightLabel.classList.toggle('hidden', !showRightNote); }
+      const rightWrapper = $('#d_pupil_right_wrapper');
+      if(rightWrapper) rightWrapper.setAttribute('aria-expanded', showRightNote);
       $('#e_back_notes').style.display = ($$('.chip.active', $('#e_back_group')).some(c=>c.dataset.value==='Pakitimai'))?'block':'none';
       $('#c_skin_color_other').style.display = ($$('.chip.active', $('#c_skin_color_group')).some(c=>c.dataset.value==='Kita'))?'block':'none';
-      $('#oxygenFields').style.display = ($('#b_oxygen_liters').value || $('#b_oxygen_type').value) ? 'flex' : 'none';
-    $('#dpvFields').style.display = $('#b_dpv_fio2').value ? 'flex' : 'none';
+      $('#oxygenFields').classList.toggle('hidden', !($('#b_oxygen_liters').value || $('#b_oxygen_type').value));
+      $('#dpvFields').classList.toggle('hidden', !$('#b_dpv_fio2').value);
     $('#spr_skyrius_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Stacionarizavimas'))?'block':'none';
     $('#spr_ligonine_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Pervežimas į kitą ligoninę'))?'block':'none';
     $('#spr_skyrius_kita').style.display = ($('#spr_skyrius').value === 'Kita') ? 'block' : 'none';


### PR DESCRIPTION
## Summary
- show text inputs when selecting "kita" pupil options
- reveal O2 and DPV fields by removing hidden class
- update session restore logic and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae97373fac832080e2b160d1050c06