### PR TITLE
refactor: add explicit server start

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ npm install
 Start the application backend:
 
 ```bash
-node server/index.js
+node server/start.js
 ```
 
-You can also create an `npm start` script for convenience.
+Alternatively, use the provided `npm start` script.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:server": "jest --config jest.server.config.js",
     "build:css": "sass --no-source-map --style=compressed public/css/scss/main.scss public/css/main.css",
     "build": "npm run build:css && rm -rf docs && cp -r public docs && rm -rf docs/js/__tests__",
-    "start": "node server/index.js",
+    "start": "node server/start.js",
     "lint": "eslint 'public/js/**/*.js' 'server/**/*.js'"
   },
   "keywords": [],

--- a/server/index.js
+++ b/server/index.js
@@ -187,8 +187,6 @@ app.use((err, req, res, next) => {
 const server = http.createServer(app);
 const io = new Server(server, { cors: { origin: '*' } });
 
-module.exports = { app, server };
-
 io.use((socket, next) => {
   if (DISABLE_AUTH) return next();
   const raw = socket.handshake.auth && socket.handshake.auth.token;
@@ -202,12 +200,16 @@ io.on('connection', socket => {
   socket.emit('users', db.users.map(u => u.name));
 });
 
-(async () => {
+async function startServer () {
   db = await loadDB();
-  server.listen(PORT, () => {
-    console.log('Server listening on', PORT);
-    if (DISABLE_AUTH) console.warn('Authentication disabled');
+  return new Promise((resolve, reject) => {
+    server.listen(PORT, () => {
+      console.log('Server listening on', PORT);
+      if (DISABLE_AUTH) console.warn('Authentication disabled');
+      resolve();
+    });
+    server.on('error', reject);
   });
-})().catch(err => {
-  console.error('Failed to start server', err);
-});
+}
+
+module.exports = { app, server, startServer };

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -20,23 +20,21 @@ describe('server API', () => {
   let fakeDB;
   let fsPromises;
   let originalPort;
+  let startServer;
 
-  beforeEach(async () => {
-    jest.resetModules();
-    fakeDB = { sessions: [], data: {}, users: [] };
-    fsPromises = require('fs').promises;
-    fsPromises.readFile.mockResolvedValue(JSON.stringify(fakeDB));
-    fsPromises.writeFile.mockImplementation(async (_path, data) => {
-      fakeDB = JSON.parse(data);
+    beforeEach(async () => {
+      jest.resetModules();
+      fakeDB = { sessions: [], data: {}, users: [] };
+      fsPromises = require('fs').promises;
+      fsPromises.readFile.mockResolvedValue(JSON.stringify(fakeDB));
+      fsPromises.writeFile.mockImplementation(async (_path, data) => {
+        fakeDB = JSON.parse(data);
+      });
+      originalPort = process.env.PORT;
+      process.env.PORT = 0;
+      ({ app, server, startServer } = require('./index'));
+      await startServer();
     });
-    originalPort = process.env.PORT;
-    process.env.PORT = 0;
-    ({ app, server } = require('./index'));
-    await new Promise(resolve => {
-      if (server.listening) return resolve();
-      server.on('listening', resolve);
-    });
-  });
 
   afterEach(async () => {
     await new Promise(resolve => server.close(resolve));

--- a/server/sessions.test.js
+++ b/server/sessions.test.js
@@ -11,21 +11,19 @@ describe('auth middleware', () => {
   let dbPath;
   let server;
   let base;
+  let startServer;
 
-  beforeAll(async () => {
-    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'db-'));
-    dbPath = path.join(tempDir, 'db.json');
-    await fs.promises.writeFile(dbPath, JSON.stringify({ sessions: [], data: {}, users: [] }));
-    process.env.DB_FILE = dbPath;
-    process.env.PORT = 0;
-    server = require('./index.js').server;
-    await new Promise(resolve => {
-      if (server.listening) return resolve();
-      server.on('listening', resolve);
+    beforeAll(async () => {
+      tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'db-'));
+      dbPath = path.join(tempDir, 'db.json');
+      await fs.promises.writeFile(dbPath, JSON.stringify({ sessions: [], data: {}, users: [] }));
+      process.env.DB_FILE = dbPath;
+      process.env.PORT = 0;
+      ({ server, startServer } = require('./index.js'));
+      await startServer();
+      const address = server.address();
+      base = `http://localhost:${address.port}`;
     });
-    const address = server.address();
-    base = `http://localhost:${address.port}`;
-  });
 
   afterAll(async () => {
     await new Promise(resolve => server.close(resolve));

--- a/server/start.js
+++ b/server/start.js
@@ -1,0 +1,5 @@
+const { startServer } = require('./index');
+
+startServer().catch(err => {
+  console.error('Failed to start server', err);
+});


### PR DESCRIPTION
## Summary
- refactor server setup to expose a `startServer` function
- add `server/start.js` entry point
- update docs and start script to use the new entry point

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae99d58eb88320bbf0f4d4a013a999