### PR TITLE
Handle socket connection states and manual reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ Execute the test suite:
 npm test
 ```
 
+## Connection Lifecycle
+
+The application maintains a Socket.IO connection to sync sessions and
+users. The client listens for several connection events to aid
+debugging:
+
+- `connect_error` – logs the error, notifies the user and retries the
+  connection.
+- `disconnect` – warns the user that the connection was lost.
+- `reconnect` – logs successful reconnection and notifies the user.
+
+After refreshing authentication tokens, call `setAuthToken()` followed
+by `reconnectSocket()` to manually re-establish the connection.
+
 ## Stylesheets
 
 The CSS is generated from Sass files in `css/scss`:


### PR DESCRIPTION
## Summary
- Add socket connection listeners for `connect_error`, `disconnect`, and `reconnect` with user notifications and retry logic.
- Expose `reconnectSocket` and `setAuthToken` helpers to allow manual reconnection after refreshing authentication tokens.
- Document connection lifecycle and manual reconnection steps.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae9fce6c008320916f782e3a3403f2