### PR TITLE
refactor: modularize app logic

### DIFF
--- a/docs/js/activation.js
+++ b/docs/js/activation.js
@@ -1,0 +1,64 @@
+import { $, $$ } from './utils.js';
+import { setChipActive, isChipActive } from './chips.js';
+import { saveAll } from './sessionManager.js';
+
+function ensureSingleTeam(){
+  const red=$('#chips_red');
+  const yellow=$('#chips_yellow');
+  const redActive=$$('.chip.active', red).length>0;
+  const yellowActive=$$('.chip.active', yellow).length>0;
+  if(redActive && yellowActive){
+    $$('.chip', yellow).forEach(c=>setChipActive(c,false));
+  }
+}
+
+function updateActivationIndicator(){
+  const dot=$('#activationIndicator');
+  const status=$('#activationStatusText');
+  const redActive=$$('.chip.active', $('#chips_red')).length>0;
+  const yellowActive=$$('.chip.active', $('#chips_yellow')).length>0;
+  if(!dot) return;
+  dot.classList.remove('red','yellow');
+  dot.style.display='none';
+  let text='No team activated';
+  if(redActive){
+    dot.classList.add('red');
+    dot.style.display='inline-block';
+    text='Red team activated';
+  } else if(yellowActive){
+    dot.classList.add('yellow');
+    dot.style.display='inline-block';
+    text='Yellow team activated';
+  }
+  if(status) status.textContent=text;
+}
+
+function setupActivationControls(){
+  const redGroup=$('#chips_red');
+  const yellowGroup=$('#chips_yellow');
+  redGroup.addEventListener('click',e=>{
+    const chip=e.target.closest('.chip');
+    if(!chip) return;
+    if(isChipActive(chip)){
+      $$('.chip', yellowGroup).forEach(c=>setChipActive(c,false));
+    }
+    ensureSingleTeam();
+    updateActivationIndicator();
+    saveAll();
+  });
+  yellowGroup.addEventListener('click',e=>{
+    const chip=e.target.closest('.chip');
+    if(!chip) return;
+    if(isChipActive(chip)){
+      $$('.chip', redGroup).forEach(c=>setChipActive(c,false));
+    }
+    ensureSingleTeam();
+    updateActivationIndicator();
+    saveAll();
+  });
+}
+
+window.updateActivationIndicator=updateActivationIndicator;
+window.ensureSingleTeam=ensureSingleTeam;
+
+export { ensureSingleTeam, updateActivationIndicator, setupActivationControls };

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1,4 +1,4 @@
-import { $, $$, nowHM } from './utils.js';
+import { $, $$ } from './utils.js';
 import { initTabs } from './tabs.js';
 import { initChips, setChipActive, isChipActive, addChipIndicators } from './chips.js';
 import { initAutoActivate } from './autoActivate.js';
@@ -11,17 +11,17 @@ import { initTopbar } from './components/topbar.js';
 import { initCollapsibles } from './sections.js';
 import { connectSocket, initSessions, fetchUsers, initTheme, saveAll, loadAll } from './sessionManager.js';
 import bodyMap from './bodyMap.js';
-import { generateReport, gksSum } from './report.js';
+import { generateReport } from './report.js';
 import { setupHeaderActions } from './headerActions.js';
 import { TEAM_ROLES } from './constants.js';
-import { initCirculationChecks } from './circulation.js';
+import { initCirculation } from './circulation.js';
+import { setupActivationControls, ensureSingleTeam, updateActivationIndicator } from './activation.js';
+import { initGcs } from './gcs.js';
+import { IMG_CT, IMG_XRAY, LABS, BLOOD_GROUPS, FAST_AREAS } from './config.js';
 export { validateVitals };
 
 /* ===== Imaging / Labs / Team ===== */
-const IMG_CT=['Galvos KT','Kaklo KT','Viso kūno KT'];
-const IMG_XRAY=['Krūtinės Ro','Dubens Ro'];
-const LABS=['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
-const BLOOD_GROUPS=['0-','0+','A-','A+','B-','B+','AB-','AB+'];
+const LS_MECHANISM_KEY='traumos_mechanizmai';
 
 const imgCtWrap=$('#imaging_ct'); IMG_CT.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); imgCtWrap.appendChild(s);});
 const imgXrayWrap=$('#imaging_xray'); IMG_XRAY.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); imgXrayWrap.appendChild(s);});
@@ -31,7 +31,8 @@ const bloodGroupWrap=$('#bloodGroup'); if(bloodGroupWrap){ BLOOD_GROUPS.forEach(
 const bloodUnitsInput=$('#bloodUnits');
 const addBloodOrderBtn=$('#addBloodOrder');
 if(bloodUnitsInput && bloodGroupWrap && addBloodOrderBtn){
-  addBloodOrderBtn.addEventListener('click',()=>{
+  const addOrder=e=>{
+    e.preventDefault();
     const units=bloodUnitsInput.value.trim();
     const groupEl=$$('.chip',bloodGroupWrap).find(c=>isChipActive(c));
     const group=groupEl?.dataset.value||'';
@@ -47,18 +48,12 @@ if(bloodUnitsInput && bloodGroupWrap && addBloodOrderBtn){
     saveAll();
     bloodUnitsInput.value='';
     $$('.chip',bloodGroupWrap).forEach(c=>setChipActive(c,false));
-  });
+  };
+  addBloodOrderBtn.addEventListener('click',addOrder);
+  bloodUnitsInput.addEventListener('keydown',e=>{ if(e.key==='Enter') addOrder(e); });
 }
-const fastAreas=[
-  {name:'Perikardas', marker:'skystis'},
-  {name:'Dešinė pleura', marker:'skystis ar oras'},
-  {name:'Kairė pleura', marker:'skystis ar oras'},
-  {name:'RUQ', marker:'skystis'},
-  {name:'LUQ', marker:'skystis'},
-  {name:'Dubuo', marker:'skystis'}
-];
 const fastWrap=$('#fastGrid');
-fastAreas.forEach(({name,marker})=>{
+FAST_AREAS.forEach(({name,marker})=>{
   const box=document.createElement('div');
   box.innerHTML=`<label>${name} (${marker})</label><div class="row"><label class="pill red"><input type="radio" name="fast_${name}" value="Yra"> Yra</label><label class="pill"><input type="radio" name="fast_${name}" value="Nėra"> Nėra</label></div>`;
   fastWrap.appendChild(box);
@@ -70,51 +65,31 @@ const teamWrap=$('#teamGrid'); TEAM_ROLES.forEach(r=>{
   teamWrap.appendChild(box);
 });
 
-/* ===== Activation indicator ===== */
-function ensureSingleTeam(){
-  const red=$('#chips_red');
-  const yellow=$('#chips_yellow');
-  const redActive=$$('.chip.active', red).length>0;
-  const yellowActive=$$('.chip.active', yellow).length>0;
-  if(redActive && yellowActive){
-    $$('.chip', yellow).forEach(c=>setChipActive(c,false));
-  }
-}
-function updateActivationIndicator(){
-  const dot=$('#activationIndicator');
-  const redActive=$$('.chip.active', $('#chips_red')).length>0;
-  const yellowActive=$$('.chip.active', $('#chips_yellow')).length>0;
-  dot.classList.remove('red','yellow');
-  dot.style.display='none';
-  if(redActive){ dot.classList.add('red'); dot.style.display='inline-block'; }
-  else if(yellowActive){ dot.classList.add('yellow'); dot.style.display='inline-block'; }
-}
-function setupActivationControls(){
-  const redGroup=$('#chips_red');
-  const yellowGroup=$('#chips_yellow');
-  redGroup.addEventListener('click',e=>{
-    const chip=e.target.closest('.chip');
-    if(!chip) return;
-    if(isChipActive(chip)){
-      $$('.chip', yellowGroup).forEach(c=>setChipActive(c,false));
+function initMechanismList(){
+  const list=$('#gmp_mechanism_list');
+  const input=$('#gmp_mechanism');
+  if(!list||!input) return;
+  const existing=new Set(Array.from(list.options).map(o=>o.value));
+  const stored=JSON.parse(localStorage.getItem(LS_MECHANISM_KEY)||'[]');
+  stored.forEach(v=>{
+    if(!existing.has(v)){
+      const opt=document.createElement('option');
+      opt.value=v;
+      list.appendChild(opt);
+      existing.add(v);
     }
-    ensureSingleTeam();
-    updateActivationIndicator();
-    saveAll();
   });
-  yellowGroup.addEventListener('click',e=>{
-    const chip=e.target.closest('.chip');
-    if(!chip) return;
-    if(isChipActive(chip)){
-      $$('.chip', redGroup).forEach(c=>setChipActive(c,false));
-    }
-    ensureSingleTeam();
-    updateActivationIndicator();
-    saveAll();
+  input.addEventListener('change',()=>{
+    const val=input.value.trim();
+    if(!val||existing.has(val)) return;
+    const opt=document.createElement('option');
+    opt.value=val;
+    list.appendChild(opt);
+    existing.add(val);
+    stored.push(val);
+    localStorage.setItem(LS_MECHANISM_KEY, JSON.stringify(stored));
   });
 }
-window.updateActivationIndicator=updateActivationIndicator;
-window.ensureSingleTeam=ensureSingleTeam;
 
 /* ===== Save / Load ===== */
 function expandOutput(){
@@ -132,81 +107,8 @@ function debounce(fn, delay){
   };
 }
 const saveAllDebounced = debounce(saveAll, 300);
+initGcs();
 /* ===== Other UI ===== */
-$('#btnGCS15').addEventListener('click',()=>{
-  $('#d_gksa').value=4; $('#d_gksk').value=5; $('#d_gksm').value=6;
-  ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
-  saveAll();
-});
-function setupGcsCalc(prefix){
-  const panel=$(`#${prefix}_gcs_calc`);
-  const selA=$(`#${prefix}_gcs_calc_a`);
-  const selK=$(`#${prefix}_gcs_calc_k`);
-  const selM=$(`#${prefix}_gcs_calc_m`);
-  const apply=$(`#${prefix}_gcs_apply`);
-  const total=$(`#${prefix}_gcs_calc_total`);
-  const btnClose=$(`#${prefix}_gcs_close`);
-  const btn = prefix==='spr' ? $('#btnSprGCSCalc') : $('#btnGCSCalc');
-  if(!panel||!selA||!selK||!selM||!apply||!total) return ()=>{};
-
-  const update=()=>{ total.textContent=gksSum(selA.value,selK.value,selM.value); };
-  [selA,selK,selM].forEach(sel=>sel.addEventListener('change',update));
-
-  let firstFocusable, lastFocusable;
-  const close=()=>{
-    panel.style.display='none';
-    document.removeEventListener('keydown',onKey);
-    document.removeEventListener('click',onDocClick);
-    if(btn) btn.focus();
-  };
-  const onKey=e=>{
-    if(e.key==='Escape') return close();
-    if(e.key==='Tab'){
-      if(e.shiftKey && document.activeElement===firstFocusable){
-        e.preventDefault();
-        lastFocusable.focus();
-      }else if(!e.shiftKey && document.activeElement===lastFocusable){
-        e.preventDefault();
-        firstFocusable.focus();
-      }
-    }
-  };
-  const onDocClick=e=>{ if(!panel.contains(e.target) && e.target!==btn) close(); };
-
-  apply.addEventListener('click',()=>{
-    if(selA.value) $(`#${prefix}_gksa`).value=selA.value;
-    if(selK.value) $(`#${prefix}_gksk`).value=selK.value;
-    if(selM.value) $(`#${prefix}_gksm`).value=selM.value;
-    ['#'+prefix+'_gksa','#'+prefix+'_gksk','#'+prefix+'_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
-    close();
-    saveAll();
-  });
-
-  if(btnClose) btnClose.addEventListener('click',close);
-
-  return ()=>{
-    const hidden=panel.style.display==='none';
-    if(hidden){
-      panel.style.display='block';
-      const focusables=panel.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-      firstFocusable=focusables[0];
-      lastFocusable=focusables[focusables.length-1];
-      document.addEventListener('keydown',onKey);
-      document.addEventListener('click',onDocClick);
-      selA.focus();
-    }else{
-      close();
-    }
-  };
-}
-if($('#d_gcs_calc') && $('#btnGCSCalc')){
-  const toggleDGcs=setupGcsCalc('d');
-  $('#btnGCSCalc').addEventListener('click',toggleDGcs);
-}
-if($('#spr_gcs_calc') && $('#btnSprGCSCalc')){
-  const toggleSprGcs=setupGcsCalc('spr');
-  $('#btnSprGCSCalc').addEventListener('click',toggleSprGcs);
-}
 
 function clampNumberInputs(){
   const clamp=el=>{
@@ -237,18 +139,21 @@ function clampNumberInputs(){
 async function init(){
   initTheme();
   await initTopbar();
-    setupHeaderActions({ validateForm, saveAll });
+  setupHeaderActions({ validateForm, saveAll });
   connectSocket();
   await fetchUsers();
   await initSessions();
-  initTabs();
-  initCollapsibles();
+  if(document.getElementById('tabs')){
+    initTabs();
+    initCollapsibles();
+  }
   bodyMap.init(saveAllDebounced);
   initChips(saveAllDebounced);
   initAutoActivate(saveAllDebounced);
   initActions(saveAllDebounced);
   initTimeline();
   setupActivationControls();
+  initMechanismList();
   document.addEventListener('input', saveAllDebounced);
 
   const vitals = {
@@ -282,42 +187,17 @@ async function init(){
       if(chip && isChipActive(chip)) logEvent('vital', label, chip.dataset.value);
     });
   });
-  const updateCirculationMetrics=()=>{
-    const hr=parseFloat($('#c_hr')?.value);
-    const sbp=parseFloat($('#c_sbp')?.value);
-    const dbp=parseFloat($('#c_dbp')?.value);
-    const mapEl=$('#c_map');
-    const siEl=$('#c_si');
-    const map=!isNaN(sbp)&&!isNaN(dbp)?Math.round((sbp+2*dbp)/3):'';
-    const si=!isNaN(hr)&&!isNaN(sbp)&&sbp>0?(hr/sbp).toFixed(2):'';
-    if(mapEl) mapEl.textContent=map;
-    if(siEl) siEl.textContent=si;
-  };
-  initCirculationChecks(updateCirculationMetrics);
-  updateCirculationMetrics();
-    const updateDGksTotal=()=>{
-      $('#d_gks_total').textContent=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value);
-    };
-    ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).addEventListener('input', updateDGksTotal));
-    const updateGmpGksTotal=()=>{
-      $('#gmp_gks_total').textContent=gksSum($('#gmp_gksa').value,$('#gmp_gksk').value,$('#gmp_gksm').value);
-    };
-    ['#gmp_gksa','#gmp_gksk','#gmp_gksm'].forEach(sel=>$(sel).addEventListener('input', updateGmpGksTotal));
-    if($('#spr_gks_total')){
-      const updateSprGksTotal=()=>{
-        $('#spr_gks_total').textContent=gksSum($('#spr_gksa').value,$('#spr_gksk').value,$('#spr_gksm').value);
-      };
-      ['#spr_gksa','#spr_gksk','#spr_gksm'].forEach(sel=>$(sel).addEventListener('input', updateSprGksTotal));
-    }
-    $('#btnGmpNow').addEventListener('click', ()=>{ $('#gmp_time').value=nowHM(); saveAll(); });
-    $('#btnSprNow').addEventListener('click', ()=>{ $('#spr_time').value=nowHM(); saveAll(); });
-  $('#btnOxygen').addEventListener('click', ()=>{
-    const box = $('#oxygenFields');
+
+  initCirculation();
+  const btnOxygen=$('#btnOxygen');
+  if(btnOxygen) btnOxygen.addEventListener('click',()=>{
+    const box=$('#oxygenFields');
     box.classList.toggle('hidden');
     saveAll();
   });
-  $('#btnDPV').addEventListener('click', ()=>{
-    const box = $('#dpvFields');
+  const btnDPV=$('#btnDPV');
+  if(btnDPV) btnDPV.addEventListener('click',()=>{
+    const box=$('#dpvFields');
     box.classList.toggle('hidden');
     saveAll();
   });
@@ -329,16 +209,20 @@ async function init(){
     });
     $('#output').addEventListener('input', expandOutput);
     loadAll();
-    ensureSingleTeam();
-    updateActivationIndicator();
+    if(document.getElementById('chips_red') && document.getElementById('chips_yellow')){
+      ensureSingleTeam();
+      updateActivationIndicator();
+    }
     expandOutput();
     clampNumberInputs();
     initValidation();
     validateVitals();
-    updateDGksTotal();
-    updateGmpGksTotal();
   }
-  window.addEventListener('DOMContentLoaded', init);
+  if(document.readyState==='loading'){
+    window.addEventListener('DOMContentLoaded', init);
+  }else{
+    init();
+  }
 
 function validateForm(){
   const fields=[

--- a/docs/js/chips.js
+++ b/docs/js/chips.js
@@ -158,7 +158,7 @@ export function initChips(saveAll){
   }
 
   document.addEventListener('click', e => {
-    const chip = e.target.closest('.chip');
+    const chip = e.target?.closest?.('.chip');
     if(!chip) return;
     handleChip(chip);
   }, true);
@@ -169,7 +169,7 @@ export function initChips(saveAll){
   //   newly focused chip is activated automatically to mirror native
   //   radio behaviour.
   document.addEventListener('keydown', e => {
-    const chip = e.target.closest('.chip');
+    const chip = e.target?.closest?.('.chip');
     if(!chip) return;
 
     if(e.key === 'Enter' || e.key === ' '){

--- a/docs/js/circulation.js
+++ b/docs/js/circulation.js
@@ -30,3 +30,20 @@ export function initCirculationChecks(updateMetrics) {
     });
   });
 }
+
+export function updateCirculationMetrics() {
+  const hr = parseFloat($('#c_hr')?.value);
+  const sbp = parseFloat($('#c_sbp')?.value);
+  const dbp = parseFloat($('#c_dbp')?.value);
+  const mapEl = $('#c_map');
+  const siEl = $('#c_si');
+  const map = !isNaN(sbp) && !isNaN(dbp) ? Math.round((sbp + 2 * dbp) / 3) : '';
+  const si = !isNaN(hr) && !isNaN(sbp) && sbp > 0 ? (hr / sbp).toFixed(2) : '';
+  if (mapEl) mapEl.textContent = map;
+  if (siEl) siEl.textContent = si;
+}
+
+export function initCirculation() {
+  initCirculationChecks(updateCirculationMetrics);
+  updateCirculationMetrics();
+}

--- a/docs/js/config.js
+++ b/docs/js/config.js
@@ -1,0 +1,12 @@
+export const IMG_CT = ['Galvos KT','Kaklo KT','Viso kūno KT'];
+export const IMG_XRAY = ['Krūtinės Ro','Dubens Ro'];
+export const LABS = ['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
+export const BLOOD_GROUPS = ['0-','0+','A-','A+','B-','B+','AB-','AB+'];
+export const FAST_AREAS = [
+  {name:'Perikardas', marker:'skystis'},
+  {name:'Dešinė pleura', marker:'skystis ar oras'},
+  {name:'Kairė pleura', marker:'skystis ar oras'},
+  {name:'RUQ', marker:'skystis'},
+  {name:'LUQ', marker:'skystis'},
+  {name:'Dubuo', marker:'skystis'},
+];

--- a/docs/js/gcs.js
+++ b/docs/js/gcs.js
@@ -1,0 +1,113 @@
+import { $, nowHM } from './utils.js';
+import { gksSum } from './report.js';
+import { saveAll } from './sessionManager.js';
+
+function setupGcsCalc(prefix){
+  const panel=$(`#${prefix}_gcs_calc`);
+  const selA=$(`#${prefix}_gcs_calc_a`);
+  const selK=$(`#${prefix}_gcs_calc_k`);
+  const selM=$(`#${prefix}_gcs_calc_m`);
+  const apply=$(`#${prefix}_gcs_apply`);
+  const total=$(`#${prefix}_gcs_calc_total`);
+  const btnClose=$(`#${prefix}_gcs_close`);
+  const btn = prefix==='spr' ? $('#btnSprGCSCalc') : $('#btnGCSCalc');
+  if(!panel||!selA||!selK||!selM||!apply||!total) return ()=>{};
+
+  const update=()=>{ total.textContent=gksSum(selA.value,selK.value,selM.value); };
+  [selA,selK,selM].forEach(sel=>sel.addEventListener('change',update));
+
+  let firstFocusable, lastFocusable;
+  const close=()=>{
+    panel.style.display='none';
+    document.removeEventListener('keydown',onKey);
+    document.removeEventListener('click',onDocClick);
+    if(btn) btn.focus();
+  };
+  const onKey=e=>{
+    if(e.key==='Escape') return close();
+    if(e.key==='Tab'){
+      if(e.shiftKey && document.activeElement===firstFocusable){
+        e.preventDefault();
+        lastFocusable.focus();
+      }else if(!e.shiftKey && document.activeElement===lastFocusable){
+        e.preventDefault();
+        firstFocusable.focus();
+      }
+    }
+  };
+  const onDocClick=e=>{ if(!panel.contains(e.target) && e.target!==btn) close(); };
+
+  apply.addEventListener('click',()=>{
+    if(selA.value) $(`#${prefix}_gksa`).value=selA.value;
+    if(selK.value) $(`#${prefix}_gksk`).value=selK.value;
+    if(selM.value) $(`#${prefix}_gksm`).value=selM.value;
+    ['#'+prefix+'_gksa','#'+prefix+'_gksk','#'+prefix+'_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
+    close();
+    saveAll();
+  });
+
+  if(btnClose) btnClose.addEventListener('click',close);
+
+  return ()=>{
+    const hidden=panel.style.display==='none';
+    if(hidden){
+      panel.style.display='block';
+      const focusables=panel.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      firstFocusable=focusables[0];
+      lastFocusable=focusables[focusables.length-1];
+      document.addEventListener('keydown',onKey);
+      document.addEventListener('click',onDocClick);
+      selA.focus();
+    }else{
+      close();
+    }
+  };
+}
+
+export function initGcs(){
+  const btnGcs15=$('#btnGCS15');
+  if(btnGcs15) btnGcs15.addEventListener('click',()=>{
+    $('#d_gksa').value=4; $('#d_gksk').value=5; $('#d_gksm').value=6;
+    ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
+    saveAll();
+  });
+
+  if($('#d_gcs_calc') && $('#btnGCSCalc')){
+    const toggleDGcs=setupGcsCalc('d');
+    $('#btnGCSCalc').addEventListener('click',toggleDGcs);
+  }
+  if($('#spr_gcs_calc') && $('#btnSprGCSCalc')){
+    const toggleSprGcs=setupGcsCalc('spr');
+    $('#btnSprGCSCalc').addEventListener('click',toggleSprGcs);
+  }
+
+  const updateDGksTotal=()=>{
+    const el=$('#d_gks_total');
+    if(el) el.textContent=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value);
+  };
+  ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).addEventListener('input', updateDGksTotal));
+
+  const updateGmpGksTotal=()=>{
+    const el=$('#gmp_gks_total');
+    if(el) el.textContent=gksSum($('#gmp_gksa').value,$('#gmp_gksk').value,$('#gmp_gksm').value);
+  };
+  ['#gmp_gksa','#gmp_gksk','#gmp_gksm'].forEach(sel=>$(sel).addEventListener('input', updateGmpGksTotal));
+
+  let updateSprGksTotal;
+  if($('#spr_gks_total')){
+    updateSprGksTotal=()=>{
+      const el=$('#spr_gks_total');
+      if(el) el.textContent=gksSum($('#spr_gksa').value,$('#spr_gksk').value,$('#spr_gksm').value);
+    };
+    ['#spr_gksa','#spr_gksk','#spr_gksm'].forEach(sel=>$(sel).addEventListener('input', updateSprGksTotal));
+  }
+
+  const btnGmpNow=$('#btnGmpNow');
+  if(btnGmpNow) btnGmpNow.addEventListener('click',()=>{ $('#gmp_time').value=nowHM(); saveAll(); });
+  const btnSprNow=$('#btnSprNow');
+  if(btnSprNow) btnSprNow.addEventListener('click',()=>{ $('#spr_time').value=nowHM(); saveAll(); });
+
+  updateDGksTotal();
+  updateGmpGksTotal();
+  if(updateSprGksTotal) updateSprGksTotal();
+}

--- a/public/js/activation.js
+++ b/public/js/activation.js
@@ -1,0 +1,64 @@
+import { $, $$ } from './utils.js';
+import { setChipActive, isChipActive } from './chips.js';
+import { saveAll } from './sessionManager.js';
+
+function ensureSingleTeam(){
+  const red=$('#chips_red');
+  const yellow=$('#chips_yellow');
+  const redActive=$$('.chip.active', red).length>0;
+  const yellowActive=$$('.chip.active', yellow).length>0;
+  if(redActive && yellowActive){
+    $$('.chip', yellow).forEach(c=>setChipActive(c,false));
+  }
+}
+
+function updateActivationIndicator(){
+  const dot=$('#activationIndicator');
+  const status=$('#activationStatusText');
+  const redActive=$$('.chip.active', $('#chips_red')).length>0;
+  const yellowActive=$$('.chip.active', $('#chips_yellow')).length>0;
+  if(!dot) return;
+  dot.classList.remove('red','yellow');
+  dot.style.display='none';
+  let text='No team activated';
+  if(redActive){
+    dot.classList.add('red');
+    dot.style.display='inline-block';
+    text='Red team activated';
+  } else if(yellowActive){
+    dot.classList.add('yellow');
+    dot.style.display='inline-block';
+    text='Yellow team activated';
+  }
+  if(status) status.textContent=text;
+}
+
+function setupActivationControls(){
+  const redGroup=$('#chips_red');
+  const yellowGroup=$('#chips_yellow');
+  redGroup.addEventListener('click',e=>{
+    const chip=e.target.closest('.chip');
+    if(!chip) return;
+    if(isChipActive(chip)){
+      $$('.chip', yellowGroup).forEach(c=>setChipActive(c,false));
+    }
+    ensureSingleTeam();
+    updateActivationIndicator();
+    saveAll();
+  });
+  yellowGroup.addEventListener('click',e=>{
+    const chip=e.target.closest('.chip');
+    if(!chip) return;
+    if(isChipActive(chip)){
+      $$('.chip', redGroup).forEach(c=>setChipActive(c,false));
+    }
+    ensureSingleTeam();
+    updateActivationIndicator();
+    saveAll();
+  });
+}
+
+window.updateActivationIndicator=updateActivationIndicator;
+window.ensureSingleTeam=ensureSingleTeam;
+
+export { ensureSingleTeam, updateActivationIndicator, setupActivationControls };

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,4 +1,4 @@
-import { $, $$, nowHM } from './utils.js';
+import { $, $$ } from './utils.js';
 import { initTabs } from './tabs.js';
 import { initChips, setChipActive, isChipActive, addChipIndicators } from './chips.js';
 import { initAutoActivate } from './autoActivate.js';
@@ -11,17 +11,16 @@ import { initTopbar } from './components/topbar.js';
 import { initCollapsibles } from './sections.js';
 import { connectSocket, initSessions, fetchUsers, initTheme, saveAll, loadAll } from './sessionManager.js';
 import bodyMap from './bodyMap.js';
-import { generateReport, gksSum } from './report.js';
+import { generateReport } from './report.js';
 import { setupHeaderActions } from './headerActions.js';
 import { TEAM_ROLES } from './constants.js';
-import { initCirculationChecks } from './circulation.js';
+import { initCirculation } from './circulation.js';
+import { setupActivationControls, ensureSingleTeam, updateActivationIndicator } from './activation.js';
+import { initGcs } from './gcs.js';
+import { IMG_CT, IMG_XRAY, LABS, BLOOD_GROUPS, FAST_AREAS } from './config.js';
 export { validateVitals };
 
 /* ===== Imaging / Labs / Team ===== */
-const IMG_CT=['Galvos KT','Kaklo KT','Viso kūno KT'];
-const IMG_XRAY=['Krūtinės Ro','Dubens Ro'];
-const LABS=['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
-const BLOOD_GROUPS=['0-','0+','A-','A+','B-','B+','AB-','AB+'];
 const LS_MECHANISM_KEY='traumos_mechanizmai';
 
 const imgCtWrap=$('#imaging_ct'); IMG_CT.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); imgCtWrap.appendChild(s);});
@@ -53,16 +52,8 @@ if(bloodUnitsInput && bloodGroupWrap && addBloodOrderBtn){
   addBloodOrderBtn.addEventListener('click',addOrder);
   bloodUnitsInput.addEventListener('keydown',e=>{ if(e.key==='Enter') addOrder(e); });
 }
-const fastAreas=[
-  {name:'Perikardas', marker:'skystis'},
-  {name:'Dešinė pleura', marker:'skystis ar oras'},
-  {name:'Kairė pleura', marker:'skystis ar oras'},
-  {name:'RUQ', marker:'skystis'},
-  {name:'LUQ', marker:'skystis'},
-  {name:'Dubuo', marker:'skystis'}
-];
 const fastWrap=$('#fastGrid');
-fastAreas.forEach(({name,marker})=>{
+FAST_AREAS.forEach(({name,marker})=>{
   const box=document.createElement('div');
   box.innerHTML=`<label>${name} (${marker})</label><div class="row"><label class="pill red"><input type="radio" name="fast_${name}" value="Yra"> Yra</label><label class="pill"><input type="radio" name="fast_${name}" value="Nėra"> Nėra</label></div>`;
   fastWrap.appendChild(box);
@@ -100,62 +91,6 @@ function initMechanismList(){
   });
 }
 
-/* ===== Activation indicator ===== */
-function ensureSingleTeam(){
-  const red=$('#chips_red');
-  const yellow=$('#chips_yellow');
-  const redActive=$$('.chip.active', red).length>0;
-  const yellowActive=$$('.chip.active', yellow).length>0;
-  if(redActive && yellowActive){
-    $$('.chip', yellow).forEach(c=>setChipActive(c,false));
-  }
-}
-function updateActivationIndicator(){
-  const dot=$('#activationIndicator');
-  const status=$('#activationStatusText');
-  const redActive=$$('.chip.active', $('#chips_red')).length>0;
-  const yellowActive=$$('.chip.active', $('#chips_yellow')).length>0;
-  dot.classList.remove('red','yellow');
-  dot.style.display='none';
-  let text='No team activated';
-  if(redActive){
-    dot.classList.add('red');
-    dot.style.display='inline-block';
-    text='Red team activated';
-  } else if(yellowActive){
-    dot.classList.add('yellow');
-    dot.style.display='inline-block';
-    text='Yellow team activated';
-  }
-  if(status) status.textContent=text;
-}
-function setupActivationControls(){
-  const redGroup=$('#chips_red');
-  const yellowGroup=$('#chips_yellow');
-  redGroup.addEventListener('click',e=>{
-    const chip=e.target.closest('.chip');
-    if(!chip) return;
-    if(isChipActive(chip)){
-      $$('.chip', yellowGroup).forEach(c=>setChipActive(c,false));
-    }
-    ensureSingleTeam();
-    updateActivationIndicator();
-    saveAll();
-  });
-  yellowGroup.addEventListener('click',e=>{
-    const chip=e.target.closest('.chip');
-    if(!chip) return;
-    if(isChipActive(chip)){
-      $$('.chip', redGroup).forEach(c=>setChipActive(c,false));
-    }
-    ensureSingleTeam();
-    updateActivationIndicator();
-    saveAll();
-  });
-}
-window.updateActivationIndicator=updateActivationIndicator;
-window.ensureSingleTeam=ensureSingleTeam;
-
 /* ===== Save / Load ===== */
 function expandOutput(){
   const ta = $('#output');
@@ -172,81 +107,8 @@ function debounce(fn, delay){
   };
 }
 const saveAllDebounced = debounce(saveAll, 300);
+initGcs();
 /* ===== Other UI ===== */
-$('#btnGCS15').addEventListener('click',()=>{
-  $('#d_gksa').value=4; $('#d_gksk').value=5; $('#d_gksm').value=6;
-  ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
-  saveAll();
-});
-function setupGcsCalc(prefix){
-  const panel=$(`#${prefix}_gcs_calc`);
-  const selA=$(`#${prefix}_gcs_calc_a`);
-  const selK=$(`#${prefix}_gcs_calc_k`);
-  const selM=$(`#${prefix}_gcs_calc_m`);
-  const apply=$(`#${prefix}_gcs_apply`);
-  const total=$(`#${prefix}_gcs_calc_total`);
-  const btnClose=$(`#${prefix}_gcs_close`);
-  const btn = prefix==='spr' ? $('#btnSprGCSCalc') : $('#btnGCSCalc');
-  if(!panel||!selA||!selK||!selM||!apply||!total) return ()=>{};
-
-  const update=()=>{ total.textContent=gksSum(selA.value,selK.value,selM.value); };
-  [selA,selK,selM].forEach(sel=>sel.addEventListener('change',update));
-
-  let firstFocusable, lastFocusable;
-  const close=()=>{
-    panel.style.display='none';
-    document.removeEventListener('keydown',onKey);
-    document.removeEventListener('click',onDocClick);
-    if(btn) btn.focus();
-  };
-  const onKey=e=>{
-    if(e.key==='Escape') return close();
-    if(e.key==='Tab'){
-      if(e.shiftKey && document.activeElement===firstFocusable){
-        e.preventDefault();
-        lastFocusable.focus();
-      }else if(!e.shiftKey && document.activeElement===lastFocusable){
-        e.preventDefault();
-        firstFocusable.focus();
-      }
-    }
-  };
-  const onDocClick=e=>{ if(!panel.contains(e.target) && e.target!==btn) close(); };
-
-  apply.addEventListener('click',()=>{
-    if(selA.value) $(`#${prefix}_gksa`).value=selA.value;
-    if(selK.value) $(`#${prefix}_gksk`).value=selK.value;
-    if(selM.value) $(`#${prefix}_gksm`).value=selM.value;
-    ['#'+prefix+'_gksa','#'+prefix+'_gksk','#'+prefix+'_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
-    close();
-    saveAll();
-  });
-
-  if(btnClose) btnClose.addEventListener('click',close);
-
-  return ()=>{
-    const hidden=panel.style.display==='none';
-    if(hidden){
-      panel.style.display='block';
-      const focusables=panel.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-      firstFocusable=focusables[0];
-      lastFocusable=focusables[focusables.length-1];
-      document.addEventListener('keydown',onKey);
-      document.addEventListener('click',onDocClick);
-      selA.focus();
-    }else{
-      close();
-    }
-  };
-}
-if($('#d_gcs_calc') && $('#btnGCSCalc')){
-  const toggleDGcs=setupGcsCalc('d');
-  $('#btnGCSCalc').addEventListener('click',toggleDGcs);
-}
-if($('#spr_gcs_calc') && $('#btnSprGCSCalc')){
-  const toggleSprGcs=setupGcsCalc('spr');
-  $('#btnSprGCSCalc').addEventListener('click',toggleSprGcs);
-}
 
 function clampNumberInputs(){
   const clamp=el=>{
@@ -277,12 +139,14 @@ function clampNumberInputs(){
 async function init(){
   initTheme();
   await initTopbar();
-    setupHeaderActions({ validateForm, saveAll });
+  setupHeaderActions({ validateForm, saveAll });
   connectSocket();
   await fetchUsers();
   await initSessions();
-  initTabs();
-  initCollapsibles();
+  if(document.getElementById('tabs')){
+    initTabs();
+    initCollapsibles();
+  }
   bodyMap.init(saveAllDebounced);
   initChips(saveAllDebounced);
   initAutoActivate(saveAllDebounced);
@@ -324,37 +188,7 @@ async function init(){
     });
   });
 
-  const updateCirculationMetrics=()=>{
-    const hr=parseFloat($('#c_hr')?.value);
-    const sbp=parseFloat($('#c_sbp')?.value);
-    const dbp=parseFloat($('#c_dbp')?.value);
-    const mapEl=$('#c_map');
-    const siEl=$('#c_si');
-    const map = !isNaN(sbp) && !isNaN(dbp) ? Math.round((sbp + 2*dbp)/3) : '';
-    const si = !isNaN(hr) && !isNaN(sbp) && sbp>0 ? (hr/sbp).toFixed(2) : '';
-    if(mapEl) mapEl.textContent=map;
-    if(siEl) siEl.textContent=si;
-  };
-  initCirculationChecks(updateCirculationMetrics);
-  updateCirculationMetrics();
-    const updateDGksTotal=()=>{
-      $('#d_gks_total').textContent=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value);
-    };
-    ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).addEventListener('input', updateDGksTotal));
-    const updateGmpGksTotal=()=>{
-      $('#gmp_gks_total').textContent=gksSum($('#gmp_gksa').value,$('#gmp_gksk').value,$('#gmp_gksm').value);
-    };
-    ['#gmp_gksa','#gmp_gksk','#gmp_gksm'].forEach(sel=>$(sel).addEventListener('input', updateGmpGksTotal));
-    if($('#spr_gks_total')){
-      const updateSprGksTotal=()=>{
-        $('#spr_gks_total').textContent=gksSum($('#spr_gksa').value,$('#spr_gksk').value,$('#spr_gksm').value);
-      };
-      ['#spr_gksa','#spr_gksk','#spr_gksm'].forEach(sel=>$(sel).addEventListener('input', updateSprGksTotal));
-    }
-    const btnGmpNow=$('#btnGmpNow');
-    if(btnGmpNow) btnGmpNow.addEventListener('click',()=>{ $('#gmp_time').value=nowHM(); saveAll(); });
-    const btnSprNow=$('#btnSprNow');
-    if(btnSprNow) btnSprNow.addEventListener('click',()=>{ $('#spr_time').value=nowHM(); saveAll(); });
+  initCirculation();
   const btnOxygen=$('#btnOxygen');
   if(btnOxygen) btnOxygen.addEventListener('click',()=>{
     const box=$('#oxygenFields');
@@ -375,16 +209,20 @@ async function init(){
     });
     $('#output').addEventListener('input', expandOutput);
     loadAll();
-    ensureSingleTeam();
-    updateActivationIndicator();
+    if(document.getElementById('chips_red') && document.getElementById('chips_yellow')){
+      ensureSingleTeam();
+      updateActivationIndicator();
+    }
     expandOutput();
     clampNumberInputs();
     initValidation();
     validateVitals();
-    updateDGksTotal();
-    updateGmpGksTotal();
   }
-  window.addEventListener('DOMContentLoaded', init);
+  if(document.readyState==='loading'){
+    window.addEventListener('DOMContentLoaded', init);
+  }else{
+    init();
+  }
 
 function validateForm(){
   const fields=[

--- a/public/js/chips.js
+++ b/public/js/chips.js
@@ -158,7 +158,7 @@ export function initChips(saveAll){
   }
 
   document.addEventListener('click', e => {
-    const chip = e.target.closest('.chip');
+    const chip = e.target?.closest?.('.chip');
     if(!chip) return;
     handleChip(chip);
   }, true);
@@ -169,7 +169,7 @@ export function initChips(saveAll){
   //   newly focused chip is activated automatically to mirror native
   //   radio behaviour.
   document.addEventListener('keydown', e => {
-    const chip = e.target.closest('.chip');
+    const chip = e.target?.closest?.('.chip');
     if(!chip) return;
 
     if(e.key === 'Enter' || e.key === ' '){

--- a/public/js/circulation.js
+++ b/public/js/circulation.js
@@ -30,3 +30,20 @@ export function initCirculationChecks(updateMetrics) {
     });
   });
 }
+
+export function updateCirculationMetrics() {
+  const hr = parseFloat($('#c_hr')?.value);
+  const sbp = parseFloat($('#c_sbp')?.value);
+  const dbp = parseFloat($('#c_dbp')?.value);
+  const mapEl = $('#c_map');
+  const siEl = $('#c_si');
+  const map = !isNaN(sbp) && !isNaN(dbp) ? Math.round((sbp + 2 * dbp) / 3) : '';
+  const si = !isNaN(hr) && !isNaN(sbp) && sbp > 0 ? (hr / sbp).toFixed(2) : '';
+  if (mapEl) mapEl.textContent = map;
+  if (siEl) siEl.textContent = si;
+}
+
+export function initCirculation() {
+  initCirculationChecks(updateCirculationMetrics);
+  updateCirculationMetrics();
+}

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -1,0 +1,12 @@
+export const IMG_CT = ['Galvos KT','Kaklo KT','Viso kūno KT'];
+export const IMG_XRAY = ['Krūtinės Ro','Dubens Ro'];
+export const LABS = ['BKT','Biocheminis tyrimas','Krešumai','Fibrinogenas','ROTEM','Kraujo grupė','Kraujo dujos'];
+export const BLOOD_GROUPS = ['0-','0+','A-','A+','B-','B+','AB-','AB+'];
+export const FAST_AREAS = [
+  {name:'Perikardas', marker:'skystis'},
+  {name:'Dešinė pleura', marker:'skystis ar oras'},
+  {name:'Kairė pleura', marker:'skystis ar oras'},
+  {name:'RUQ', marker:'skystis'},
+  {name:'LUQ', marker:'skystis'},
+  {name:'Dubuo', marker:'skystis'},
+];

--- a/public/js/gcs.js
+++ b/public/js/gcs.js
@@ -1,0 +1,113 @@
+import { $, nowHM } from './utils.js';
+import { gksSum } from './report.js';
+import { saveAll } from './sessionManager.js';
+
+function setupGcsCalc(prefix){
+  const panel=$(`#${prefix}_gcs_calc`);
+  const selA=$(`#${prefix}_gcs_calc_a`);
+  const selK=$(`#${prefix}_gcs_calc_k`);
+  const selM=$(`#${prefix}_gcs_calc_m`);
+  const apply=$(`#${prefix}_gcs_apply`);
+  const total=$(`#${prefix}_gcs_calc_total`);
+  const btnClose=$(`#${prefix}_gcs_close`);
+  const btn = prefix==='spr' ? $('#btnSprGCSCalc') : $('#btnGCSCalc');
+  if(!panel||!selA||!selK||!selM||!apply||!total) return ()=>{};
+
+  const update=()=>{ total.textContent=gksSum(selA.value,selK.value,selM.value); };
+  [selA,selK,selM].forEach(sel=>sel.addEventListener('change',update));
+
+  let firstFocusable, lastFocusable;
+  const close=()=>{
+    panel.style.display='none';
+    document.removeEventListener('keydown',onKey);
+    document.removeEventListener('click',onDocClick);
+    if(btn) btn.focus();
+  };
+  const onKey=e=>{
+    if(e.key==='Escape') return close();
+    if(e.key==='Tab'){
+      if(e.shiftKey && document.activeElement===firstFocusable){
+        e.preventDefault();
+        lastFocusable.focus();
+      }else if(!e.shiftKey && document.activeElement===lastFocusable){
+        e.preventDefault();
+        firstFocusable.focus();
+      }
+    }
+  };
+  const onDocClick=e=>{ if(!panel.contains(e.target) && e.target!==btn) close(); };
+
+  apply.addEventListener('click',()=>{
+    if(selA.value) $(`#${prefix}_gksa`).value=selA.value;
+    if(selK.value) $(`#${prefix}_gksk`).value=selK.value;
+    if(selM.value) $(`#${prefix}_gksm`).value=selM.value;
+    ['#'+prefix+'_gksa','#'+prefix+'_gksk','#'+prefix+'_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
+    close();
+    saveAll();
+  });
+
+  if(btnClose) btnClose.addEventListener('click',close);
+
+  return ()=>{
+    const hidden=panel.style.display==='none';
+    if(hidden){
+      panel.style.display='block';
+      const focusables=panel.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      firstFocusable=focusables[0];
+      lastFocusable=focusables[focusables.length-1];
+      document.addEventListener('keydown',onKey);
+      document.addEventListener('click',onDocClick);
+      selA.focus();
+    }else{
+      close();
+    }
+  };
+}
+
+export function initGcs(){
+  const btnGcs15=$('#btnGCS15');
+  if(btnGcs15) btnGcs15.addEventListener('click',()=>{
+    $('#d_gksa').value=4; $('#d_gksk').value=5; $('#d_gksm').value=6;
+    ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).dispatchEvent(new Event('input')));
+    saveAll();
+  });
+
+  if($('#d_gcs_calc') && $('#btnGCSCalc')){
+    const toggleDGcs=setupGcsCalc('d');
+    $('#btnGCSCalc').addEventListener('click',toggleDGcs);
+  }
+  if($('#spr_gcs_calc') && $('#btnSprGCSCalc')){
+    const toggleSprGcs=setupGcsCalc('spr');
+    $('#btnSprGCSCalc').addEventListener('click',toggleSprGcs);
+  }
+
+  const updateDGksTotal=()=>{
+    const el=$('#d_gks_total');
+    if(el) el.textContent=gksSum($('#d_gksa').value,$('#d_gksk').value,$('#d_gksm').value);
+  };
+  ['#d_gksa','#d_gksk','#d_gksm'].forEach(sel=>$(sel).addEventListener('input', updateDGksTotal));
+
+  const updateGmpGksTotal=()=>{
+    const el=$('#gmp_gks_total');
+    if(el) el.textContent=gksSum($('#gmp_gksa').value,$('#gmp_gksk').value,$('#gmp_gksm').value);
+  };
+  ['#gmp_gksa','#gmp_gksk','#gmp_gksm'].forEach(sel=>$(sel).addEventListener('input', updateGmpGksTotal));
+
+  let updateSprGksTotal;
+  if($('#spr_gks_total')){
+    updateSprGksTotal=()=>{
+      const el=$('#spr_gks_total');
+      if(el) el.textContent=gksSum($('#spr_gksa').value,$('#spr_gksk').value,$('#spr_gksm').value);
+    };
+    ['#spr_gksa','#spr_gksk','#spr_gksm'].forEach(sel=>$(sel).addEventListener('input', updateSprGksTotal));
+  }
+
+  const btnGmpNow=$('#btnGmpNow');
+  if(btnGmpNow) btnGmpNow.addEventListener('click',()=>{ $('#gmp_time').value=nowHM(); saveAll(); });
+  const btnSprNow=$('#btnSprNow');
+  if(btnSprNow) btnSprNow.addEventListener('click',()=>{ $('#spr_time').value=nowHM(); saveAll(); });
+
+  updateDGksTotal();
+  updateGmpGksTotal();
+  if(updateSprGksTotal) updateSprGksTotal();
+}


### PR DESCRIPTION
## Summary
- centralize static imaging and lab configuration in `config.js`
- extract activation, GCS calculator, and circulation metric logic into dedicated modules
- streamline `app.js` to orchestrate new modules and configuration

## Testing
- `npm test`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68aea1a98c108320a47891a20431855e