### PR TITLE
Ensure default DB structure on load

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,8 @@ async function loadDB(){
     const data = await fs.promises.readFile(DB_FILE, 'utf8');
     const parsed = JSON.parse(data);
     if (!Array.isArray(parsed.sessions)) parsed.sessions = [];
+    if (typeof parsed.data !== 'object' || parsed.data === null || Array.isArray(parsed.data)) parsed.data = {};
+    if (!Array.isArray(parsed.users)) parsed.users = [];
     // Ensure all sessions have an archived flag for backwards compatibility
     parsed.sessions = parsed.sessions.map(s => ({ ...s, archived: !!s.archived }));
     return parsed;
@@ -212,4 +214,4 @@ async function startServer () {
   });
 }
 
-module.exports = { app, server, startServer };
+module.exports = { app, server, startServer, loadDB };

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -190,3 +190,30 @@ describe('server API', () => {
   });
 });
 
+describe('loadDB', () => {
+  let fsPromises;
+
+  beforeEach(() => {
+    jest.resetModules();
+    fsPromises = require('fs').promises;
+  });
+
+  test('initializes missing data and users', async () => {
+    fsPromises.readFile.mockResolvedValue(JSON.stringify({ sessions: [] }));
+    const { loadDB } = require('./index');
+    const db = await loadDB();
+    expect(db.data).toEqual({});
+    expect(db.users).toEqual([]);
+  });
+
+  test('initializes invalid data and users types', async () => {
+    fsPromises.readFile.mockResolvedValue(
+      JSON.stringify({ sessions: [], data: [], users: {} })
+    );
+    const { loadDB } = require('./index');
+    const db = await loadDB();
+    expect(db.data).toEqual({});
+    expect(db.users).toEqual([]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Guard against invalid `data` and `users` fields when loading the DB
- Add unit tests for `loadDB` initialization of missing fields

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea662aa6c832094a5801aa7acd088