### PR TITLE
feat: await session save writes

### DIFF
--- a/public/js/__tests__/sessionManager.test.js
+++ b/public/js/__tests__/sessionManager.test.js
@@ -1,8 +1,44 @@
-import { sessionKey, setCurrentSessionId } from '../sessionManager.js';
+jest.mock('../bodyMap.js', () => ({ __esModule: true, default: { serialize: () => '' } }));
 
-describe('sessionKey', () => {
-  test('returns key with current session id', () => {
+const realFetch = global.fetch;
+
+describe('sessionManager utilities', () => {
+  afterEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+    if(realFetch){
+      global.fetch = realFetch;
+    }else{
+      delete global.fetch;
+    }
+  });
+
+  test('sessionKey returns key with current session id', () => {
+    const { sessionKey, setCurrentSessionId } = require('../sessionManager.js');
     setCurrentSessionId('abc');
     expect(sessionKey()).toBe('trauma_v10_abc');
   });
+
+  test('saveAll resolves and updates status text', async () => {
+    localStorage.setItem('trauma_current_session', 'test');
+    localStorage.setItem('trauma_token', 'token');
+    document.body.innerHTML = `
+      <input id="field" />
+      <div id="saveStatus"></div>
+      <div id="pain_meds"></div>
+      <div id="bleeding_meds"></div>
+      <div id="other_meds"></div>
+      <div id="procedures"></div>
+    `;
+    const mockFetch = jest.fn(() => Promise.resolve({ ok: true }));
+    global.fetch = mockFetch;
+    const { saveAll, setCurrentSessionId } = require('../sessionManager.js');
+    setCurrentSessionId('test');
+    const promise = saveAll();
+    expect(document.getElementById('saveStatus').textContent).toBe('Saving...');
+    await promise;
+    expect(document.getElementById('saveStatus').textContent).toBe('Saved');
+    expect(mockFetch).toHaveBeenCalled();
+  });
 });
+

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -296,7 +296,7 @@ const IMAGING_GROUPS=['#imaging_ct','#imaging_xray','#imaging_other_group'];
 const CHIP_GROUPS=['#chips_red','#chips_yellow',...IMAGING_GROUPS,'#labs_basic','#a_airway_group','#b_breath_left_group','#b_breath_right_group','#c_pulse_radial_group','#c_pulse_femoral_group','#c_skin_temp_group','#c_skin_color_group','#d_pupil_left_group','#d_pupil_right_group','#spr_decision_group'];
 const FIELD_SELECTORS='input[type="text"],input[type="number"],input[type="time"],input[type="date"],textarea,select';
 
-export function saveAll(){
+export async function saveAll(){
   if(!currentSessionId) return;
   const data={};
   $$(FIELD_SELECTORS).forEach(el=>{
@@ -317,16 +317,17 @@ export function saveAll(){
     statusEl.classList.remove('offline');
   }
   if(authToken && typeof fetch === 'function'){
-    fetch(`/api/sessions/${currentSessionId}/data`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + authToken },
-      body: JSON.stringify(data)
-    }).then(res => {
+    try{
+      const res = await fetch(`/api/sessions/${currentSessionId}/data`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + authToken },
+        body: JSON.stringify(data)
+      });
       if(!res.ok) throw new Error(res.status);
       if(statusEl){ statusEl.textContent='Saved'; statusEl.classList.remove('offline'); }
-    }).catch(() => {
+    }catch(e){
       if(statusEl){ statusEl.textContent='Save failed'; statusEl.classList.add('offline'); }
-    });
+    }
   } else if(statusEl){
     statusEl.textContent='Saved';
   }


### PR DESCRIPTION
## Summary
- make `saveAll` async and await server saves before updating status
- test that async save resolves and updates status indicator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeae81f9e883209bcf874db9834d5d