### PR TITLE
feat: enhance body map silhouettes

### DIFF
--- a/docs/assets/body_back.svg
+++ b/docs/assets/body_back.svg
@@ -1,8 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
   <g id="back-map">
     <g class="silhouette" id="back-shape" data-side="back">
-      <!-- Silhouette path from Material Design Icons (Apache License 2.0) -->
-      <path transform="scale(2)" d="M21,9H15V22H13V16H11V22H9V9H3V7H21M12,2A2,2 0 0,1 14,4A2,2 0 0,1 12,6C10.89,6 10,5.1 10,4C10,2.89 10.89,2 12,2Z"/>
+      <!-- Silhouette derived from Ionicons body outline (MIT License) with additional detail lines -->
+      <path transform="scale(0.09375)" d="M256,0a56,56 0 1,1 0,112a56,56 0 1,1 0,-112Z M437,128H75a27,27 0,0,0 0,54H176.88c6.91,0 15,3.09 19.58,15 5.35,13.83 2.73,40.54-.57,61.23l-4.32,24.45a.42.42,0,0,1-.12.35l-34.6,196.81A27.43,27.43,0,0,0,179,511.58a27.06,27.06,0,0,0,31.42-22.29l23.91-136.8S242,320,256,320c14.23,0,21.74,32.49,21.74,32.49l23.91,136.92a27.24,27.24,0,1,0,53.62-9.6L320.66,283a.45.45,0,0,0-.11-.35l-4.33-24.45c-3.3-20.69-5.92-47.4-.57-61.23,4.56-11.88,12.91-15,19.28-15H437a27,27,0,0,0,0-54Z"/>
+      <path d="M18 22c2 3 10 3 12 0" fill="none" stroke-linecap="round" stroke-width="1.5"/>
+      <path d="M24 16v30" fill="none" stroke-linecap="round" stroke-width="1.5"/>
+      <path d="M22 34q2 2 4 0" fill="none" stroke-linecap="round" stroke-width="1.5"/>
     </g>
   </g>
 </svg>

--- a/docs/assets/body_front.svg
+++ b/docs/assets/body_front.svg
@@ -1,8 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
   <g id="front-map">
     <g class="silhouette" id="front-shape" data-side="front">
-      <!-- Silhouette path from Material Design Icons (Apache License 2.0) -->
-      <path transform="scale(2)" d="M21,9H15V22H13V16H11V22H9V9H3V7H21M12,2A2,2 0 0,1 14,4A2,2 0 0,1 12,6C10.89,6 10,5.1 10,4C10,2.89 10.89,2 12,2Z"/>
+      <!-- Silhouette derived from Ionicons body outline (MIT License) with additional detail lines -->
+      <path transform="scale(0.09375)" d="M256,0a56,56 0 1,1 0,112a56,56 0 1,1 0,-112Z M437,128H75a27,27 0,0,0 0,54H176.88c6.91,0 15,3.09 19.58,15 5.35,13.83 2.73,40.54-.57,61.23l-4.32,24.45a.42.42,0,0,1-.12.35l-34.6,196.81A27.43,27.43,0,0,0,179,511.58a27.06,27.06,0,0,0,31.42-22.29l23.91-136.8S242,320,256,320c14.23,0,21.74,32.49,21.74,32.49l23.91,136.92a27.24,27.24,0,1,0,53.62-9.6L320.66,283a.45.45,0,0,0-.11-.35l-4.33-24.45c-3.3-20.69-5.92-47.4-.57-61.23,4.56-11.88,12.91-15,19.28-15H437a27,27,0,0,0,0-54Z"/>
+      <path d="M18 22c2-3 10-3 12 0" fill="none" stroke-linecap="round" stroke-width="1.5"/>
+      <path d="M24 24v22" fill="none" stroke-linecap="round" stroke-width="1.5"/>
+      <path d="M20 34L24 32L28 34" fill="none" stroke-linecap="round" stroke-width="1.5"/>
     </g>
   </g>
 </svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -341,7 +341,7 @@
       </div>
 
       <!-- SVG BODY MAP -->
-      <svg id="bodySvg" viewBox="0 0 1500 1100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <svg id="bodySvg" viewBox="0 0 1500 1090" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <!-- Marker symbols -->
         <defs>
           <g id="sym-wound">
@@ -356,13 +356,13 @@
         <!-- FRONT silhouette -->
         <g id="layer-front" transform="translate(0,0)">
           <text x="16" y="28" class="label">PRIEKIS</text>
-          <use id="front-shape" class="silhouette" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
+          <use id="front-shape" class="silhouette" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(3,50) scale(15.5,21)"></use>
         </g>
 
         <!-- BACK silhouette -->
         <g id="layer-back" transform="translate(750,0)">
           <text x="16" y="28" class="label">NUGARA</text>
-          <use id="back-shape" class="silhouette" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
+          <use id="back-shape" class="silhouette" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(3,50) scale(15.5,21)"></use>
         </g>
 
         <!-- MARKS container -->

--- a/public/assets/body_back.svg
+++ b/public/assets/body_back.svg
@@ -1,8 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
   <g id="back-map">
     <g class="silhouette" id="back-shape" data-side="back">
-      <!-- Silhouette path from Ionicons (MIT License) -->
+      <!-- Silhouette derived from Ionicons body outline (MIT License) with additional detail lines -->
       <path transform="scale(0.09375)" d="M256,0a56,56 0 1,1 0,112a56,56 0 1,1 0,-112Z M437,128H75a27,27 0,0,0 0,54H176.88c6.91,0 15,3.09 19.58,15 5.35,13.83 2.73,40.54-.57,61.23l-4.32,24.45a.42.42,0,0,1-.12.35l-34.6,196.81A27.43,27.43,0,0,0,179,511.58a27.06,27.06,0,0,0,31.42-22.29l23.91-136.8S242,320,256,320c14.23,0,21.74,32.49,21.74,32.49l23.91,136.92a27.24,27.24,0,1,0,53.62-9.6L320.66,283a.45.45,0,0,0-.11-.35l-4.33-24.45c-3.3-20.69-5.92-47.4-.57-61.23,4.56-11.88,12.91-15,19.28-15H437a27,27,0,0,0,0-54Z"/>
+      <path d="M18 22c2 3 10 3 12 0" fill="none" stroke-linecap="round" stroke-width="1.5"/>
+      <path d="M24 16v30" fill="none" stroke-linecap="round" stroke-width="1.5"/>
+      <path d="M22 34q2 2 4 0" fill="none" stroke-linecap="round" stroke-width="1.5"/>
     </g>
   </g>
 </svg>

--- a/public/assets/body_front.svg
+++ b/public/assets/body_front.svg
@@ -1,8 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
   <g id="front-map">
     <g class="silhouette" id="front-shape" data-side="front">
-      <!-- Silhouette path from Ionicons (MIT License) -->
+      <!-- Silhouette derived from Ionicons body outline (MIT License) with additional detail lines -->
       <path transform="scale(0.09375)" d="M256,0a56,56 0 1,1 0,112a56,56 0 1,1 0,-112Z M437,128H75a27,27 0,0,0 0,54H176.88c6.91,0 15,3.09 19.58,15 5.35,13.83 2.73,40.54-.57,61.23l-4.32,24.45a.42.42,0,0,1-.12.35l-34.6,196.81A27.43,27.43,0,0,0,179,511.58a27.06,27.06,0,0,0,31.42-22.29l23.91-136.8S242,320,256,320c14.23,0,21.74,32.49,21.74,32.49l23.91,136.92a27.24,27.24,0,1,0,53.62-9.6L320.66,283a.45.45,0,0,0-.11-.35l-4.33-24.45c-3.3-20.69-5.92-47.4-.57-61.23,4.56-11.88,12.91-15,19.28-15H437a27,27,0,0,0,0-54Z"/>
+      <path d="M18 22c2-3 10-3 12 0" fill="none" stroke-linecap="round" stroke-width="1.5"/>
+      <path d="M24 24v22" fill="none" stroke-linecap="round" stroke-width="1.5"/>
+      <path d="M20 34L24 32L28 34" fill="none" stroke-linecap="round" stroke-width="1.5"/>
     </g>
   </g>
 </svg>

--- a/public/index.html
+++ b/public/index.html
@@ -341,7 +341,7 @@
       </div>
 
       <!-- SVG BODY MAP -->
-      <svg id="bodySvg" viewBox="0 0 1500 1100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <svg id="bodySvg" viewBox="0 0 1500 1090" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <!-- Marker symbols -->
         <defs>
           <g id="sym-wound">
@@ -356,13 +356,13 @@
         <!-- FRONT silhouette -->
         <g id="layer-front" transform="translate(0,0)">
           <text x="16" y="28" class="label">PRIEKIS</text>
-          <use id="front-shape" class="silhouette" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
+          <use id="front-shape" class="silhouette" data-side="front" href="assets/body_front.svg#front-shape" data-src="assets/body_front.svg#front-shape" transform="translate(3,50) scale(15.5,21)"></use>
         </g>
 
         <!-- BACK silhouette -->
         <g id="layer-back" transform="translate(750,0)">
           <text x="16" y="28" class="label">NUGARA</text>
-          <use id="back-shape" class="silhouette" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(3,50) scale(15.5,21.05)"></use>
+          <use id="back-shape" class="silhouette" data-side="back" href="assets/body_back.svg#back-shape" data-src="assets/body_back.svg#back-shape" transform="translate(3,50) scale(15.5,21)"></use>
         </g>
 
         <!-- MARKS container -->


### PR DESCRIPTION
## Summary
- add detailed front and back body SVGs derived from Ionicons (MIT) with extra guides
- tweak SVG viewBox and transforms so sizing remains consistent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeb8415c1c8320b6f89a1ddd931fbd