### PR TITLE
localize topbar labels

### DIFF
--- a/docs/assets/partials/topbar.html
+++ b/docs/assets/partials/topbar.html
@@ -22,12 +22,12 @@
   </div>
   <div class="header-actions">
     <div class="toolbar" id="mobileActions" hidden>
-      <button type="button" class="btn" id="actionsToggle" aria-controls="actionsMenu" aria-expanded="false">Actions ▾</button>
+      <button type="button" class="btn" id="actionsToggle" aria-controls="actionsMenu" aria-expanded="false"></button>
       <div class="menu" id="actionsMenu" hidden></div>
     </div>
     <div class="toolbar">
       <details class="more-actions">
-        <summary class="btn">More ▾</summary>
+        <summary class="btn"></summary>
         <div class="menu">
             <button type="button" class="btn" id="btnCopy"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>Kopijuoti</button>
             <button type="button" class="btn" id="btnSave"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>Išsaugoti</button>

--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -1,3 +1,5 @@
+import { ACTIONS_LABEL, MORE_LABEL } from '../constants.js';
+
 export function initNavToggle(toggle, nav){
   if(!toggle || !nav) return;
   toggle.setAttribute('aria-controls', nav.id);
@@ -58,6 +60,7 @@ export async function initTopbar(){
   }catch(e){
     console.error('Failed to load topbar', e);
   }
+  applyTopbarLocalization(header);
   const setHeight=()=>{
     const h=header.offsetHeight+'px';
     header.style.setProperty('--header-height', h);
@@ -70,6 +73,13 @@ export async function initTopbar(){
   initNavToggle(toggle, nav);
 
   initActionsMenu();
+}
+
+function applyTopbarLocalization(root){
+  const actionsToggle=root?.querySelector('#actionsToggle');
+  if(actionsToggle) actionsToggle.textContent=ACTIONS_LABEL;
+  const moreSummary=root?.querySelector('.more-actions summary');
+  if(moreSummary) moreSummary.textContent=MORE_LABEL;
 }
 
 function initActionsMenu(){

--- a/docs/js/constants.js
+++ b/docs/js/constants.js
@@ -9,3 +9,6 @@ export const TEAM_ROLES = [
   'Chirurgas',
   'Ortopedas'
 ];
+
+export const ACTIONS_LABEL = 'Veiksmai ▾';
+export const MORE_LABEL = 'Daugiau ▾';

--- a/public/assets/partials/topbar.html
+++ b/public/assets/partials/topbar.html
@@ -22,12 +22,12 @@
   </div>
   <div class="header-actions">
     <div class="toolbar" id="mobileActions" hidden>
-      <button type="button" class="btn" id="actionsToggle" aria-controls="actionsMenu" aria-expanded="false">Actions ▾</button>
+      <button type="button" class="btn" id="actionsToggle" aria-controls="actionsMenu" aria-expanded="false"></button>
       <div class="menu" id="actionsMenu" hidden></div>
     </div>
     <div class="toolbar">
       <details class="more-actions">
-        <summary class="btn">More ▾</summary>
+        <summary class="btn"></summary>
         <div class="menu">
             <button type="button" class="btn" id="btnCopy"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>Kopijuoti</button>
             <button type="button" class="btn" id="btnSave"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>Išsaugoti</button>

--- a/public/js/__tests__/topbarLocalization.test.js
+++ b/public/js/__tests__/topbarLocalization.test.js
@@ -1,0 +1,18 @@
+import { initTopbar } from '../components/topbar.js';
+import { ACTIONS_LABEL, MORE_LABEL } from '../constants.js';
+import fs from 'fs';
+import path from 'path';
+
+describe('topbar localization', () => {
+  test('inserts localized labels', async () => {
+    const html = fs.readFileSync(path.join(__dirname, '../../assets/partials/topbar.html'), 'utf8');
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve(html) }));
+    document.body.innerHTML = '<header id="appHeader"></header><nav></nav>';
+    window.matchMedia = window.matchMedia || function(){
+      return { matches: false, addEventListener(){}, removeEventListener(){}, addListener(){}, removeListener(){} };
+    };
+    await initTopbar();
+    expect(document.getElementById('actionsToggle').textContent).toBe(ACTIONS_LABEL);
+    expect(document.querySelector('.more-actions summary').textContent).toBe(MORE_LABEL);
+  });
+});

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -1,3 +1,5 @@
+import { ACTIONS_LABEL, MORE_LABEL } from '../constants.js';
+
 export function initNavToggle(toggle, nav){
   if(!toggle || !nav) return;
   toggle.setAttribute('aria-controls', nav.id);
@@ -58,6 +60,7 @@ export async function initTopbar(){
   }catch(e){
     console.error('Failed to load topbar', e);
   }
+  applyTopbarLocalization(header);
   const setHeight=()=>{
     const h=header.offsetHeight+'px';
     header.style.setProperty('--header-height', h);
@@ -70,6 +73,13 @@ export async function initTopbar(){
   initNavToggle(toggle, nav);
 
   initActionsMenu();
+}
+
+function applyTopbarLocalization(root){
+  const actionsToggle=root?.querySelector('#actionsToggle');
+  if(actionsToggle) actionsToggle.textContent=ACTIONS_LABEL;
+  const moreSummary=root?.querySelector('.more-actions summary');
+  if(moreSummary) moreSummary.textContent=MORE_LABEL;
 }
 
 function initActionsMenu(){

--- a/public/js/constants.js
+++ b/public/js/constants.js
@@ -9,3 +9,6 @@ export const TEAM_ROLES = [
   'Chirurgas',
   'Ortopedas'
 ];
+
+export const ACTIONS_LABEL = 'Veiksmai ▾';
+export const MORE_LABEL = 'Daugiau ▾';


### PR DESCRIPTION
## Summary
- remove hard-coded English labels from topbar partial
- add Lithuanian label constants and apply them in the topbar component
- test top bar localization to ensure Lithuanian strings are rendered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aec3f6aac883208ff6c8b7a525c688