### PR TITLE
Close nav menu on wide screens

### DIFF
--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -1,6 +1,12 @@
 import { ACTIONS_LABEL, MORE_LABEL } from '../constants.js';
 
+let navMq;
+let navMqListener;
+
 export function initNavToggle(toggle, nav){
+  if(navMq && navMqListener){
+    navMq.removeEventListener('change', navMqListener);
+  }
   if(!toggle || !nav) return;
   toggle.setAttribute('aria-controls', nav.id);
   toggle.setAttribute('aria-expanded','false');
@@ -47,6 +53,12 @@ export function initNavToggle(toggle, nav){
   nav.addEventListener('click',e=>{
     if(e.target.closest('.tab')) close();
   });
+  navMq=typeof matchMedia==='function' ? matchMedia('(min-width: 768px)') : null;
+  if(navMq){
+    navMqListener=e=>{ if(e.matches) close(); };
+    navMq.addEventListener('change', navMqListener);
+    if(navMq.matches) close();
+  }
 }
 
 export async function initTopbar(){


### PR DESCRIPTION
## Summary
- Close the mobile navigation when the viewport width reaches 768px
- Remove and re-add media query listener on nav toggle reinitialization
- Keep body scrolling restored when the nav closes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aed33569dc8320837801a712415ace