### PR TITLE
Refactor header toolbar spacing

### DIFF
--- a/public/css/scss/_base.scss
+++ b/public/css/scss/_base.scss
@@ -76,10 +76,16 @@ header{
     min-width:auto;
   }
 }
-.header-actions .toolbar + .toolbar{
-  border-left:1px solid var(--line);
-  padding-left:$space-8;
-  margin-left:$space-8;
+
+.header-actions{
+  column-gap:$space-16;
+  &.nowrap{
+    flex-wrap:nowrap;
+    > .toolbar:not(:first-child){
+      border-left:1px solid var(--line);
+      padding-left:$space-8;
+    }
+  }
 }
 
 .header-center{


### PR DESCRIPTION
## Summary
- switch header toolbar spacing to a gap-based layout
- allow optional border-left separators only when toolbars stay on one row

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aedfbdbfa883208c9ca77b9e1f2bfb