### PR TITLE
fix: prevent content shift on refresh

### DIFF
--- a/docs/assets/partials/topbar.html
+++ b/docs/assets/partials/topbar.html
@@ -21,7 +21,7 @@
     </div>
   </div>
   <div class="header-actions">
-    <div class="toolbar" id="mobileActions">
+    <div class="toolbar" id="mobileActions" hidden>
       <button type="button" class="btn" id="actionsToggle" aria-controls="actionsMenu" aria-expanded="false"></button>
       <div class="menu" id="actionsMenu" hidden></div>
       <div class="toolbar" id="arrivalBar">

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sunkios traumos forma</title>
 <script>
-  document.documentElement.classList.add('dark');
+  document.documentElement.classList.add('dark','js');
 </script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/main.css">

--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -98,7 +98,6 @@ function applyTopbarLocalization(root){
 }
 
 function initActionsMenu(){
-  document.documentElement.classList.add('js');
   const container=document.getElementById('mobileActions');
   if(container){
     container.querySelector('#arrivalBar')?.remove();

--- a/public/assets/partials/topbar.html
+++ b/public/assets/partials/topbar.html
@@ -21,7 +21,7 @@
     </div>
   </div>
   <div class="header-actions">
-    <div class="toolbar" id="mobileActions">
+    <div class="toolbar" id="mobileActions" hidden>
       <button type="button" class="btn" id="actionsToggle" aria-controls="actionsMenu" aria-expanded="false"></button>
       <div class="menu" id="actionsMenu" hidden></div>
       <div class="toolbar" id="arrivalBar">

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sunkios traumos forma</title>
 <script>
-  document.documentElement.classList.add('dark');
+  document.documentElement.classList.add('dark','js');
 </script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/main.css">

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -98,7 +98,6 @@ function applyTopbarLocalization(root){
 }
 
 function initActionsMenu(){
-  document.documentElement.classList.add('js');
   const container=document.getElementById('mobileActions');
   if(container){
     container.querySelector('#arrivalBar')?.remove();


### PR DESCRIPTION
## Summary
- ensure `js` class is applied before styles load to hide JS-only header elements
- hide mobile actions container until scripts initialize
- remove redundant `js` class toggle from topbar component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aefa5c75608320830cc8bc7a29fff5