### PR TITLE
Fix hidden input toggling for other and decision fields

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -203,8 +203,10 @@ async function init(){
   });
     $('#spr_skyrius').addEventListener('change', e=>{
       const show = e.target.value === 'Kita';
-      $('#spr_skyrius_kita').style.display = show ? 'block' : 'none';
-      if(!show) $('#spr_skyrius_kita').value='';
+      const field = $('#spr_skyrius_kita');
+      field.style.display = show ? 'block' : 'none';
+      field.classList.toggle('hidden', !show);
+      if(!show) field.value='';
       saveAll();
     });
     $('#output').addEventListener('input', expandOutput);

--- a/docs/js/chips.js
+++ b/docs/js/chips.js
@@ -70,6 +70,7 @@ function toggleBackNote(chip){
   const note = $('#e_back_notes');
   const show = chip.dataset.value==='Pakitimai' && isChipActive(chip);
   note.style.display = show ? 'block' : 'none';
+  note.classList.toggle('hidden', !show);
   if(!show) note.value='';
 }
 
@@ -134,21 +135,25 @@ export function initChips(saveAll){
       const box=$('#imaging_other');
       const show=!!document.querySelector('[id^="imaging_"] .chip.active[data-value="Kita"]');
       box.style.display = show ? 'block' : 'none';
+      box.classList.toggle('hidden', !show);
       if(!show) box.value='';
     }
     if(group.id==='spr_decision_group'){
       const showSky = chip.dataset.value==='Stacionarizavimas' && isChipActive(chip);
       const boxSky = $('#spr_skyrius_container');
       boxSky.style.display = showSky ? 'block' : 'none';
+      boxSky.classList.toggle('hidden', !showSky);
       if(!showSky){
         $('#spr_skyrius').value='';
         $('#spr_skyrius_kita').style.display='none';
+        $('#spr_skyrius_kita').classList.add('hidden');
         $('#spr_skyrius_kita').value='';
       }
 
       const showHosp = chip.dataset.value==='Pervežimas į kitą ligoninę' && isChipActive(chip);
       const boxHosp = $('#spr_ligonine_container');
       boxHosp.style.display = showHosp ? 'block' : 'none';
+      boxHosp.classList.toggle('hidden', !showHosp);
       if(!showHosp){
         $('#spr_ligonine').value='';
       }

--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -374,17 +374,32 @@ export function loadAll(){
       if(rightLabel){ rightLabel.hidden = !showRightNote; rightLabel.classList.toggle('hidden', !showRightNote); }
       const rightWrapper = $('#d_pupil_right_wrapper');
       if(rightWrapper) rightWrapper.setAttribute('aria-expanded', showRightNote);
-      $('#e_back_notes').style.display = ($$('.chip.active', $('#e_back_group')).some(c=>c.dataset.value==='Pakitimai'))?'block':'none';
+      const showBack = $$('.chip.active', $('#e_back_group')).some(c=>c.dataset.value==='Pakitimai');
+      const backNote = $('#e_back_notes');
+      backNote.style.display = showBack ? 'block' : 'none';
+      backNote.classList.toggle('hidden', !showBack);
       const showSkinColorOther = $$('.chip.active', $('#c_skin_color_group')).some(c=>c.dataset.value==='Kita');
       const skinColorOther = $('#c_skin_color_other');
       skinColorOther.hidden = !showSkinColorOther;
       skinColorOther.classList.toggle('hidden', !showSkinColorOther);
       $('#oxygenFields').classList.toggle('hidden', !($('#b_oxygen_liters').value || $('#b_oxygen_type').value));
       $('#dpvFields').classList.toggle('hidden', !$('#b_dpv_fio2').value);
-    $('#spr_skyrius_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Stacionarizavimas'))?'block':'none';
-    $('#spr_ligonine_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Pervežimas į kitą ligoninę'))?'block':'none';
-    $('#spr_skyrius_kita').style.display = ($('#spr_skyrius').value === 'Kita') ? 'block' : 'none';
-    $('#imaging_other').style.display = (IMAGING_GROUPS.some(sel=>$$('.chip.active', $(sel)).some(c=>c.dataset.value==='Kita')))?'block':'none';
+    const showSky = $$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Stacionarizavimas');
+    const skyBox = $('#spr_skyrius_container');
+    skyBox.style.display = showSky ? 'block' : 'none';
+    skyBox.classList.toggle('hidden', !showSky);
+    const showHosp = $$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Pervežimas į kitą ligoninę');
+    const hospBox = $('#spr_ligonine_container');
+    hospBox.style.display = showHosp ? 'block' : 'none';
+    hospBox.classList.toggle('hidden', !showHosp);
+    const showSkyOther = ($('#spr_skyrius').value === 'Kita');
+    const skyOther = $('#spr_skyrius_kita');
+    skyOther.style.display = showSkyOther ? 'block' : 'none';
+    skyOther.classList.toggle('hidden', !showSkyOther);
+    const showImgOther = (IMAGING_GROUPS.some(sel=>$$('.chip.active', $(sel)).some(c=>c.dataset.value==='Kita')));
+    const imgOther = $('#imaging_other');
+    imgOther.style.display = showImgOther ? 'block' : 'none';
+    imgOther.classList.toggle('hidden', !showImgOther);
   };
   const fallback=()=>{
     const raw=localStorage.getItem(sessionKey()); if(!raw) return; try{ apply(JSON.parse(raw)); }catch(e){ console.error(e); }

--- a/public/js/__tests__/chips.test.js
+++ b/public/js/__tests__/chips.test.js
@@ -125,6 +125,50 @@ describe('chips', () => {
     expect(container.style.display).toBe('none');
   });
 
+  test('shows department field when hospitalization decision selected', () => {
+    document.body.innerHTML = `
+      <div id="spr_decision_group" data-single="true">
+        <button type="button" class="chip" data-value="Stacionarizavimas" aria-pressed="false"></button>
+        <button type="button" class="chip" data-value="Namo" aria-pressed="false"></button>
+      </div>
+      <div id="spr_skyrius_container" style="display:none;" class="hidden">
+        <select id="spr_skyrius"></select>
+        <input id="spr_skyrius_kita" class="hidden" />
+      </div>
+      <div id="spr_ligonine_container" style="display:none;" class="hidden">
+        <input id="spr_ligonine" />
+      </div>
+    `;
+    const { initChips } = require('../chips.js');
+    initChips();
+    const [hospChip, otherChip] = document.querySelectorAll('#spr_decision_group .chip');
+    const container = document.getElementById('spr_skyrius_container');
+    hospChip.click();
+    expect(container.style.display).toBe('block');
+    otherChip.click();
+    expect(container.style.display).toBe('none');
+  });
+
+  test('shows back note input when changes selected', () => {
+    document.body.innerHTML = `
+      <div id="e_back_group" data-single="true">
+        <button type="button" class="chip" data-value="Be pakitimų" aria-pressed="false"></button>
+        <button type="button" class="chip" data-value="Pakitimai" aria-pressed="false"></button>
+      </div>
+      <input id="e_back_notes" class="hidden" />
+    `;
+    const { initChips } = require('../chips.js');
+    initChips();
+    const [noChange, changes] = document.querySelectorAll('#e_back_group .chip');
+    const input = document.getElementById('e_back_notes');
+    changes.click();
+    expect(input.style.display).toBe('block');
+    expect(input.classList.contains('hidden')).toBe(false);
+    noChange.click();
+    expect(input.style.display).toBe('none');
+    expect(input.classList.contains('hidden')).toBe(true);
+  });
+
   test('shows other imaging field when "Kita" selected', () => {
     document.body.innerHTML = `
       <div id="imaging_ct">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -216,8 +216,10 @@ async function init(){
   });
     $('#spr_skyrius').addEventListener('change', e=>{
       const show = e.target.value === 'Kita';
-      $('#spr_skyrius_kita').style.display = show ? 'block' : 'none';
-      if(!show) $('#spr_skyrius_kita').value='';
+      const field = $('#spr_skyrius_kita');
+      field.style.display = show ? 'block' : 'none';
+      field.classList.toggle('hidden', !show);
+      if(!show) field.value='';
       saveAll();
     });
     $('#output').addEventListener('input', expandOutput);

--- a/public/js/chips.js
+++ b/public/js/chips.js
@@ -70,6 +70,7 @@ function toggleBackNote(chip){
   const note = $('#e_back_notes');
   const show = chip.dataset.value==='Pakitimai' && isChipActive(chip);
   note.style.display = show ? 'block' : 'none';
+  note.classList.toggle('hidden', !show);
   if(!show) note.value='';
 }
 
@@ -134,21 +135,25 @@ export function initChips(saveAll){
       const box=$('#imaging_other');
       const show=!!document.querySelector('[id^="imaging_"] .chip.active[data-value="Kita"]');
       box.style.display = show ? 'block' : 'none';
+      box.classList.toggle('hidden', !show);
       if(!show) box.value='';
     }
     if(group.id==='spr_decision_group'){
       const showSky = chip.dataset.value==='Stacionarizavimas' && isChipActive(chip);
       const boxSky = $('#spr_skyrius_container');
       boxSky.style.display = showSky ? 'block' : 'none';
+      boxSky.classList.toggle('hidden', !showSky);
       if(!showSky){
         $('#spr_skyrius').value='';
         $('#spr_skyrius_kita').style.display='none';
+        $('#spr_skyrius_kita').classList.add('hidden');
         $('#spr_skyrius_kita').value='';
       }
 
       const showHosp = chip.dataset.value==='Pervežimas į kitą ligoninę' && isChipActive(chip);
       const boxHosp = $('#spr_ligonine_container');
       boxHosp.style.display = showHosp ? 'block' : 'none';
+      boxHosp.classList.toggle('hidden', !showHosp);
       if(!showHosp){
         $('#spr_ligonine').value='';
       }

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -375,17 +375,32 @@ export function loadAll(){
       if(rightLabel){ rightLabel.hidden = !showRightNote; rightLabel.classList.toggle('hidden', !showRightNote); }
       const rightWrapper = $('#d_pupil_right_wrapper');
       if(rightWrapper) rightWrapper.setAttribute('aria-expanded', showRightNote);
-      $('#e_back_notes').style.display = ($$('.chip.active', $('#e_back_group')).some(c=>c.dataset.value==='Pakitimai'))?'block':'none';
+      const showBack = $$('.chip.active', $('#e_back_group')).some(c=>c.dataset.value==='Pakitimai');
+      const backNote = $('#e_back_notes');
+      backNote.style.display = showBack ? 'block' : 'none';
+      backNote.classList.toggle('hidden', !showBack);
       const showSkinColorOther = $$('.chip.active', $('#c_skin_color_group')).some(c=>c.dataset.value==='Kita');
       const skinColorOther = $('#c_skin_color_other');
       skinColorOther.hidden = !showSkinColorOther;
       skinColorOther.classList.toggle('hidden', !showSkinColorOther);
       $('#oxygenFields').classList.toggle('hidden', !($('#b_oxygen_liters').value || $('#b_oxygen_type').value));
       $('#dpvFields').classList.toggle('hidden', !$('#b_dpv_fio2').value);
-    $('#spr_skyrius_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Stacionarizavimas'))?'block':'none';
-    $('#spr_ligonine_container').style.display = ($$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Pervežimas į kitą ligoninę'))?'block':'none';
-    $('#spr_skyrius_kita').style.display = ($('#spr_skyrius').value === 'Kita') ? 'block' : 'none';
-    $('#imaging_other').style.display = (IMAGING_GROUPS.some(sel=>$$('.chip.active', $(sel)).some(c=>c.dataset.value==='Kita')))?'block':'none';
+    const showSky = $$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Stacionarizavimas');
+    const skyBox = $('#spr_skyrius_container');
+    skyBox.style.display = showSky ? 'block' : 'none';
+    skyBox.classList.toggle('hidden', !showSky);
+    const showHosp = $$('.chip.active', $('#spr_decision_group')).some(c=>c.dataset.value==='Pervežimas į kitą ligoninę');
+    const hospBox = $('#spr_ligonine_container');
+    hospBox.style.display = showHosp ? 'block' : 'none';
+    hospBox.classList.toggle('hidden', !showHosp);
+    const showSkyOther = ($('#spr_skyrius').value === 'Kita');
+    const skyOther = $('#spr_skyrius_kita');
+    skyOther.style.display = showSkyOther ? 'block' : 'none';
+    skyOther.classList.toggle('hidden', !showSkyOther);
+    const showImgOther = (IMAGING_GROUPS.some(sel=>$$('.chip.active', $(sel)).some(c=>c.dataset.value==='Kita')));
+    const imgOther = $('#imaging_other');
+    imgOther.style.display = showImgOther ? 'block' : 'none';
+    imgOther.classList.toggle('hidden', !showImgOther);
   };
   const fallback=()=>{
     const raw=localStorage.getItem(sessionKey()); if(!raw) return; try{ apply(JSON.parse(raw)); }catch(e){ console.error(e); }


### PR DESCRIPTION
## Summary
- show back note input when selecting Pakitimai on E – Kita page
- reveal custom imaging and decision fields and manage hidden class
- add tests for back note and hospitalization decision visibility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af04fc53c88320959cf0b8ba597548