### PR TITLE
Refine body map limb shapes

### DIFF
--- a/public/js/bodyMapZones.js
+++ b/public/js/bodyMapZones.js
@@ -58,21 +58,28 @@ function makeSymmetric (side, defs) {
 }
 
 const frontDefs = [
-  { id: 'upper-arm', path: 'M1 18H7V28H1Z', area: 2, label: 'žastas', bbox: [1, 18, 7, 28] },
-  { id: 'lower-arm', path: 'M1 28H7V40H1Z', area: 1.5, label: 'dilbis', bbox: [1, 28, 7, 40] },
-  { id: 'hand', path: 'M1 40H7V46H1Z', area: 1, label: 'plaštaka', bbox: [1, 40, 7, 46] },
-  { id: 'thigh', path: 'M15 34H23V41H15Z', area: 4.5, label: 'šlaunis', bbox: [15, 34, 23, 41] },
-  { id: 'leg', path: 'M15 41H23V46H15Z', area: 3.5, label: 'blauzda', bbox: [15, 41, 23, 46] },
-  { id: 'foot', path: 'M15 46H23V50H15Z', area: 1, label: 'pėda', bbox: [15, 46, 23, 50] }
+  // Tapered trapezoid resembling the upper arm
+  { id: 'upper-arm', path: 'M1 18 L7 18 L6 28 L2 28 Z', area: 2, label: 'žastas', bbox: [1, 18, 7, 28] },
+  // Narrowing towards the wrist
+  { id: 'lower-arm', path: 'M2 28 L6 28 L5 40 L3 40 Z', area: 1.5, label: 'dilbis', bbox: [2, 28, 6, 40] },
+  // Simple polygon approximating palm and fingers
+  { id: 'hand', path: 'M2 40 L6 40 L6.5 43 L7 46 L1 46 L1.5 43 Z', area: 1, label: 'plaštaka', bbox: [1, 40, 7, 46] },
+  // Slightly curved thigh
+  { id: 'thigh', path: 'M15 34 L23 34 L22.5 38 L21 41 L17 41 L15.5 38 Z', area: 4.5, label: 'šlaunis', bbox: [15, 34, 23, 41] },
+  // Tapered lower leg
+  { id: 'leg', path: 'M16 41 L22 41 L21.5 44 L21 46 L17 46 L16.5 44 Z', area: 3.5, label: 'blauzda', bbox: [16, 41, 22, 46] },
+  // Wedge shaped foot
+  { id: 'foot', path: 'M15 46 L23 46 L23 48 L21 50 L17 50 L15 48 Z', area: 1, label: 'pėda', bbox: [15, 46, 23, 50] }
 ];
 
+// Back definitions mirror the front shapes for now
 const backDefs = [
-  { id: 'upper-arm', path: 'M1 18H7V28H1Z', area: 2, label: 'žastas', bbox: [1, 18, 7, 28] },
-  { id: 'lower-arm', path: 'M1 28H7V40H1Z', area: 1.5, label: 'dilbis', bbox: [1, 28, 7, 40] },
-  { id: 'hand', path: 'M1 40H7V46H1Z', area: 1, label: 'plaštaka', bbox: [1, 40, 7, 46] },
-  { id: 'thigh', path: 'M15 34H23V41H15Z', area: 4.5, label: 'šlaunis', bbox: [15, 34, 23, 41] },
-  { id: 'leg', path: 'M15 41H23V46H15Z', area: 3.5, label: 'blauzda', bbox: [15, 41, 23, 46] },
-  { id: 'foot', path: 'M15 46H23V50H15Z', area: 1, label: 'pėda', bbox: [15, 46, 23, 50] }
+  { id: 'upper-arm', path: 'M1 18 L7 18 L6 28 L2 28 Z', area: 2, label: 'žastas', bbox: [1, 18, 7, 28] },
+  { id: 'lower-arm', path: 'M2 28 L6 28 L5 40 L3 40 Z', area: 1.5, label: 'dilbis', bbox: [2, 28, 6, 40] },
+  { id: 'hand', path: 'M2 40 L6 40 L6.5 43 L7 46 L1 46 L1.5 43 Z', area: 1, label: 'plaštaka', bbox: [1, 40, 7, 46] },
+  { id: 'thigh', path: 'M15 34 L23 34 L22.5 38 L21 41 L17 41 L15.5 38 Z', area: 4.5, label: 'šlaunis', bbox: [15, 34, 23, 41] },
+  { id: 'leg', path: 'M16 41 L22 41 L21.5 44 L21 46 L17 46 L16.5 44 Z', area: 3.5, label: 'blauzda', bbox: [16, 41, 22, 46] },
+  { id: 'foot', path: 'M15 46 L23 46 L23 48 L21 50 L17 50 L15 48 Z', area: 1, label: 'pėda', bbox: [15, 46, 23, 50] }
 ];
 
 export default [


### PR DESCRIPTION
## Summary
- replace rectangular limb zones with tapered polygonal paths for more natural body contours
- update bounding boxes for new limb shapes while keeping existing IDs and areas
- confirm BodyMap logic continues to map zone labels using updated definitions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af2a5e44348320be451c90bcb3aa71