### PR TITLE
Add client-side interaction tests

### DIFF
--- a/public/js/__tests__/chips.test.js
+++ b/public/js/__tests__/chips.test.js
@@ -216,4 +216,20 @@ describe('chips', () => {
     expect(document.getElementById('d_pupil_left_wrapper').getAttribute('aria-expanded')).toBe('false');
     expect(note.value).toBe('');
   });
+
+  test('updates status indicator when chip is activated', () => {
+    document.body.innerHTML = `
+      <div id="group"><span class="chip" data-value="a"></span></div>
+    `;
+    const { setChipActive } = require('../chips.js');
+    const chip = document.querySelector('#group .chip');
+    setChipActive(chip, true);
+    const icon = chip.querySelector('.chip-status-icon');
+    const sr = chip.querySelector('.chip-status-text');
+    expect(icon.textContent).toBe('✓');
+    expect(sr.textContent).toBe('selected');
+    setChipActive(chip, false);
+    expect(icon.textContent).toBe('✗');
+    expect(sr.textContent).toBe('not selected');
+  });
 });

--- a/public/js/__tests__/sessionManager.test.js
+++ b/public/js/__tests__/sessionManager.test.js
@@ -40,5 +40,15 @@ describe('sessionManager utilities', () => {
     expect(document.getElementById('saveStatus').textContent).toBe('Saved');
     expect(mockFetch).toHaveBeenCalled();
   });
+
+  test('setAuthToken stores and clears token', () => {
+    const { setAuthToken, getAuthToken } = require('../sessionManager.js');
+    setAuthToken('abc123');
+    expect(getAuthToken()).toBe('abc123');
+    expect(localStorage.getItem('trauma_token')).toBe('abc123');
+    setAuthToken(null);
+    expect(getAuthToken()).toBeNull();
+    expect(localStorage.getItem('trauma_token')).toBeNull();
+  });
 });
 

--- a/public/js/__tests__/validation.test.js
+++ b/public/js/__tests__/validation.test.js
@@ -20,6 +20,16 @@ describe('validateField', () => {
     expect(err.textContent).toBe('Netinkama reikšmė');
     expect(input.classList.contains('invalid')).toBe(true);
   });
+
+  test('returns error for value outside numeric range', () => {
+    document.body.innerHTML = '<input id="num" min="1" max="5" value="10" />';
+    const input = document.getElementById('num');
+    validateField(input);
+    const err = input.nextElementSibling;
+    expect(err).not.toBeNull();
+    expect(err.textContent).toBe('Leistina 1–5');
+    expect(input.classList.contains('invalid')).toBe(true);
+  });
 });
 
 describe('validateVitals', () => {


### PR DESCRIPTION
## Summary
- add chip status indicator test to verify accessibility text updates
- test session token storage and cleanup
- cover numeric range validation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af56eb50a883208ead43ac6a371560