### PR TITLE
Configure ESLint and pre-commit linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
+node_modules/
+docs/
 public/js/lib

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,47 @@
 {
+  "root": true,
   "env": {
-    "browser": true,
-    "node": true,
-    "es2021": true,
-    "jest": true
+    "es2021": true
   },
   "extends": ["eslint:recommended"],
-  "parserOptions": {
-    "sourceType": "module"
-  },
+  "overrides": [
+    {
+      "files": ["server/**/*.js"],
+      "env": {
+        "node": true,
+        "jest": true
+      },
+      "extends": ["plugin:n/recommended"],
+      "settings": {
+        "node": {
+          "version": ">=18.0.0"
+        }
+      },
+      "rules": {
+        "n/no-unpublished-require": "off"
+      }
+    },
+    {
+      "files": ["public/js/**/*.js"],
+      "env": {
+        "browser": true
+      },
+      "parserOptions": {
+        "sourceType": "module"
+      }
+    },
+    {
+      "files": ["public/js/__tests__/**/*.js", "public/js/__fixtures__/**/*.js"],
+      "env": {
+        "browser": true,
+        "jest": true,
+        "node": true
+      },
+      "parserOptions": {
+        "sourceType": "module"
+      }
+    }
+  ],
   "rules": {
     "semi": ["error", "always"]
   }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-n": "^15.7.0",
         "eslint-plugin-promise": "^6.1.1",
+        "husky": "^9.1.7",
         "jest": "^27.5.1",
         "jsdom": "^26.1.0",
         "sass": "^1.90.0",
@@ -6010,6 +6011,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:css": "sass --no-source-map --style=compressed public/css/scss/main.scss public/css/main.css",
     "build": "npm run build:css && rm -rf docs && cp -r public docs && rm -rf docs/js/__tests__",
     "start": "node server/start.js",
-    "lint": "eslint 'public/js/**/*.js' 'server/**/*.js'"
+    "lint": "eslint server public/js",
+    "prepare": "husky install"
   },
   "keywords": [],
   "author": "",
@@ -30,6 +31,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-promise": "^6.1.1",
+    "husky": "^9.1.7",
     "jest": "^27.5.1",
     "jsdom": "^26.1.0",
     "sass": "^1.90.0",


### PR DESCRIPTION
## Summary
- configure ESLint for Node server and browser scripts
- ignore generated files in linting and add npm lint script
- add Husky pre-commit hook to run lint automatically

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af59a8ed8c83209583044b2cd2ada3