### PR TITLE
feat: add strict session data schema

### DIFF
--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -9,6 +9,9 @@ const socketEndpoint = window.socketEndpoint || window.SOCKET_URL;
 let currentSessionId = localStorage.getItem('trauma_current_session') || null;
 let showArchived = false;
 
+const MAX_FIELD_LENGTH = 500;
+const limit = (val, max = MAX_FIELD_LENGTH) => (val || '').toString().slice(0, max);
+
 function updateUserList(users){
   const el=document.getElementById('userList');
   if(el) el.textContent=users.length?`Prisijungę: ${users.join(', ')}`:'';
@@ -303,13 +306,13 @@ export function saveAll(){
     const key=el.dataset.field || el.id || el.name;
     if(!key) return;
     if(el.type==='radio'){ if(el.checked) data[key+'__'+el.value]=true; }
-    else if(el.type==='checkbox'){ data[key]=el.checked?'__checked__':(el.value||''); }
-    else{ data[key]=el.value; }
+    else if(el.type==='checkbox'){ data[key]=el.checked?'__checked__':limit(el.value); }
+    else{ data[key]=limit(el.value); }
   });
   CHIP_GROUPS.forEach(sel=>{ const arr=$$('.chip.active',$(sel)).map(c=>c.dataset.value); data['chips:'+sel]=arr; });
-  function pack(container){ return Array.from(container.children).map(card=>({ name:(card.querySelector('.act_custom_name')?card.querySelector('.act_custom_name').value:card.querySelector('.act_name').textContent.trim()), on:card.querySelector('.act_chk').checked, time:card.querySelector('.act_time').value, dose:(card.querySelector('.act_dose')?card.querySelector('.act_dose').value:''), note:card.querySelector('.act_note').value }));}
+  function pack(container){ return Array.from(container.children).map(card=>({ name:limit(card.querySelector('.act_custom_name')?card.querySelector('.act_custom_name').value:card.querySelector('.act_name').textContent.trim()), on:card.querySelector('.act_chk').checked, time:limit(card.querySelector('.act_time').value), dose:limit(card.querySelector('.act_dose')?card.querySelector('.act_dose').value:''), note:limit(card.querySelector('.act_note').value) }));}
   data['pain_meds']=pack($('#pain_meds')); data['bleeding_meds']=pack($('#bleeding_meds')); data['other_meds']=pack($('#other_meds')); data['procs']=pack($('#procedures'));
-  data['bodymap_svg']=bodyMap.serialize();
+  data['bodymap_svg']=limit(bodyMap.serialize(), 200000);
   localStorage.setItem(sessionKey(), JSON.stringify(data));
   const statusEl = $('#saveStatus');
   if(statusEl){

--- a/public/js/__tests__/sessionManager.test.js
+++ b/public/js/__tests__/sessionManager.test.js
@@ -23,7 +23,7 @@ describe('sessionManager utilities', () => {
     localStorage.setItem('trauma_current_session', 'test');
     localStorage.setItem('trauma_token', 'token');
     document.body.innerHTML = `
-      <input id="field" />
+      <input id="field" type="text" />
       <div id="saveStatus"></div>
       <div id="pain_meds"></div>
       <div id="bleeding_meds"></div>
@@ -39,6 +39,14 @@ describe('sessionManager utilities', () => {
     await promise;
     expect(document.getElementById('saveStatus').textContent).toBe('Saved');
     expect(mockFetch).toHaveBeenCalled();
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(payload).toMatchObject({
+      pain_meds: [],
+      bleeding_meds: [],
+      other_meds: [],
+      procs: [],
+      bodymap_svg: ''
+    });
   });
 
   test('setAuthToken stores and clears token', () => {

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -9,6 +9,9 @@ const socketEndpoint = window.socketEndpoint || window.SOCKET_URL;
 let currentSessionId = localStorage.getItem('trauma_current_session') || null;
 let showArchived = false;
 
+const MAX_FIELD_LENGTH = 500;
+const limit = (val, max = MAX_FIELD_LENGTH) => (val || '').toString().slice(0, max);
+
 function updateUserList(users){
   const el=document.getElementById('userList');
   if(el) el.textContent=users.length?`Prisijungę: ${users.join(', ')}`:'';
@@ -303,13 +306,13 @@ export async function saveAll(){
     const key=el.dataset.field || el.id || el.name;
     if(!key) return;
     if(el.type==='radio'){ if(el.checked) data[key+'__'+el.value]=true; }
-    else if(el.type==='checkbox'){ data[key]=el.checked?'__checked__':(el.value||''); }
-    else{ data[key]=el.value; }
+    else if(el.type==='checkbox'){ data[key]=el.checked?'__checked__':limit(el.value); }
+    else{ data[key]=limit(el.value); }
   });
   CHIP_GROUPS.forEach(sel=>{ const arr=$$('.chip.active',$(sel)).map(c=>c.dataset.value); data['chips:'+sel]=arr; });
-  function pack(container){ return Array.from(container.children).map(card=>({ name:(card.querySelector('.act_custom_name')?card.querySelector('.act_custom_name').value:card.querySelector('.act_name').textContent.trim()), on:card.querySelector('.act_chk').checked, time:card.querySelector('.act_time').value, dose:(card.querySelector('.act_dose')?card.querySelector('.act_dose').value:''), note:card.querySelector('.act_note').value }));}
+  function pack(container){ return Array.from(container.children).map(card=>({ name:limit(card.querySelector('.act_custom_name')?card.querySelector('.act_custom_name').value:card.querySelector('.act_name').textContent.trim()), on:card.querySelector('.act_chk').checked, time:limit(card.querySelector('.act_time').value), dose:limit(card.querySelector('.act_dose')?card.querySelector('.act_dose').value:''), note:limit(card.querySelector('.act_note').value) }));}
   data['pain_meds']=pack($('#pain_meds')); data['bleeding_meds']=pack($('#bleeding_meds')); data['other_meds']=pack($('#other_meds')); data['procs']=pack($('#procedures'));
-  data['bodymap_svg']=bodyMap.serialize();
+  data['bodymap_svg']=limit(bodyMap.serialize(), 200000);
   localStorage.setItem(sessionKey(), JSON.stringify(data));
   const statusEl = $('#saveStatus');
   if(statusEl){

--- a/server/index.js
+++ b/server/index.js
@@ -65,7 +65,24 @@ const sessionListItemSchema = Joi.object({
 
 const sessionsListSchema = Joi.array().items(sessionListItemSchema);
 
-const sessionDataSchema = Joi.object().unknown(true);
+const medRecordSchema = Joi.object({
+  name: Joi.string().allow('').max(100).required(),
+  on: Joi.boolean().required(),
+  time: Joi.string().allow('').max(20).required(),
+  dose: Joi.string().allow('').max(50).required(),
+  note: Joi.string().allow('').max(1000).required()
+});
+
+const sessionDataSchema = Joi.object({
+  pain_meds: Joi.array().items(medRecordSchema).max(50),
+  bleeding_meds: Joi.array().items(medRecordSchema).max(50),
+  other_meds: Joi.array().items(medRecordSchema).max(50),
+  procs: Joi.array().items(medRecordSchema).max(50),
+  bodymap_svg: Joi.string().allow('').max(200000)
+})
+  .pattern(/^chips:/, Joi.array().items(Joi.string().max(100)).max(100))
+  .pattern(/.*/, Joi.alternatives().try(Joi.string().max(500), Joi.boolean()))
+  .unknown(false);
 
 /* ===== Auth ===== */
 app.post('/api/login', (req, res, next) => {

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -174,7 +174,14 @@ describe('server API', () => {
       .send({ name: 'data session' });
     const id = session.body.id;
 
-    const payload = { foo: 'bar' };
+    const payload = {
+      foo: 'bar',
+      pain_meds: [{ name: '', on: false, time: '', dose: '', note: '' }],
+      bleeding_meds: [],
+      other_meds: [],
+      procs: [],
+      bodymap_svg: ''
+    };
     const putData = await request(app)
       .put(`/api/sessions/${id}/data`)
       .set('Authorization', `Bearer ${token}`)
@@ -187,6 +194,20 @@ describe('server API', () => {
       .set('Authorization', `Bearer ${token}`);
     expect(getData.statusCode).toBe(200);
     expect(getData.body).toEqual(payload);
+  });
+
+  test('rejects invalid session data shape', async () => {
+    const token = await login('invalid');
+    const session = await request(app)
+      .post('/api/sessions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'bad data' });
+    const id = session.body.id;
+    const res = await request(app)
+      .put(`/api/sessions/${id}/data`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ pain_meds: [{ name: 'x', on: 'yes' }] });
+    expect(res.statusCode).toBe(400);
   });
 
   test('serializes concurrent writes to prevent data loss', async () => {

--- a/server/sessions.test.js
+++ b/server/sessions.test.js
@@ -173,14 +173,14 @@ describe('auth middleware', () => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`
       },
-      body: JSON.stringify({ foo: 1 })
+      body: JSON.stringify({ foo: '1' })
     });
     await httpRequest('PUT', `/api/sessions/${session2.id}/data`, {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`
       },
-      body: JSON.stringify({ bar: 2 })
+      body: JSON.stringify({ bar: '2' })
     });
 
     const replace = await httpRequest('PUT', '/api/sessions', {
@@ -200,11 +200,11 @@ describe('auth middleware', () => {
     const data2 = await httpRequest('GET', `/api/sessions/${session2.id}/data`, {
       headers: { Authorization: `Bearer ${token}` }
     });
-    expect(JSON.parse(data2.data)).toEqual({ bar: 2 });
+    expect(JSON.parse(data2.data)).toEqual({ bar: '2' });
 
     const raw = await fs.promises.readFile(dbPath, 'utf8');
     const parsed = JSON.parse(raw);
     expect(parsed.data[session1.id]).toBeUndefined();
-    expect(parsed.data[session2.id]).toEqual({ bar: 2 });
+    expect(parsed.data[session2.id]).toEqual({ bar: '2' });
   });
 });


### PR DESCRIPTION
## Summary
- validate session payloads with explicit Joi schema
- limit client session data size before saving
- test valid and invalid session data flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afd2e882e88320936e782854537147