### PR TITLE
Fix body map back-zone loading and pointer events

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,6 +10,9 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/main.css">
 <link rel="stylesheet" href="https://unpkg.com/vis-timeline@8.3.0/styles/vis-timeline-graph2d.min.css">
+<style>
+  .silhouette { pointer-events: none; }
+</style>
 </head>
 <body>
 <a href="#views" class="skip-link">Skip to content</a>

--- a/docs/js/components/BodyMap.js
+++ b/docs/js/components/BodyMap.js
@@ -131,11 +131,11 @@ export default class BodyMap {
       });
     }
 
-    // Build zone paths if they are not already present in the SVG.  Tests
-    // provide a bare bones SVG so we create the required paths here.
-    if (this.svg && !this.svg.querySelector('.zone')) {
+    // Build zone paths ensuring all zones from bodyMapZones.js are present.
+    if (this.svg) {
       const layers = { front: $('#layer-front'), back: $('#layer-back') };
       zones.forEach(z => {
+        if (this.svg.querySelector(`.zone[data-zone="${z.id}"]`)) return;
         let group = layers[z.side].querySelector('.zones');
         if (!group) {
           group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
@@ -160,6 +160,7 @@ export default class BodyMap {
     }
 
     // Cache zone elements and attach click handlers
+    this.zoneMap.clear();
     $$('.zone', this.svg).forEach(el => {
       const id = el.dataset.zone;
       this.zoneMap.set(id, el);


### PR DESCRIPTION
## Summary
- Prevent silhouette images from intercepting body map clicks
- Ensure `BodyMap` builds missing front/back zones and refreshes handlers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aff45f1b2083208850a051a587e8dd