### PR TITLE
Clear session fields when switching sessions

### DIFF
--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -341,9 +341,9 @@ export function loadAll(){
     $$(FIELD_SELECTORS).forEach(el=>{
       const key=el.dataset.field || el.id || el.name;
       if(!key) return;
-      if(el.type==='radio'){ if(data[key+'__'+el.value]) el.checked=true; }
+      if(el.type==='radio'){ el.checked=!!data[key+'__'+el.value]; }
       else if(el.type==='checkbox'){ el.checked=(data[key]==='__checked__'); }
-      else{ if(data[key]!=null) el.value=data[key]; }
+      else{ el.value = data[key] ?? ''; }
     });
     CHIP_GROUPS.forEach(sel=>{ const arr=data['chips:'+sel]||[]; $$('.chip',$(sel)).forEach(c=>c.classList.toggle('active',arr.includes(c.dataset.value))); });
     const labsArr=data['chips:#labs_basic']||[];
@@ -358,9 +358,19 @@ export function loadAll(){
       }
     });
     $$('.chip',labsContainer).forEach(c=>c.classList.toggle('active',labsArr.includes(c.dataset.value)));
-    function unpack(container,records){ if(!Array.isArray(records)) return; Array.from(container.children).forEach((card,i)=>{ const r=records[i]; if(!r) return; card.querySelector('.act_chk').checked=!!r.on; card.querySelector('.act_time').value=r.time||''; const d=card.querySelector('.act_dose'); if(d) d.value=r.dose||''; card.querySelector('.act_note').value=r.note||''; const cn=card.querySelector('.act_custom_name'); if(cn) cn.value=r.name||'';});}
+    function unpack(container,records){
+      const arr=Array.isArray(records)?records:[];
+      Array.from(container.children).forEach((card,i)=>{
+        const r=arr[i]||{};
+        card.querySelector('.act_chk').checked=!!r.on;
+        card.querySelector('.act_time').value=r.time||'';
+        const d=card.querySelector('.act_dose'); if(d) d.value=r.dose||'';
+        card.querySelector('.act_note').value=r.note||'';
+        const cn=card.querySelector('.act_custom_name'); if(cn) cn.value=r.name||'';
+      });
+    }
     unpack($('#pain_meds'),data['pain_meds']); unpack($('#bleeding_meds'),data['bleeding_meds']); unpack($('#other_meds'),data['other_meds']); unpack($('#procedures'),data['procs']);
-    if(data['bodymap_svg']) bodyMap.load(data['bodymap_svg']);
+    bodyMap.load(data['bodymap_svg']||'{}');
       const showLeftNote = $$('.chip.active', $('#d_pupil_left_group')).some(c=>c.dataset.value==='kita');
       const leftNote = $('#d_pupil_left_note');
       const leftLabel = $('#d_pupil_left_wrapper label[for="d_pupil_left_note"]');
@@ -409,7 +419,9 @@ export function loadAll(){
     imgOther.classList.toggle('hidden', !showImgOther);
   };
   const fallback=()=>{
-    const raw=localStorage.getItem(sessionKey()); if(!raw) return; try{ apply(JSON.parse(raw)); }catch(e){ console.error(e); }
+    const raw=localStorage.getItem(sessionKey());
+    if(!raw){ apply({}); return; }
+    try{ apply(JSON.parse(raw)); }catch(e){ console.error(e); }
   };
   if(authToken && typeof fetch === 'function'){
     fetch(`/api/sessions/${currentSessionId}/data`, { headers:{ 'Authorization': 'Bearer ' + authToken }})

--- a/public/js/__tests__/patient.test.js
+++ b/public/js/__tests__/patient.test.js
@@ -234,6 +234,35 @@ describe('patient fields', () => {
     expect(svg).not.toBeNull();
   });
 
+  test('switching sessions clears patient fields', () => {
+    document.getElementById('patient_age').value='40';
+    document.getElementById('patient_sex').value='F';
+    document.getElementById('patient_history').value='hist';
+    const { setChipActive } = require('../chips.js');
+    const chip=document.querySelector('#c_skin_color_group .chip[data-value="Blyški"]');
+    setChipActive(chip,true);
+    const card=document.createElement('div');
+    card.innerHTML='<input type="checkbox" class="act_chk"><input class="act_time"><input class="act_dose"><input class="act_note"><input class="act_custom_name"><span class="act_name">Med</span>';
+    document.getElementById('pain_meds').appendChild(card);
+    card.querySelector('.act_chk').checked=true;
+    card.querySelector('.act_time').value='10:00';
+    card.querySelector('.act_dose').value='5';
+    card.querySelector('.act_note').value='note';
+    card.querySelector('.act_custom_name').value='Name';
+    saveAll();
+    setCurrentSessionId('new');
+    loadAll();
+    expect(document.getElementById('patient_age').value).toBe('');
+    expect(document.getElementById('patient_sex').value).toBe('');
+    expect(document.getElementById('patient_history').value).toBe('');
+    expect(document.querySelector('#c_skin_color_group .chip.active')).toBeNull();
+    expect(card.querySelector('.act_chk').checked).toBe(false);
+    expect(card.querySelector('.act_time').value).toBe('');
+    expect(card.querySelector('.act_dose').value).toBe('');
+    expect(card.querySelector('.act_note').value).toBe('');
+    expect(card.querySelector('.act_custom_name').value).toBe('');
+  });
+
   test('validation flags out-of-range values', () => {
     const { initValidation } = require('../validation.js');
     initValidation();


### PR DESCRIPTION
## Summary
- Ensure `loadAll` clears missing data for inputs, radios, checkboxes, chips, and body map
- Mirror session field reset logic in docs build
- Add regression test verifying patient fields reset on new session

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68affe1b16348320834d8801b64bfa58