### PR TITLE
Use PATCH for session archive/unarchive

### DIFF
--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -207,7 +207,13 @@ export async function initSessions(){
       archive.setAttribute('aria-label', s.archived ? 'Unarchive session' : 'Archive session');
       archive.addEventListener('click', async () => {
         if(authToken && typeof fetch==='function'){
-          try{ await fetch(`/api/sessions/${s.id}/${s.archived?'unarchive':'archive'}`, { method:'POST', headers:{ 'Authorization': 'Bearer ' + authToken } }); }catch(e){ console.error(e); }
+          try{
+            await fetch(`/api/sessions/${s.id}/archive`, {
+              method: 'PATCH',
+              headers: { 'Authorization': 'Bearer ' + authToken, 'Content-Type': 'application/json' },
+              body: JSON.stringify({ archived: !s.archived })
+            });
+          }catch(e){ console.error(e); }
         }
         s.archived=!s.archived;
         await saveSessions(sessions);

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -207,7 +207,13 @@ export async function initSessions(){
       archive.setAttribute('aria-label', s.archived ? 'Unarchive session' : 'Archive session');
       archive.addEventListener('click', async () => {
         if(authToken && typeof fetch==='function'){
-          try{ await fetch(`/api/sessions/${s.id}/${s.archived?'unarchive':'archive'}`, { method:'POST', headers:{ 'Authorization': 'Bearer ' + authToken } }); }catch(e){ console.error(e); }
+          try{
+            await fetch(`/api/sessions/${s.id}/archive`, {
+              method: 'PATCH',
+              headers: { 'Authorization': 'Bearer ' + authToken, 'Content-Type': 'application/json' },
+              body: JSON.stringify({ archived: !s.archived })
+            });
+          }catch(e){ console.error(e); }
         }
         s.archived=!s.archived;
         await saveSessions(sessions);

--- a/server/index.js
+++ b/server/index.js
@@ -160,21 +160,15 @@ app.put('/api/sessions/:id', auth, validate(sessionSchema), async (req, res) => 
   res.json({ ok: true });
 });
 
-app.post('/api/sessions/:id/archive', auth, async (req, res) => {
+app.patch('/api/sessions/:id/archive', auth, async (req, res) => {
   const id = req.params.id;
   const session = db.sessions.find(s => s.id === id);
   if (!session) return res.status(404).json({ error: 'Not found' });
-  session.archived = true;
-  await saveDB();
-  io.emit('sessions', db.sessions);
-  res.json({ ok: true });
-});
-
-app.post('/api/sessions/:id/unarchive', auth, async (req, res) => {
-  const id = req.params.id;
-  const session = db.sessions.find(s => s.id === id);
-  if (!session) return res.status(404).json({ error: 'Not found' });
-  session.archived = false;
+  const { archived } = req.body;
+  if (typeof archived !== 'boolean') {
+    return res.status(400).json({ error: '"archived" must be a boolean' });
+  }
+  session.archived = archived;
   await saveDB();
   io.emit('sessions', db.sessions);
   res.json({ ok: true });

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -94,13 +94,15 @@ describe('server API', () => {
       .send({ name: 'arch' });
     const id = create.body.id;
     const archive = await request(app)
-      .post(`/api/sessions/${id}/archive`)
-      .set('Authorization', `Bearer ${token}`);
+      .patch(`/api/sessions/${id}/archive`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ archived: true });
     expect(archive.statusCode).toBe(200);
     expect(fakeDB.sessions[0].archived).toBe(true);
     const unarchive = await request(app)
-      .post(`/api/sessions/${id}/unarchive`)
-      .set('Authorization', `Bearer ${token}`);
+      .patch(`/api/sessions/${id}/archive`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ archived: false });
     expect(unarchive.statusCode).toBe(200);
     expect(fakeDB.sessions[0].archived).toBe(false);
   });


### PR DESCRIPTION
## Summary
- replace session archive/unarchive POST routes with a single PATCH `/api/sessions/:id/archive`
- update client session manager to toggle archived state via PATCH
- adjust server tests for the new endpoint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b00a4b069c8320af7deb7b29d5f8b6