### PR TITLE
Validate DB structure with Joi and fallback for corrupt files

### DIFF
--- a/server/dbSchema.js
+++ b/server/dbSchema.js
@@ -1,0 +1,39 @@
+const Joi = require('joi');
+
+const medRecordSchema = Joi.object({
+  name: Joi.string().allow('').max(100).required(),
+  on: Joi.boolean().required(),
+  time: Joi.string().allow('').max(20).required(),
+  dose: Joi.string().allow('').max(50).required(),
+  note: Joi.string().allow('').max(1000).required()
+});
+
+const sessionDataSchema = Joi.object({
+  pain_meds: Joi.array().items(medRecordSchema).max(50),
+  bleeding_meds: Joi.array().items(medRecordSchema).max(50),
+  other_meds: Joi.array().items(medRecordSchema).max(50),
+  procs: Joi.array().items(medRecordSchema).max(50),
+  bodymap_svg: Joi.string().allow('').max(200000)
+})
+  .pattern(/^chips:/, Joi.array().items(Joi.string().max(100)).max(100))
+  .pattern(/.*/, Joi.alternatives().try(Joi.string().max(500), Joi.boolean()))
+  .unknown(false);
+
+const sessionSchema = Joi.object({
+  id: Joi.string().required(),
+  name: Joi.string().min(1).max(100).required(),
+  archived: Joi.boolean().default(false)
+});
+
+const userSchema = Joi.object({
+  token: Joi.string().required(),
+  name: Joi.string().min(1).max(50).required()
+});
+
+const dbSchema = Joi.object({
+  sessions: Joi.array().items(sessionSchema).required(),
+  data: Joi.object().pattern(Joi.string(), sessionDataSchema).required(),
+  users: Joi.array().items(userSchema).required()
+});
+
+module.exports = { dbSchema, sessionDataSchema };

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -277,5 +277,25 @@ describe('loadDB', () => {
     expect(consoleError).toHaveBeenCalledWith('Failed to load DB', expect.any(Error));
     consoleError.mockRestore();
   });
+
+  test('returns defaults and logs when DB JSON is invalid', async () => {
+    fsPromises.readFile.mockResolvedValue('{ invalid');
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { loadDB } = require('./index');
+    const db = await loadDB();
+    expect(db).toEqual({ sessions: [], data: {}, users: [] });
+    expect(consoleError).toHaveBeenCalledWith('Failed to parse DB', expect.any(SyntaxError));
+    consoleError.mockRestore();
+  });
+
+  test('returns defaults and logs when DB schema is invalid', async () => {
+    fsPromises.readFile.mockResolvedValue(JSON.stringify({ sessions: 'bad' }));
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { loadDB } = require('./index');
+    const db = await loadDB();
+    expect(db).toEqual({ sessions: [], data: {}, users: [] });
+    expect(consoleError).toHaveBeenCalledWith('Invalid DB schema', expect.any(Error));
+    consoleError.mockRestore();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add Joi schema describing DB sessions, data, and users
- validate DB load against schema and log errors
- test that corrupted DB files fall back to defaults

## Testing
- `npm run lint`
- `npm run test:server`

------
https://chatgpt.com/codex/tasks/task_e_68b00b667780832080c221f9858de8d0