### PR TITLE
Allow configuring Socket.IO origins via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ node server/start.js
 
 Alternatively, use the provided `npm start` script.
 
+## Environment Variables
+
+- `ALLOWED_ORIGINS` – Comma-separated list of origins allowed for
+  Socket.IO connections. If unset, all origins are permitted.
+
 ## Testing
 
 Execute the test suite:

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,9 @@ const { dbSchema, sessionDataSchema } = require('./dbSchema');
 const PORT = process.env.PORT || 3000;
 const DB_FILE = process.env.DB_FILE || path.join(__dirname, 'db.json');
 const DISABLE_AUTH = process.env.DISABLE_AUTH === 'true';
+const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim()).filter(Boolean)
+  : undefined;
 
 async function loadDB(){
   try {
@@ -198,7 +201,7 @@ app.use((err, req, res, next) => {
 });
 
 const server = http.createServer(app);
-const io = new Server(server, { cors: { origin: '*' } });
+const io = new Server(server, { cors: { origin: ALLOWED_ORIGINS || '*' } });
 
 io.use((socket, next) => {
   if (DISABLE_AUTH) return next();


### PR DESCRIPTION
## Summary
- allow configuring Socket.IO CORS origins via `ALLOWED_ORIGINS` env var
- document `ALLOWED_ORIGINS` environment variable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b00d6e724083209a303d7f3c87516c