### PR TITLE
Limit JSON payload size and add regression test

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -56,7 +56,7 @@ function saveDB(){
 let db;
 
 const app = express();
-app.use(express.json());
+app.use(express.json({ limit: '1mb' }));
 // Serve static assets from the public directory
 app.use(express.static(path.join(__dirname, '..', 'public')));
 

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -123,6 +123,12 @@ describe('server API', () => {
     expect(res.body).toEqual({ error: '"name" is required' });
   });
 
+  test('returns 413 for payloads exceeding limit', async () => {
+    const bigName = 'a'.repeat(1024 * 1024 + 1);
+    const res = await request(app).post('/api/login').send({ name: bigName });
+    expect(res.statusCode).toBe(413);
+  });
+
   test('rejects session update with invalid name', async () => {
     const token = await login('frank');
     const create = await request(app)


### PR DESCRIPTION
## Summary
- Limit JSON body parser to 1mb to prevent excessively large requests
- Add regression test ensuring payloads over the limit return 413

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b00f8882e083208da859d4c4dd3e2a