### PR TITLE
Refactor: modularize grids and vitals handling

### DIFF
--- a/public/js/__tests__/fastGrid.test.js
+++ b/public/js/__tests__/fastGrid.test.js
@@ -1,0 +1,21 @@
+import { FAST_AREAS } from '../config.js';
+
+describe('fastGrid', () => {
+  let init;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="fastGrid"></div>';
+    ({ init } = require('../fastGrid.js'));
+  });
+
+  test('renders a box for each FAST area', () => {
+    init();
+    expect(document.querySelectorAll('#fastGrid > div')).toHaveLength(FAST_AREAS.length);
+  });
+
+  test('handles missing container gracefully', () => {
+    document.body.innerHTML = '';
+    expect(() => init()).not.toThrow();
+  });
+});
+

--- a/public/js/__tests__/mechanismList.test.js
+++ b/public/js/__tests__/mechanismList.test.js
@@ -1,0 +1,32 @@
+describe('mechanismList', () => {
+  let init;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = '<datalist id="gmp_mechanism_list"><option value="Existing"></option></datalist><input id="gmp_mechanism">';
+    ({ init } = require('../mechanismList.js'));
+  });
+
+  test('loads stored mechanisms', () => {
+    localStorage.setItem('traumos_mechanizmai', JSON.stringify(['Stored']));
+    init();
+    const options = Array.from(document.querySelectorAll('#gmp_mechanism_list option')).map(o => o.value);
+    expect(options).toContain('Stored');
+  });
+
+  test('adds new mechanism to list and storage', () => {
+    init();
+    const input = document.getElementById('gmp_mechanism');
+    input.value = 'NewMech';
+    input.dispatchEvent(new Event('change'));
+    const options = Array.from(document.querySelectorAll('#gmp_mechanism_list option')).map(o => o.value);
+    expect(options).toContain('NewMech');
+    expect(JSON.parse(localStorage.getItem('traumos_mechanizmai'))).toContain('NewMech');
+  });
+
+  test('gracefully handles missing elements', () => {
+    document.body.innerHTML = '';
+    expect(() => init()).not.toThrow();
+  });
+});
+

--- a/public/js/__tests__/teamGrid.test.js
+++ b/public/js/__tests__/teamGrid.test.js
@@ -1,0 +1,21 @@
+import { TEAM_ROLES } from '../constants.js';
+
+describe('teamGrid', () => {
+  let init;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="teamGrid"></div>';
+    ({ init } = require('../teamGrid.js'));
+  });
+
+  test('renders inputs for all team roles', () => {
+    init();
+    expect(document.querySelectorAll('#teamGrid > div')).toHaveLength(TEAM_ROLES.length);
+  });
+
+  test('handles missing container gracefully', () => {
+    document.body.innerHTML = '';
+    expect(() => init()).not.toThrow();
+  });
+});
+

--- a/public/js/__tests__/vitalsEvents.test.js
+++ b/public/js/__tests__/vitalsEvents.test.js
@@ -1,0 +1,31 @@
+jest.mock('../timeline.js', () => ({ logEvent: jest.fn() }));
+jest.mock('../chips.js', () => ({ isChipActive: jest.fn() }));
+
+describe('vitalsEvents', () => {
+  let init;
+  const { logEvent } = require('../timeline.js');
+  const { isChipActive } = require('../chips.js');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '<input id="gmp_hr"><div id="c_pulse_radial_group"><span class="chip" data-value="Present"></span></div>';
+    ({ init } = require('../vitalsEvents.js'));
+  });
+
+  test('logs vital input changes', () => {
+    init();
+    const input = document.getElementById('gmp_hr');
+    input.value = '80';
+    input.dispatchEvent(new Event('change'));
+    expect(logEvent).toHaveBeenCalledWith('vital', 'GMP ŠSD', '80');
+  });
+
+  test('logs chip vital when active', () => {
+    isChipActive.mockReturnValue(true);
+    init();
+    const chip = document.querySelector('#c_pulse_radial_group .chip');
+    chip.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(logEvent).toHaveBeenCalledWith('vital', 'Radialinis pulsas', 'Present');
+  });
+});
+

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3,7 +3,7 @@ import { initTabs } from './tabs.js';
 import { initChips, setChipActive, isChipActive, addChipIndicators } from './chips.js';
 import { initAutoActivate } from './autoActivate.js';
 import { initActions } from './actions.js';
-import { logEvent, initTimeline } from './timeline.js';
+import { initTimeline } from './timeline.js';
 import './components/toast.js';
 import './components/modal.js';
 import { initValidation, validateVitals } from './validation.js';
@@ -13,15 +13,17 @@ import { connectSocket, initSessions, fetchUsers, initTheme, saveAll, loadAll } 
 import bodyMap from './bodyMap.js';
 import { generateReport } from './report.js';
 import { setupHeaderActions } from './headerActions.js';
-import { TEAM_ROLES } from './constants.js';
 import { initCirculation } from './circulation.js';
 import { setupActivationControls, ensureSingleTeam, updateActivationIndicator } from './activation.js';
 import { initGcs } from './gcs.js';
-import { IMG_CT, IMG_XRAY, LABS, BLOOD_GROUPS, FAST_AREAS } from './config.js';
+import { IMG_CT, IMG_XRAY, LABS, BLOOD_GROUPS } from './config.js';
+import { init as initFastGrid } from './fastGrid.js';
+import { init as initTeamGrid } from './teamGrid.js';
+import { init as initMechanismList } from './mechanismList.js';
+import { init as initVitalsEvents } from './vitalsEvents.js';
 export { validateVitals, createChipGroup };
 
 /* ===== Imaging / Labs / Team ===== */
-const LS_MECHANISM_KEY='traumos_mechanizmai';
 function createChipGroup(selector, values){
   const wrap=$(selector);
   if(!wrap) return null;
@@ -64,53 +66,6 @@ if(bloodUnitsInput && bloodGroupWrap && addBloodOrderBtn){
   };
   addBloodOrderBtn.addEventListener('click',addOrder);
   bloodUnitsInput.addEventListener('keydown',e=>{ if(e.key==='Enter') addOrder(e); });
-}
-function initFastGrid(){
-  const fastWrap=$('#fastGrid');
-  if(!fastWrap) return;
-  FAST_AREAS.forEach(({name,marker})=>{
-    const box=document.createElement('div');
-    box.innerHTML=`<label>${name} (${marker})</label><div class="row"><label class="pill red"><input type="radio" name="fast_${name}" value="Yra"> Yra</label><label class="pill"><input type="radio" name="fast_${name}" value="Nėra"> Nėra</label></div>`;
-    fastWrap.appendChild(box);
-  });
-}
-function initTeamGrid(){
-  const teamWrap=$('#teamGrid');
-  if(!teamWrap) return;
-  TEAM_ROLES.forEach(r=>{
-    const slug=r.replace(/\s+/g,'_');
-    const box=document.createElement('div');
-    box.innerHTML=`<label>${r}</label><input type="text" data-team="${r}" data-field="team_${slug}" placeholder="Vardas Pavardė">`;
-    teamWrap.appendChild(box);
-  });
-}
-initFastGrid();
-initTeamGrid();
-
-function initMechanismList(){
-  const list=$('#gmp_mechanism_list');
-  const input=$('#gmp_mechanism');
-  if(!list||!input) return;
-  const existing=new Set(Array.from(list.options).map(o=>o.value));
-  const stored=JSON.parse(localStorage.getItem(LS_MECHANISM_KEY)||'[]');
-  stored.forEach(v=>{
-    if(!existing.has(v)){
-      const opt=document.createElement('option');
-      opt.value=v;
-      list.appendChild(opt);
-      existing.add(v);
-    }
-  });
-  input.addEventListener('change',()=>{
-    const val=input.value.trim();
-    if(!val||existing.has(val)) return;
-    const opt=document.createElement('option');
-    opt.value=val;
-    list.appendChild(opt);
-    existing.add(val);
-    stored.push(val);
-    localStorage.setItem(LS_MECHANISM_KEY, JSON.stringify(stored));
-  });
 }
 
 /* ===== Save / Load ===== */
@@ -175,41 +130,11 @@ async function init(){
   initActions(saveAllDebounced);
   initTimeline();
   setupActivationControls();
+  initFastGrid();
+  initTeamGrid();
   initMechanismList();
+  initVitalsEvents();
   document.addEventListener('input', saveAllDebounced);
-
-  const vitals = {
-    '#gmp_hr': 'GMP ŠSD',
-    '#gmp_rr': 'GMP KD',
-    '#gmp_spo2': 'GMP SpO₂',
-    '#gmp_sbp': 'GMP AKS s',
-    '#gmp_dbp': 'GMP AKS d',
-    '#b_rr': 'KD',
-    '#b_spo2': 'SpO₂',
-    '#c_hr': 'ŠSD',
-    '#c_sbp': 'AKS s',
-    '#c_dbp': 'AKS d',
-    '#c_caprefill': 'KPL'
-  };
-  Object.entries(vitals).forEach(([sel,label])=>{
-    const el=$(sel);
-    if(el) el.addEventListener('change',()=>{ if(el.value) logEvent('vital', label, el.value); });
-  });
-
-  const chipVitals = {
-    '#c_pulse_radial_group': 'Radialinis pulsas',
-    '#c_pulse_femoral_group': 'Femoralis pulsas',
-    '#c_skin_temp_group': 'Odos temp.',
-    '#c_skin_color_group': 'Odos spalva'
-  };
-  Object.entries(chipVitals).forEach(([sel,label])=>{
-    const group=$(sel);
-    if(group) group.addEventListener('click',e=>{
-      const chip=e.target.closest('.chip');
-      if(chip && isChipActive(chip)) logEvent('vital', label, chip.dataset.value);
-    });
-  });
-
   initCirculation();
   const btnOxygen=$('#btnOxygen');
   if(btnOxygen) btnOxygen.addEventListener('click',()=>{

--- a/public/js/fastGrid.js
+++ b/public/js/fastGrid.js
@@ -1,0 +1,13 @@
+import { $ } from './utils.js';
+import { FAST_AREAS } from './config.js';
+
+export function init() {
+  const fastWrap = $('#fastGrid');
+  if (!fastWrap) return;
+  FAST_AREAS.forEach(({ name, marker }) => {
+    const box = document.createElement('div');
+    box.innerHTML = `<label>${name} (${marker})</label><div class="row"><label class="pill red"><input type="radio" name="fast_${name}" value="Yra"> Yra</label><label class="pill"><input type="radio" name="fast_${name}" value="Nėra"> Nėra</label></div>`;
+    fastWrap.appendChild(box);
+  });
+}
+

--- a/public/js/mechanismList.js
+++ b/public/js/mechanismList.js
@@ -1,0 +1,30 @@
+import { $ } from './utils.js';
+
+const LS_MECHANISM_KEY = 'traumos_mechanizmai';
+
+export function init() {
+  const list = $('#gmp_mechanism_list');
+  const input = $('#gmp_mechanism');
+  if (!list || !input) return;
+  const existing = new Set(Array.from(list.options).map(o => o.value));
+  const stored = JSON.parse(localStorage.getItem(LS_MECHANISM_KEY) || '[]');
+  stored.forEach(v => {
+    if (!existing.has(v)) {
+      const opt = document.createElement('option');
+      opt.value = v;
+      list.appendChild(opt);
+      existing.add(v);
+    }
+  });
+  input.addEventListener('change', () => {
+    const val = input.value.trim();
+    if (!val || existing.has(val)) return;
+    const opt = document.createElement('option');
+    opt.value = val;
+    list.appendChild(opt);
+    existing.add(val);
+    stored.push(val);
+    localStorage.setItem(LS_MECHANISM_KEY, JSON.stringify(stored));
+  });
+}
+

--- a/public/js/teamGrid.js
+++ b/public/js/teamGrid.js
@@ -1,0 +1,14 @@
+import { $ } from './utils.js';
+import { TEAM_ROLES } from './constants.js';
+
+export function init() {
+  const teamWrap = $('#teamGrid');
+  if (!teamWrap) return;
+  TEAM_ROLES.forEach(r => {
+    const slug = r.replace(/\s+/g, '_');
+    const box = document.createElement('div');
+    box.innerHTML = `<label>${r}</label><input type="text" data-team="${r}" data-field="team_${slug}" placeholder="Vardas Pavardė">`;
+    teamWrap.appendChild(box);
+  });
+}
+

--- a/public/js/vitalsEvents.js
+++ b/public/js/vitalsEvents.js
@@ -1,0 +1,38 @@
+import { $ } from './utils.js';
+import { logEvent } from './timeline.js';
+import { isChipActive } from './chips.js';
+
+export function init() {
+  const vitals = {
+    '#gmp_hr': 'GMP ŠSD',
+    '#gmp_rr': 'GMP KD',
+    '#gmp_spo2': 'GMP SpO₂',
+    '#gmp_sbp': 'GMP AKS s',
+    '#gmp_dbp': 'GMP AKS d',
+    '#b_rr': 'KD',
+    '#b_spo2': 'SpO₂',
+    '#c_hr': 'ŠSD',
+    '#c_sbp': 'AKS s',
+    '#c_dbp': 'AKS d',
+    '#c_caprefill': 'KPL'
+  };
+  Object.entries(vitals).forEach(([sel, label]) => {
+    const el = $(sel);
+    if (el) el.addEventListener('change', () => { if (el.value) logEvent('vital', label, el.value); });
+  });
+
+  const chipVitals = {
+    '#c_pulse_radial_group': 'Radialinis pulsas',
+    '#c_pulse_femoral_group': 'Femoralis pulsas',
+    '#c_skin_temp_group': 'Odos temp.',
+    '#c_skin_color_group': 'Odos spalva'
+  };
+  Object.entries(chipVitals).forEach(([sel, label]) => {
+    const group = $(sel);
+    if (group) group.addEventListener('click', e => {
+      const chip = e.target.closest('.chip');
+      if (chip && isChipActive(chip)) logEvent('vital', label, chip.dataset.value);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- Extract FAST and team grid builders into dedicated modules
- Separate mechanism list logic into its own module
- Move vitals event bindings into a new module
- Import and invoke new modules from `app.js`
- Add unit tests for all new modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b03e96b5208320aa07bfa93ed0bc53