### PR TITLE
Build chip groups dynamically from data definitions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -94,29 +94,11 @@
           <div class="split mt-12">
             <div>
               <label><strong>RAUDONA</strong></label>
-              <div class="chip-group" id="chips_red" aria-label="RAUDONA">
-                <button type="button" class="chip red" data-value="GKS &lt; 9" aria-pressed="false">GKS &lt; 9</button>
-                <button type="button" class="chip red" data-value="KD &lt; 8 ar &gt; 30/min" aria-pressed="false">KD &lt; 8 ar &gt; 30/min</button>
-                <button type="button" class="chip red" data-value="AKS &lt; 90 mmHg" aria-pressed="false">AKS &lt; 90 mmHg</button>
-                <button type="button" class="chip red" data-value="SpO₂ &lt; 90%" aria-pressed="false">SpO₂ &lt; 90%</button>
-                <button type="button" class="chip red" data-value="ŠSD &gt; 120/min" aria-pressed="false">ŠSD &gt; 120/min</button>
-                <button type="button" class="chip red" data-value="Stridoras" aria-pressed="false">Stridoras</button>
-                <button type="button" class="chip red" data-value="Lūžę 2 ilgieji kaulai/dubuo" aria-pressed="false">Lūžę 2 ilgieji kaulai/dubuo</button>
-                <button type="button" class="chip red" data-value="Kiauriniai suž. kakle/krūtinėje/juosmenyje" aria-pressed="false">Kiauriniai suž. kakle/krūtinėje/juosmenyje</button>
-                <button type="button" class="chip red" data-value="Įtariamas vidinis kraujavimas" aria-pressed="false">Įtariamas vidinis kraujavimas</button>
-                <button type="button" class="chip red" data-value="Nestabili krūtinės ląsta" aria-pressed="false">Nestabili krūtinės ląsta</button>
-                <button type="button" class="chip red" data-value="Nudegimas &gt;18% ar KT nudegimas" aria-pressed="false">Nudegimas &gt;18% ar KT nudegimas</button>
-                <button type="button" class="chip red" data-value="Amputacijos aukščiau plašt./pėdų" aria-pressed="false">Amputacijos aukščiau plašt./pėdų</button>
-              </div>
+              <div class="chip-group" id="chips_red" aria-label="RAUDONA"></div>
             </div>
             <div>
               <label><strong>GELTONA</strong></label>
-              <div class="chip-group" id="chips_yellow" aria-label="GELTONA">
-                <button type="button" class="chip yellow" data-value="Pėst./dvir./motociklo trauma" aria-pressed="false">Pėst./dvir./motociklo trauma</button>
-                <button type="button" class="chip yellow" data-value="Sprogimas/susišaudymas" aria-pressed="false">Sprogimas/susišaudymas</button>
-                <button type="button" class="chip yellow" data-value="Kritimas &gt;3 m ar nardymas" aria-pressed="false">Kritimas &gt;3 m ar nardymas</button>
-                <button type="button" class="chip yellow" data-value="Reikėjo gelbėtojų pagalbos" aria-pressed="false">Reikėjo gelbėtojų pagalbos</button>
-              </div>
+              <div class="chip-group" id="chips_yellow" aria-label="GELTONA"></div>
             </div>
           </div>
           <div class="hint mt-6">Auto-aktyvacija – tik iš GMP rodiklių; rankiniai pakeitimai išlieka.</div>
@@ -127,13 +109,7 @@
     <section class="card view" id="view-a" data-tab="A – Kvėpavimo takai">
       <h2>A – Kvėpavimo takai</h2>
       <label>Takai</label>
-      <div class="chip-group" id="a_airway_group" data-single="true" aria-label="Takai">
-        <button type="button" class="chip" data-value="Atviri" aria-pressed="false">Atviri</button>
-        <button type="button" class="chip red" data-value="Obstrukcija" aria-pressed="false">Obstrukcija</button>
-        <button type="button" class="chip red" data-value="Įvesta laringinė kaukė" aria-pressed="false">Įvesta laringinė kaukė</button>
-        <button type="button" class="chip red" data-value="Intubuotas" aria-pressed="false">Intubuotas</button>
-        <button type="button" class="chip red" data-value="Kita" aria-pressed="false">Kita</button>
-      </div>
+      <div class="chip-group" id="a_airway_group" data-single="true" aria-label="Takai"></div>
       <div class="row mt-8"><label class="m-0" for="a_notes">Pastabos</label><input id="a_notes" type="text" placeholder="Trumpai..."></div>
     </section>
 
@@ -152,23 +128,11 @@
           <div class="row">
             <div>
               <div class="subtle">Kairė</div>
-              <div class="chip-group" id="b_breath_left_group" data-single="true" aria-label="Alsavimas – Kairė">
-                <button type="button" class="chip breath-chip" data-value="Normalus" aria-label="Normalus" title="Normalus">Normalus</button>
-                <button type="button" class="chip breath-chip red breath-toggle" data-value="_kita" aria-label="Kita" title="Kita">Kita</button>
-                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Neišklausomas">Neišklausomas</button>
-                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Susilpnėjęs">Susilpnėjęs</button>
-                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Kita">Kita</button>
-              </div>
+              <div class="chip-group" id="b_breath_left_group" data-single="true" aria-label="Alsavimas – Kairė"></div>
             </div>
             <div>
               <div class="subtle">Dešinė</div>
-              <div class="chip-group" id="b_breath_right_group" data-single="true" aria-label="Alsavimas – Dešinė">
-                <button type="button" class="chip breath-chip" data-value="Normalus" aria-label="Normalus" title="Normalus">Normalus</button>
-                <button type="button" class="chip breath-chip red breath-toggle" data-value="_kita" aria-label="Kita" title="Kita">Kita</button>
-                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Neišklausomas">Neišklausomas</button>
-                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Susilpnėjęs">Susilpnėjęs</button>
-                <button type="button" class="chip breath-chip red breath-option hidden" data-value="Kita">Kita</button>
-              </div>
+              <div class="chip-group" id="b_breath_right_group" data-single="true" aria-label="Alsavimas – Dešinė"></div>
             </div>
           </div>
         </fieldset>
@@ -205,33 +169,20 @@
         <div><label for="c_caprefill">KPL (sek.)</label><input id="c_caprefill" type="number" step="0.1" min="0" max="20" title="KPL – seconds, 0–20"></div>
         <div>
           <label>Radialinis pulsas</label>
-          <div class="chip-group" id="c_pulse_radial_group" data-single="true">
-            <button type="button" class="chip" data-value="Stiprus" aria-pressed="false">Stiprus</button>
-            <button type="button" class="chip red" data-value="Silpnas" aria-pressed="false">Silpnas</button>
-          </div>
+          <div class="chip-group" id="c_pulse_radial_group" data-single="true"></div>
         </div>
         <div>
           <label>Femoralis pulsas</label>
-          <div class="chip-group" id="c_pulse_femoral_group" data-single="true">
-            <button type="button" class="chip" data-value="Stiprus" aria-pressed="false">Stiprus</button>
-            <button type="button" class="chip red" data-value="Silpnas" aria-pressed="false">Silpnas</button>
-          </div>
+          <div class="chip-group" id="c_pulse_femoral_group" data-single="true"></div>
         </div>
         <div>
           <label>Odos temp.</label>
-          <div class="chip-group" id="c_skin_temp_group" data-single="true">
-            <button type="button" class="chip" data-value="Šilta" aria-pressed="false">Šilta</button>
-            <button type="button" class="chip red" data-value="Šalta" aria-pressed="false">Šalta</button>
-          </div>
+          <div class="chip-group" id="c_skin_temp_group" data-single="true"></div>
         </div>
         <div>
           <label>Odos spalva</label>
           <div class="row">
-            <div class="chip-group" id="c_skin_color_group" data-single="true">
-              <button type="button" class="chip" data-value="Rausva" aria-pressed="false">Rausva</button>
-              <button type="button" class="chip red" data-value="Blyški" aria-pressed="false">Blyški</button>
-              <button type="button" class="chip red" data-value="Kita" aria-pressed="false">Kita</button>
-            </div>
+            <div class="chip-group" id="c_skin_color_group" data-single="true"></div>
             <input id="c_skin_color_other" type="text" placeholder="Kita..." class="hidden">
           </div>
         </div>
@@ -300,7 +251,7 @@
       <div class="mt-8">
         <label>Vyzdžiai – Kairė</label>
         <div id="d_pupil_left_wrapper" aria-expanded="false">
-          <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
+          <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"></div>
           <label for="d_pupil_left_note" class="mt-6 hidden" hidden>Pastabos</label>
           <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
         </div>
@@ -308,7 +259,7 @@
       <div class="mt-8">
         <label>Vyzdžiai – Dešinė</label>
         <div id="d_pupil_right_wrapper" aria-expanded="false">
-          <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"><button type="button" class="chip" data-value="n.y." aria-pressed="false">n.y.</button><button type="button" class="chip red" data-value="kita" aria-pressed="false">kita</button></div>
+          <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"></div>
           <label for="d_pupil_right_note" class="mt-6 hidden" hidden>Pastabos</label>
           <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
         </div>
@@ -321,8 +272,8 @@
       <h2>E – Kita</h2>
       <div class="grid cols-3 cols-auto">
         <div><label for="e_temp">Temperatūra (°C)</label><input id="e_temp" type="number" step="0.1" min="30" max="43"></div>
-        <div><label for="e_back_notes">Nugaros apžiūra</label><div class="row"><div class="chip-group" id="e_back_group" data-single="true"><button type="button" class="chip" data-value="Be pakitimų" aria-pressed="false">Be pakitimų</button><button type="button" class="chip red" data-value="Pakitimai" aria-pressed="false">Pakitimai</button></div><input id="e_back_notes" type="text" placeholder="Pakitimai..." class="hidden"></div></div>
-        <div><label for="e_abdomen_notes">Pilvo apžiūra</label><div class="row"><div class="chip-group" id="e_abdomen_group" data-single="true"><button type="button" class="chip" data-value="Be pakitimų" aria-pressed="false">Be pakitimų</button><button type="button" class="chip red" data-value="Pakitimai" aria-pressed="false">Pakitimai</button></div><input id="e_abdomen_notes" type="text" placeholder="Pakitimai..." class="hidden"></div></div>
+        <div><label for="e_back_notes">Nugaros apžiūra</label><div class="row"><div class="chip-group" id="e_back_group" data-single="true"></div><input id="e_back_notes" type="text" placeholder="Pakitimai..." class="hidden"></div></div>
+        <div><label for="e_abdomen_notes">Pilvo apžiūra</label><div class="row"><div class="chip-group" id="e_abdomen_group" data-single="true"></div><input id="e_abdomen_notes" type="text" placeholder="Pakitimai..." class="hidden"></div></div>
         <div><label for="e_other">Kitos pastabos</label><input id="e_other" type="text" placeholder="..."></div>
       </div>
 
@@ -429,13 +380,7 @@
       <div><label for="spr_time">Laikas</label><div class="row"><input id="spr_time" type="time"><button type="button" class="btn ghost" id="btnSprNow">Dabar</button></div></div>
       <div class="mt-8">
         <label>Sprendimas</label>
-        <div class="chip-group" id="spr_decision_group" data-single="true" aria-label="Sprendimas">
-          <button type="button" class="chip" data-value="Stacionarizavimas" aria-pressed="false">Stacionarizavimas</button>
-          <button type="button" class="chip" data-value="Namo" aria-pressed="false">Namo</button>
-          <button type="button" class="chip" data-value="Stebėjimas SMPS" aria-pressed="false">Stebėjimas SMPS</button>
-          <button type="button" class="chip" data-value="Mirtis" aria-pressed="false">Mirtis</button>
-          <button type="button" class="chip" data-value="Pervežimas į kitą ligoninę" aria-pressed="false">Pervežimas į kitą ligoninę</button>
-        </div>
+        <div class="chip-group" id="spr_decision_group" data-single="true" aria-label="Sprendimas"></div>
       </div>
       <div id="spr_skyrius_container" class="hidden mt-8">
         <label for="spr_skyrius">Skyrius</label>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -23,6 +23,7 @@ import { init as initFastGrid } from './fastGrid.js';
 import { init as initTeamGrid } from './teamGrid.js';
 import { init as initMechanismList } from './mechanismList.js';
 import { init as initVitalsEvents } from './vitalsEvents.js';
+import { initChipGroups } from './chipData.js';
 export { validateVitals, createChipGroup };
 
 /* ===== Imaging / Labs / Team ===== */
@@ -39,6 +40,8 @@ function createChipGroup(selector, values){
   });
   return wrap;
 }
+
+initChipGroups();
 
 createChipGroup('#imaging_ct', IMG_CT);
 createChipGroup('#imaging_xray', IMG_XRAY);

--- a/public/js/chipData.js
+++ b/public/js/chipData.js
@@ -1,0 +1,110 @@
+import { createChipGroup } from './app.js';
+
+export const CHIP_DATA = {
+  chips_red: [
+    { label: 'GKS < 9', color: 'red' },
+    { label: 'KD < 8 ar > 30/min', color: 'red' },
+    { label: 'AKS < 90 mmHg', color: 'red' },
+    { label: 'SpO₂ < 90%', color: 'red' },
+    { label: 'ŠSD > 120/min', color: 'red' },
+    { label: 'Stridoras', color: 'red' },
+    { label: 'Lūžę 2 ilgieji kaulai/dubuo', color: 'red' },
+    { label: 'Kiauriniai suž. kakle/krūtinėje/juosmenyje', color: 'red' },
+    { label: 'Įtariamas vidinis kraujavimas', color: 'red' },
+    { label: 'Nestabili krūtinės ląsta', color: 'red' },
+    { label: 'Nudegimas >18% ar KT nudegimas', color: 'red' },
+    { label: 'Amputacijos aukščiau plašt./pėdų', color: 'red' }
+  ],
+  chips_yellow: [
+    { label: 'Pėst./dvir./motociklo trauma', color: 'yellow' },
+    { label: 'Sprogimas/susišaudymas', color: 'yellow' },
+    { label: 'Kritimas >3 m ar nardymas', color: 'yellow' },
+    { label: 'Reikėjo gelbėtojų pagalbos', color: 'yellow' }
+  ],
+  a_airway_group: [
+    { label: 'Atviri' },
+    { label: 'Obstrukcija', color: 'red' },
+    { label: 'Įvesta laringinė kaukė', color: 'red' },
+    { label: 'Intubuotas', color: 'red' },
+    { label: 'Kita', color: 'red' }
+  ],
+  b_breath_left_group: [
+    { label: 'Normalus', class: 'breath-chip' },
+    { label: 'Kita', value: '_kita', color: 'red', class: 'breath-chip breath-toggle' },
+    { label: 'Neišklausomas', color: 'red', class: 'breath-chip breath-option hidden' },
+    { label: 'Susilpnėjęs', color: 'red', class: 'breath-chip breath-option hidden' },
+    { label: 'Kita', color: 'red', class: 'breath-chip breath-option hidden' }
+  ],
+  b_breath_right_group: [
+    { label: 'Normalus', class: 'breath-chip' },
+    { label: 'Kita', value: '_kita', color: 'red', class: 'breath-chip breath-toggle' },
+    { label: 'Neišklausomas', color: 'red', class: 'breath-chip breath-option hidden' },
+    { label: 'Susilpnėjęs', color: 'red', class: 'breath-chip breath-option hidden' },
+    { label: 'Kita', color: 'red', class: 'breath-chip breath-option hidden' }
+  ],
+  c_pulse_radial_group: [
+    { label: 'Stiprus' },
+    { label: 'Silpnas', color: 'red' }
+  ],
+  c_pulse_femoral_group: [
+    { label: 'Stiprus' },
+    { label: 'Silpnas', color: 'red' }
+  ],
+  c_skin_temp_group: [
+    { label: 'Šilta' },
+    { label: 'Šalta', color: 'red' }
+  ],
+  c_skin_color_group: [
+    { label: 'Rausva' },
+    { label: 'Blyški', color: 'red' },
+    { label: 'Kita', color: 'red' }
+  ],
+  d_pupil_left_group: [
+    { label: 'n.y.', value: 'n.y.' },
+    { label: 'kita', value: 'kita', color: 'red' }
+  ],
+  d_pupil_right_group: [
+    { label: 'n.y.', value: 'n.y.' },
+    { label: 'kita', value: 'kita', color: 'red' }
+  ],
+  e_back_group: [
+    { label: 'Be pakitimų' },
+    { label: 'Pakitimai', color: 'red' }
+  ],
+  e_abdomen_group: [
+    { label: 'Be pakitimų' },
+    { label: 'Pakitimai', color: 'red' }
+  ],
+  spr_decision_group: [
+    { label: 'Stacionarizavimas' },
+    { label: 'Namo' },
+    { label: 'Stebėjimas SMPS' },
+    { label: 'Mirtis' },
+    { label: 'Pervežimas į kitą ligoninę' }
+  ]
+};
+
+export function buildChipGroup(containerId, chips){
+  const container = createChipGroup(`#${containerId}`, chips.map(c => c.label));
+  if(!container) return;
+  const chipEls = container.querySelectorAll('.chip');
+  chips.forEach((chip, idx) => {
+    const el = chipEls[idx];
+    if(!el) return;
+    if(chip.value && chip.value !== chip.label){
+      el.dataset.value = chip.value;
+    }
+    if(chip.color){
+      el.classList.add(chip.color);
+    }
+    if(chip.class){
+      el.classList.add(...chip.class.split(' '));
+    }
+  });
+  return container;
+}
+
+export function initChipGroups(){
+  Object.entries(CHIP_DATA).forEach(([id, chips]) => buildChipGroup(id, chips));
+}
+


### PR DESCRIPTION
## Summary
- Move chip definitions into `chipData.js` with labels, colors and values
- Add `buildChipGroup` helper and initialize chip groups in `app.js`
- Replace hardcoded chip markup in `index.html` with empty containers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0474ef66c832098076c96d0c37f25