### PR TITLE
Handle topbar load errors with fallback and retry

### DIFF
--- a/public/js/__tests__/topbarFallback.test.js
+++ b/public/js/__tests__/topbarFallback.test.js
@@ -1,0 +1,18 @@
+jest.mock('../alerts.js', () => ({ notify: jest.fn() }));
+const { initTopbar } = require('../components/topbar.js');
+
+describe('initTopbar fallback', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<header id="appHeader"></header>';
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  test('renders fallback header on fetch failure', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('fail'));
+    await initTopbar();
+    expect(document.getElementById('retryTopbar')).not.toBeNull();
+  });
+});

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -1,4 +1,5 @@
 import { ACTIONS_LABEL, MORE_LABEL } from '../constants.js';
+import { notify } from '../alerts.js';
 
 const NAV_BREAKPOINT = 768;
 let navMq;
@@ -67,11 +68,13 @@ export async function initTopbar(){
   if(!header || typeof fetch!=='function') return;
   try{
     const res=await fetch('assets/partials/topbar.html');
-    if(res.ok){
-      header.innerHTML=await res.text();
-    }
+    if(!res.ok) throw new Error(`HTTP ${res.status}`);
+    header.innerHTML=await res.text();
   }catch(e){
     console.error('Failed to load topbar', e);
+    notify({type:'error', message:'Failed to load topbar'});
+    header.innerHTML='<div class="wrap"><button type="button" class="btn" id="retryTopbar">Retry</button></div>';
+    header.querySelector('#retryTopbar')?.addEventListener('click', initTopbar);
   }
   applyTopbarLocalization(header);
   if(typeof ResizeObserver==='function'){


### PR DESCRIPTION
## Summary
- Show a simplified top bar with a retry button when fetching the real header fails
- Log failures and alert the user
- Add unit test to ensure fallback renders on fetch errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b05a755aa48320b34f9019f556bd1e