### PR TITLE
Centralize patient field validation and expand tests

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -3,10 +3,10 @@ import { initTabs } from './tabs.js';
 import { initChips, setChipActive, isChipActive, addChipIndicators } from './chips.js';
 import { initAutoActivate } from './autoActivate.js';
 import { initActions } from './actions.js';
-import { logEvent, initTimeline } from './timeline.js';
+import { initTimeline } from './timeline.js';
 import './components/toast.js';
 import './components/modal.js';
-import { initValidation, validateVitals } from './validation.js';
+import { initValidation, validateVitals, validatePatient } from './validation.js';
 import { initTopbar } from './components/topbar.js';
 import { initCollapsibles } from './sections.js';
 import { initTheme, saveAll, loadAll, getCurrentSessionId } from './sessionManager.js';
@@ -15,21 +15,39 @@ import { initSessions, populateSessionSelect, updateUserList } from './sessionUI
 import bodyMap from './bodyMap.js';
 import { generateReport } from './report.js';
 import { setupHeaderActions } from './headerActions.js';
-import { TEAM_ROLES } from './constants.js';
 import { initCirculation } from './circulation.js';
 import { setupActivationControls, ensureSingleTeam, updateActivationIndicator } from './activation.js';
 import { initGcs } from './gcs.js';
-import { IMG_CT, IMG_XRAY, LABS, BLOOD_GROUPS, FAST_AREAS } from './config.js';
-export { validateVitals };
+import { IMG_CT, IMG_XRAY, LABS, BLOOD_GROUPS } from './config.js';
+import { init as initFastGrid } from './fastGrid.js';
+import { init as initTeamGrid } from './teamGrid.js';
+import { init as initMechanismList } from './mechanismList.js';
+import { init as initVitalsEvents } from './vitalsEvents.js';
+import { initChipGroups } from './chipData.js';
+export { validateVitals, validatePatient, createChipGroup };
 
 /* ===== Imaging / Labs / Team ===== */
-const LS_MECHANISM_KEY='traumos_mechanizmai';
+function createChipGroup(selector, values){
+  const wrap=$(selector);
+  if(!wrap) return null;
+  values.forEach(val=>{
+    const chip=document.createElement('span');
+    chip.className='chip';
+    chip.dataset.value=val;
+    chip.textContent=val;
+    addChipIndicators(chip);
+    wrap.appendChild(chip);
+  });
+  return wrap;
+}
 
-const imgCtWrap=$('#imaging_ct'); IMG_CT.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); imgCtWrap.appendChild(s);});
-const imgXrayWrap=$('#imaging_xray'); IMG_XRAY.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); imgXrayWrap.appendChild(s);});
-const imgOtherWrap=$('#imaging_other_group'); ['Kita'].forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); imgOtherWrap.appendChild(s);});
-const labsWrap=$('#labs_basic'); LABS.forEach(n=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=n; s.textContent=n; addChipIndicators(s); labsWrap.appendChild(s);});
-const bloodGroupWrap=$('#bloodGroup'); if(bloodGroupWrap){ BLOOD_GROUPS.forEach(g=>{const s=document.createElement('span'); s.className='chip'; s.dataset.value=g; s.textContent=g; addChipIndicators(s); bloodGroupWrap.appendChild(s);}); }
+initChipGroups();
+
+createChipGroup('#imaging_ct', IMG_CT);
+createChipGroup('#imaging_xray', IMG_XRAY);
+createChipGroup('#imaging_other_group', ['Kita']);
+const labsWrap=createChipGroup('#labs_basic', LABS);
+const bloodGroupWrap=createChipGroup('#bloodGroup', BLOOD_GROUPS);
 const bloodUnitsInput=$('#bloodUnits');
 const addBloodOrderBtn=$('#addBloodOrder');
 if(bloodUnitsInput && bloodGroupWrap && addBloodOrderBtn){
@@ -53,44 +71,6 @@ if(bloodUnitsInput && bloodGroupWrap && addBloodOrderBtn){
   };
   addBloodOrderBtn.addEventListener('click',addOrder);
   bloodUnitsInput.addEventListener('keydown',e=>{ if(e.key==='Enter') addOrder(e); });
-}
-const fastWrap=$('#fastGrid');
-FAST_AREAS.forEach(({name,marker})=>{
-  const box=document.createElement('div');
-  box.innerHTML=`<label>${name} (${marker})</label><div class="row"><label class="pill red"><input type="radio" name="fast_${name}" value="Yra"> Yra</label><label class="pill"><input type="radio" name="fast_${name}" value="Nėra"> Nėra</label></div>`;
-  fastWrap.appendChild(box);
-});
-const teamWrap=$('#teamGrid'); TEAM_ROLES.forEach(r=>{
-  const slug=r.replace(/\s+/g,'_');
-  const box=document.createElement('div');
-  box.innerHTML=`<label>${r}</label><input type="text" data-team="${r}" data-field="team_${slug}" placeholder="Vardas Pavardė">`;
-  teamWrap.appendChild(box);
-});
-
-function initMechanismList(){
-  const list=$('#gmp_mechanism_list');
-  const input=$('#gmp_mechanism');
-  if(!list||!input) return;
-  const existing=new Set(Array.from(list.options).map(o=>o.value));
-  const stored=JSON.parse(localStorage.getItem(LS_MECHANISM_KEY)||'[]');
-  stored.forEach(v=>{
-    if(!existing.has(v)){
-      const opt=document.createElement('option');
-      opt.value=v;
-      list.appendChild(opt);
-      existing.add(v);
-    }
-  });
-  input.addEventListener('change',()=>{
-    const val=input.value.trim();
-    if(!val||existing.has(val)) return;
-    const opt=document.createElement('option');
-    opt.value=val;
-    list.appendChild(opt);
-    existing.add(val);
-    stored.push(val);
-    localStorage.setItem(LS_MECHANISM_KEY, JSON.stringify(stored));
-  });
 }
 
 /* ===== Save / Load ===== */
@@ -165,41 +145,11 @@ async function init(){
   initActions(saveAllDebounced);
   initTimeline();
   setupActivationControls();
+  initFastGrid();
+  initTeamGrid();
   initMechanismList();
+  initVitalsEvents();
   document.addEventListener('input', saveAllDebounced);
-
-  const vitals = {
-    '#gmp_hr': 'GMP ŠSD',
-    '#gmp_rr': 'GMP KD',
-    '#gmp_spo2': 'GMP SpO₂',
-    '#gmp_sbp': 'GMP AKS s',
-    '#gmp_dbp': 'GMP AKS d',
-    '#b_rr': 'KD',
-    '#b_spo2': 'SpO₂',
-    '#c_hr': 'ŠSD',
-    '#c_sbp': 'AKS s',
-    '#c_dbp': 'AKS d',
-    '#c_caprefill': 'KPL'
-  };
-  Object.entries(vitals).forEach(([sel,label])=>{
-    const el=$(sel);
-    if(el) el.addEventListener('change',()=>{ if(el.value) logEvent('vital', label, el.value); });
-  });
-
-  const chipVitals = {
-    '#c_pulse_radial_group': 'Radialinis pulsas',
-    '#c_pulse_femoral_group': 'Femoralis pulsas',
-    '#c_skin_temp_group': 'Odos temp.',
-    '#c_skin_color_group': 'Odos spalva'
-  };
-  Object.entries(chipVitals).forEach(([sel,label])=>{
-    const group=$(sel);
-    if(group) group.addEventListener('click',e=>{
-      const chip=e.target.closest('.chip');
-      if(chip && isChipActive(chip)) logEvent('vital', label, chip.dataset.value);
-    });
-  });
-
   initCirculation();
   const btnOxygen=$('#btnOxygen');
   if(btnOxygen) btnOxygen.addEventListener('click',()=>{
@@ -230,6 +180,7 @@ async function init(){
     expandOutput();
     clampNumberInputs();
     initValidation();
+    validatePatient();
     validateVitals();
   }
   if(document.readyState==='loading'){
@@ -239,38 +190,9 @@ async function init(){
   }
 
 function validateForm(){
-  const fields=[
-    {el:$('#patient_age'),check:e=>e.value!=='' && +e.value>=0 && +e.value<=120,msg:'Amžius 0-120'},
-    {el:$('#patient_sex'),check:e=>e.value!=='',msg:'Pasirinkite lytį'},
-    {el:$('#patient_history'),check:e=>e.value.trim()!=='',msg:'Ligos istorijos nr. privalomas'}
-  ];
-  let ok=true;
-  fields.forEach(({el,check,msg})=>{
-    if(!el) return;
-    if(!el.dataset.hint && el.getAttribute('aria-describedby')) el.dataset.hint=el.getAttribute('aria-describedby');
-    let err=document.getElementById(el.id+'_error');
-    const hintId=el.dataset.hint||'';
-    if(!check(el)){
-      ok=false;
-      if(!err){
-        err=document.createElement('div');
-        err.id=el.id+'_error';
-        err.className='error-msg';
-        err.textContent=msg;
-        el.parentElement.appendChild(err);
-      }
-      el.classList.add('invalid');
-      el.setAttribute('aria-invalid','true');
-      el.setAttribute('aria-describedby', (hintId+' '+err.id).trim());
-    }else{
-      if(err) err.remove();
-      el.classList.remove('invalid');
-      el.removeAttribute('aria-invalid');
-      if(hintId) el.setAttribute('aria-describedby', hintId); else el.removeAttribute('aria-describedby');
-    }
-  });
-  if(!validateVitals()) ok=false;
-  return ok;
+  const top = validatePatient();
+  const vitals = validateVitals();
+  return top && vitals;
 }
 
 

--- a/docs/js/validation.js
+++ b/docs/js/validation.js
@@ -1,53 +1,81 @@
 import { $ } from './utils.js';
 
 function showInlineError(el, msg) {
-  let err = el.nextElementSibling;
-  if (!err || !err.classList.contains('input-error')) {
-    err = document.createElement('span');
-    err.className = 'input-error';
-    err.style.color = 'var(--danger)';
-    err.style.fontSize = '12px';
-    err.style.marginLeft = '4px';
-    el.insertAdjacentElement('afterend', err);
+  if (!el.dataset.hint && el.getAttribute('aria-describedby')) {
+    el.dataset.hint = el.getAttribute('aria-describedby');
+  }
+  const hintId = el.dataset.hint || '';
+  let err = document.getElementById(el.id + '_error');
+  if (!err) {
+    err = document.createElement('div');
+    err.id = el.id + '_error';
+    err.className = 'error-msg';
+    el.parentElement.appendChild(err);
   }
   err.textContent = msg;
-  err.style.display = msg ? 'inline' : 'none';
   if (msg) {
     el.classList.add('invalid');
+    el.setAttribute('aria-invalid', 'true');
+    el.setAttribute('aria-describedby', (hintId + ' ' + err.id).trim());
   } else {
     el.classList.remove('invalid');
+    el.removeAttribute('aria-invalid');
+    if (hintId) el.setAttribute('aria-describedby', hintId); else el.removeAttribute('aria-describedby');
+    err.remove();
   }
 }
 
 export function validateField(el) {
   const val = el.value.trim();
   let msg = '';
-  if (el.hasAttribute('required') && val === '') {
-    msg = 'Privalomas laukas';
-  } else if (val !== '') {
-    const min = el.getAttribute('min');
-    const max = el.getAttribute('max');
-    if (min !== null || max !== null) {
+  switch (el.id) {
+    case 'patient_age': {
       const num = parseFloat(val);
-      if (Number.isNaN(num)) {
-        msg = 'Netinkama reikšmė';
-      } else if ((min !== null && num < parseFloat(min)) || (max !== null && num > parseFloat(max))) {
-        msg = `Leistina ${min}–${max}`;
-      }
+      if (val === '' || Number.isNaN(num) || num < 0 || num > 120) msg = 'Amžius 0-120';
+      break;
     }
+    case 'patient_sex':
+      if (val === '') msg = 'Pasirinkite lytį';
+      break;
+    case 'patient_history':
+      if (val === '') msg = 'Ligos istorijos nr. privalomas';
+      break;
+    default:
+      if (el.hasAttribute('required') && val === '') {
+        msg = 'Privalomas laukas';
+      } else if (val !== '') {
+        const min = el.getAttribute('min');
+        const max = el.getAttribute('max');
+        if (min !== null || max !== null) {
+          const num = parseFloat(val);
+          if (Number.isNaN(num)) {
+            msg = 'Netinkama reikšmė';
+          } else if ((min !== null && num < parseFloat(min)) || (max !== null && num > parseFloat(max))) {
+            msg = `Leistina ${min}–${max}`;
+          }
+        }
+      }
   }
   showInlineError(el, msg);
+  return !msg;
 }
 
-export function validateVitals() {
-  const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm','#patient_age','#patient_sex','#patient_history'];
+export function validatePatient() {
+  const fields = ['#patient_age', '#patient_sex', '#patient_history'];
   let ok = true;
   fields.forEach(sel => {
     const el = $(sel);
-    if (el) {
-      validateField(el);
-      if (el.classList.contains('invalid')) ok = false;
-    }
+    if (el && !validateField(el)) ok = false;
+  });
+  return ok;
+}
+
+export function validateVitals() {
+  const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm'];
+  let ok = true;
+  fields.forEach(sel => {
+    const el = $(sel);
+    if (el && !validateField(el)) ok = false;
   });
   return ok;
 }
@@ -64,4 +92,5 @@ export function initValidation() {
 
 if (typeof window !== 'undefined') {
   window.validateVitals = validateVitals;
+  window.validatePatient = validatePatient;
 }

--- a/public/js/__tests__/patient.test.js
+++ b/public/js/__tests__/patient.test.js
@@ -272,8 +272,8 @@ describe('patient fields', () => {
     age.value = '130';
     age.dispatchEvent(new Event('input', { bubbles: true }));
     expect(age.classList.contains('invalid')).toBe(true);
-    const err = age.nextElementSibling;
+    const err = document.getElementById('patient_age_error');
     expect(err).not.toBeNull();
-    expect(err.textContent).toContain('Leistina');
+    expect(err.textContent).toBe('Amžius 0-120');
   });
 });

--- a/public/js/__tests__/validation.test.js
+++ b/public/js/__tests__/validation.test.js
@@ -1,11 +1,11 @@
-import { validateField, validateVitals } from '../validation.js';
+import { validateField, validateVitals, validatePatient } from '../validation.js';
 
 describe('validateField', () => {
   test('returns error for required empty field', () => {
     document.body.innerHTML = '<input id="test" required />';
     const input = document.getElementById('test');
     validateField(input);
-    const err = input.nextElementSibling;
+    const err = document.getElementById('test_error');
     expect(err).not.toBeNull();
     expect(err.textContent).toBe('Privalomas laukas');
     expect(input.classList.contains('invalid')).toBe(true);
@@ -15,7 +15,7 @@ describe('validateField', () => {
     document.body.innerHTML = '<input id="num" min="1" max="5" value="abc" />';
     const input = document.getElementById('num');
     validateField(input);
-    const err = input.nextElementSibling;
+    const err = document.getElementById('num_error');
     expect(err).not.toBeNull();
     expect(err.textContent).toBe('Netinkama reikšmė');
     expect(input.classList.contains('invalid')).toBe(true);
@@ -25,33 +25,41 @@ describe('validateField', () => {
     document.body.innerHTML = '<input id="num" min="1" max="5" value="10" />';
     const input = document.getElementById('num');
     validateField(input);
-    const err = input.nextElementSibling;
+    const err = document.getElementById('num_error');
     expect(err).not.toBeNull();
     expect(err.textContent).toBe('Leistina 1–5');
     expect(input.classList.contains('invalid')).toBe(true);
   });
 });
 
-describe('validateVitals', () => {
-  test('checks required text and select fields', () => {
+describe('validatePatient', () => {
+  test('checks top level fields with custom messages', () => {
     document.body.innerHTML = `
-      <input id="patient_age" type="number" value="25" required />
+      <input id="patient_age" type="number" required />
       <select id="patient_sex" required>
         <option value=""></option>
         <option value="M">M</option>
       </select>
       <input id="patient_history" required />
     `;
-    expect(validateVitals()).toBe(false);
-    const sexErr = document.querySelector('#patient_sex').nextElementSibling;
-    const histErr = document.querySelector('#patient_history').nextElementSibling;
-    expect(sexErr.textContent).toBe('Privalomas laukas');
-    expect(histErr.textContent).toBe('Privalomas laukas');
+    expect(validatePatient()).toBe(false);
+    expect(document.getElementById('patient_age_error').textContent).toBe('Amžius 0-120');
+    expect(document.getElementById('patient_sex_error').textContent).toBe('Pasirinkite lytį');
+    expect(document.getElementById('patient_history_error').textContent).toBe('Ligos istorijos nr. privalomas');
 
+    document.getElementById('patient_age').value = '25';
     document.getElementById('patient_sex').value = 'M';
     document.getElementById('patient_history').value = 'H123';
-    validateVitals();
-    expect(document.getElementById('patient_sex').classList.contains('invalid')).toBe(false);
-    expect(document.getElementById('patient_history').classList.contains('invalid')).toBe(false);
+    expect(validatePatient()).toBe(true);
+  });
+});
+
+describe('validateVitals', () => {
+  test('invalid numeric field', () => {
+    document.body.innerHTML = '<input id="gmp_hr" min="0" max="250" value="abc" />';
+    expect(validateVitals()).toBe(false);
+    expect(document.getElementById('gmp_hr_error').textContent).toBe('Netinkama reikšmė');
+    document.getElementById('gmp_hr').value = '100';
+    expect(validateVitals()).toBe(true);
   });
 });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -6,7 +6,7 @@ import { initActions } from './actions.js';
 import { initTimeline } from './timeline.js';
 import './components/toast.js';
 import './components/modal.js';
-import { initValidation, validateVitals } from './validation.js';
+import { initValidation, validateVitals, validatePatient } from './validation.js';
 import { initTopbar } from './components/topbar.js';
 import { initCollapsibles } from './sections.js';
 import { initTheme, saveAll, loadAll, getCurrentSessionId } from './sessionManager.js';
@@ -24,7 +24,7 @@ import { init as initTeamGrid } from './teamGrid.js';
 import { init as initMechanismList } from './mechanismList.js';
 import { init as initVitalsEvents } from './vitalsEvents.js';
 import { initChipGroups } from './chipData.js';
-export { validateVitals, createChipGroup };
+export { validateVitals, validatePatient, createChipGroup };
 
 /* ===== Imaging / Labs / Team ===== */
 function createChipGroup(selector, values){
@@ -180,6 +180,7 @@ async function init(){
     expandOutput();
     clampNumberInputs();
     initValidation();
+    validatePatient();
     validateVitals();
   }
   if(document.readyState==='loading'){
@@ -189,38 +190,9 @@ async function init(){
   }
 
 function validateForm(){
-  const fields=[
-    {el:$('#patient_age'),check:e=>e.value!=='' && +e.value>=0 && +e.value<=120,msg:'Amžius 0-120'},
-    {el:$('#patient_sex'),check:e=>e.value!=='',msg:'Pasirinkite lytį'},
-    {el:$('#patient_history'),check:e=>e.value.trim()!=='',msg:'Ligos istorijos nr. privalomas'}
-  ];
-  let ok=true;
-  fields.forEach(({el,check,msg})=>{
-    if(!el) return;
-    if(!el.dataset.hint && el.getAttribute('aria-describedby')) el.dataset.hint=el.getAttribute('aria-describedby');
-    let err=document.getElementById(el.id+'_error');
-    const hintId=el.dataset.hint||'';
-    if(!check(el)){
-      ok=false;
-      if(!err){
-        err=document.createElement('div');
-        err.id=el.id+'_error';
-        err.className='error-msg';
-        err.textContent=msg;
-        el.parentElement.appendChild(err);
-      }
-      el.classList.add('invalid');
-      el.setAttribute('aria-invalid','true');
-      el.setAttribute('aria-describedby', (hintId+' '+err.id).trim());
-    }else{
-      if(err) err.remove();
-      el.classList.remove('invalid');
-      el.removeAttribute('aria-invalid');
-      if(hintId) el.setAttribute('aria-describedby', hintId); else el.removeAttribute('aria-describedby');
-    }
-  });
-  if(!validateVitals()) ok=false;
-  return ok;
+  const top = validatePatient();
+  const vitals = validateVitals();
+  return top && vitals;
 }
 
 

--- a/public/js/validation.js
+++ b/public/js/validation.js
@@ -1,53 +1,81 @@
 import { $ } from './utils.js';
 
 function showInlineError(el, msg) {
-  let err = el.nextElementSibling;
-  if (!err || !err.classList.contains('input-error')) {
-    err = document.createElement('span');
-    err.className = 'input-error';
-    err.style.color = 'var(--danger)';
-    err.style.fontSize = '12px';
-    err.style.marginLeft = '4px';
-    el.insertAdjacentElement('afterend', err);
+  if (!el.dataset.hint && el.getAttribute('aria-describedby')) {
+    el.dataset.hint = el.getAttribute('aria-describedby');
+  }
+  const hintId = el.dataset.hint || '';
+  let err = document.getElementById(el.id + '_error');
+  if (!err) {
+    err = document.createElement('div');
+    err.id = el.id + '_error';
+    err.className = 'error-msg';
+    el.parentElement.appendChild(err);
   }
   err.textContent = msg;
-  err.style.display = msg ? 'inline' : 'none';
   if (msg) {
     el.classList.add('invalid');
+    el.setAttribute('aria-invalid', 'true');
+    el.setAttribute('aria-describedby', (hintId + ' ' + err.id).trim());
   } else {
     el.classList.remove('invalid');
+    el.removeAttribute('aria-invalid');
+    if (hintId) el.setAttribute('aria-describedby', hintId); else el.removeAttribute('aria-describedby');
+    err.remove();
   }
 }
 
 export function validateField(el) {
   const val = el.value.trim();
   let msg = '';
-  if (el.hasAttribute('required') && val === '') {
-    msg = 'Privalomas laukas';
-  } else if (val !== '') {
-    const min = el.getAttribute('min');
-    const max = el.getAttribute('max');
-    if (min !== null || max !== null) {
+  switch (el.id) {
+    case 'patient_age': {
       const num = parseFloat(val);
-      if (Number.isNaN(num)) {
-        msg = 'Netinkama reikšmė';
-      } else if ((min !== null && num < parseFloat(min)) || (max !== null && num > parseFloat(max))) {
-        msg = `Leistina ${min}–${max}`;
-      }
+      if (val === '' || Number.isNaN(num) || num < 0 || num > 120) msg = 'Amžius 0-120';
+      break;
     }
+    case 'patient_sex':
+      if (val === '') msg = 'Pasirinkite lytį';
+      break;
+    case 'patient_history':
+      if (val === '') msg = 'Ligos istorijos nr. privalomas';
+      break;
+    default:
+      if (el.hasAttribute('required') && val === '') {
+        msg = 'Privalomas laukas';
+      } else if (val !== '') {
+        const min = el.getAttribute('min');
+        const max = el.getAttribute('max');
+        if (min !== null || max !== null) {
+          const num = parseFloat(val);
+          if (Number.isNaN(num)) {
+            msg = 'Netinkama reikšmė';
+          } else if ((min !== null && num < parseFloat(min)) || (max !== null && num > parseFloat(max))) {
+            msg = `Leistina ${min}–${max}`;
+          }
+        }
+      }
   }
   showInlineError(el, msg);
+  return !msg;
 }
 
-export function validateVitals() {
-  const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm','#patient_age','#patient_sex','#patient_history'];
+export function validatePatient() {
+  const fields = ['#patient_age', '#patient_sex', '#patient_history'];
   let ok = true;
   fields.forEach(sel => {
     const el = $(sel);
-    if (el) {
-      validateField(el);
-      if (el.classList.contains('invalid')) ok = false;
-    }
+    if (el && !validateField(el)) ok = false;
+  });
+  return ok;
+}
+
+export function validateVitals() {
+  const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm'];
+  let ok = true;
+  fields.forEach(sel => {
+    const el = $(sel);
+    if (el && !validateField(el)) ok = false;
   });
   return ok;
 }
@@ -64,4 +92,5 @@ export function initValidation() {
 
 if (typeof window !== 'undefined') {
   window.validateVitals = validateVitals;
+  window.validatePatient = validatePatient;
 }


### PR DESCRIPTION
## Summary
- Centralize inline error handling with ARIA updates in `validation.js`
- Add custom rules for `patient_age`, `patient_sex`, and `patient_history` via new `validatePatient`
- Refactor form validation to use shared helpers
- Add unit tests for patient-level validation and update existing cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b072eab8108320bd66f3455bc41cdf