### PR TITLE
Prevent duplicate chip group initialization

### DIFF
--- a/public/js/__tests__/chipData.test.js
+++ b/public/js/__tests__/chipData.test.js
@@ -1,0 +1,45 @@
+jest.mock('../app.js', () => ({
+  createChipGroup: jest.fn((selector, values) => {
+    const container = global.document.querySelector(selector);
+    if (!container) return null;
+    values.forEach(val => {
+      const chip = global.document.createElement('span');
+      chip.className = 'chip';
+      chip.dataset.value = val;
+      chip.textContent = val;
+      container.appendChild(chip);
+    });
+    return container;
+  })
+}));
+
+const { buildChipGroup, initChipGroups, CHIP_DATA } = require('../chipData.js');
+const { createChipGroup } = require('../app.js');
+
+describe('chipData buildChipGroup', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="a_airway_group"></div><div id="b_breath_left_group"></div>';
+    jest.clearAllMocks();
+  });
+
+  test('clears container and prevents reinitialization', () => {
+    const container = document.querySelector('#a_airway_group');
+    container.innerHTML = '<span class="chip">old</span>';
+    buildChipGroup('a_airway_group', CHIP_DATA.a_airway_group);
+    expect(container.querySelectorAll('.chip')).toHaveLength(CHIP_DATA.a_airway_group.length);
+    expect(container.dataset.initialized).toBe('true');
+    buildChipGroup('a_airway_group', CHIP_DATA.a_airway_group);
+    expect(createChipGroup).toHaveBeenCalledTimes(1);
+    expect(container.querySelectorAll('.chip')).toHaveLength(CHIP_DATA.a_airway_group.length);
+  });
+
+  test('initChipGroups runs once without duplicating chips', () => {
+    initChipGroups();
+    const firstCount = document.querySelectorAll('#a_airway_group .chip').length;
+    initChipGroups();
+    const secondCount = document.querySelectorAll('#a_airway_group .chip').length;
+    expect(firstCount).toBe(CHIP_DATA.a_airway_group.length);
+    expect(secondCount).toBe(firstCount);
+    expect(createChipGroup).toHaveBeenCalledTimes(2);
+  });
+});

--- a/public/js/chipData.js
+++ b/public/js/chipData.js
@@ -85,8 +85,14 @@ export const CHIP_DATA = {
 };
 
 export function buildChipGroup(containerId, chips){
-  const container = createChipGroup(`#${containerId}`, chips.map(c => c.label));
-  if(!container) return;
+  const selector = `#${containerId}`;
+  const container = document.querySelector(selector);
+  if(!container || container.dataset.initialized) return;
+
+  container.replaceChildren();
+  createChipGroup(selector, chips.map(c => c.label));
+  container.dataset.initialized = 'true';
+
   const chipEls = container.querySelectorAll('.chip');
   chips.forEach((chip, idx) => {
     const el = chipEls[idx];


### PR DESCRIPTION
## Summary
- clear chip group containers before rebuilding
- mark containers as initialized to avoid duplicate chips
- add tests ensuring chip groups build only once

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b08444a998832095894068d3712efa