### PR TITLE
fix: prevent focus within hidden nav

### DIFF
--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -12,16 +12,18 @@ export function initNavToggle(toggle, nav){
   toggle.setAttribute('aria-controls', nav.id);
   toggle.setAttribute('aria-expanded','false');
   nav.setAttribute('aria-hidden','true');
+  nav.setAttribute('inert','');
   const overlay=document.querySelector('.nav-overlay');
   const focusableSel='a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
   function close(){
     document.body.classList.remove('nav-open');
     toggle.setAttribute('aria-expanded','false');
-    nav.setAttribute('aria-hidden','true');
     if(overlay) overlay.hidden=true;
     document.body.style.overflow='';
     document.removeEventListener('keydown', trap);
     toggle.focus();
+    nav.setAttribute('aria-hidden','true');
+    nav.setAttribute('inert','');
   }
   function trap(e){
     if(e.key==='Tab'){
@@ -42,6 +44,7 @@ export function initNavToggle(toggle, nav){
     document.body.classList.add('nav-open');
     toggle.setAttribute('aria-expanded','true');
     nav.removeAttribute('aria-hidden');
+    nav.removeAttribute('inert');
     if(overlay) overlay.hidden=false;
     document.body.style.overflow='hidden';
     const items=nav.querySelectorAll(focusableSel);

--- a/public/js/__tests__/navToggle.test.js
+++ b/public/js/__tests__/navToggle.test.js
@@ -13,6 +13,7 @@ describe('initNavToggle',()=>{
     toggle.click();
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
     expect(nav.hasAttribute('aria-hidden')).toBe(false);
+    expect(nav.hasAttribute('inert')).toBe(false);
     expect(document.body.classList.contains('nav-open')).toBe(true);
     expect(document.activeElement).toBe(tabs[0]);
     tabs[1].focus();
@@ -25,6 +26,7 @@ describe('initNavToggle',()=>{
     document.dispatchEvent(new KeyboardEvent('keydown',{key:'Escape'}));
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     expect(nav.getAttribute('aria-hidden')).toBe('true');
+    expect(nav.hasAttribute('inert')).toBe(true);
     expect(document.body.classList.contains('nav-open')).toBe(false);
     expect(document.activeElement).toBe(toggle);
   });
@@ -34,6 +36,7 @@ describe('initNavToggle',()=>{
     tabs[0].click();
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     expect(nav.getAttribute('aria-hidden')).toBe('true');
+    expect(nav.hasAttribute('inert')).toBe(true);
     expect(document.body.classList.contains('nav-open')).toBe(false);
     expect(document.activeElement).toBe(toggle);
   });

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -13,16 +13,18 @@ export function initNavToggle(toggle, nav){
   toggle.setAttribute('aria-controls', nav.id);
   toggle.setAttribute('aria-expanded','false');
   nav.setAttribute('aria-hidden','true');
+  nav.setAttribute('inert','');
   const overlay=document.querySelector('.nav-overlay');
   const focusableSel='a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
   function close(){
     document.body.classList.remove('nav-open');
     toggle.setAttribute('aria-expanded','false');
-    nav.setAttribute('aria-hidden','true');
     if(overlay) overlay.hidden=true;
     document.body.style.overflow='';
     document.removeEventListener('keydown', trap);
     toggle.focus();
+    nav.setAttribute('aria-hidden','true');
+    nav.setAttribute('inert','');
   }
   function trap(e){
     if(e.key==='Tab'){
@@ -43,6 +45,7 @@ export function initNavToggle(toggle, nav){
     document.body.classList.add('nav-open');
     toggle.setAttribute('aria-expanded','true');
     nav.removeAttribute('aria-hidden');
+    nav.removeAttribute('inert');
     if(overlay) overlay.hidden=false;
     document.body.style.overflow='hidden';
     const items=nav.querySelectorAll(focusableSel);


### PR DESCRIPTION
## Summary
- avoid `aria-hidden` focus error by moving focus before hiding nav
- disable interaction with hidden nav via the `inert` attribute
- test nav toggle updates for inert handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b086cc5ff08320b50bb35e89f233f0