### PR TITLE
Fix mobile nav closing timing

### DIFF
--- a/public/js/__tests__/navToggle.test.js
+++ b/public/js/__tests__/navToggle.test.js
@@ -31,9 +31,10 @@ describe('initNavToggle',()=>{
     expect(document.activeElement).toBe(toggle);
   });
 
-  test('closes when tab clicked',()=>{
+  test('closes when tab clicked', async () => {
     toggle.click();
     tabs[0].click();
+    await new Promise(r => setTimeout(r, 0));
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     expect(nav.getAttribute('aria-hidden')).toBe('true');
     expect(nav.hasAttribute('inert')).toBe(true);

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -55,8 +55,11 @@ export function initNavToggle(toggle, nav){
   toggle.addEventListener('click',()=>{
     document.body.classList.contains('nav-open') ? close() : open();
   });
-  nav.addEventListener('click',e=>{
-    if(e.target.closest('.tab')) close();
+  nav.addEventListener('click', e => {
+    if (e.target.closest('.tab')) {
+      // Delay closing so the default navigation can occur
+      setTimeout(close);
+    }
   });
   navMq=typeof matchMedia==='function' ? matchMedia(`(min-width: ${NAV_BREAKPOINT}px)`) : null;
   if(navMq){


### PR DESCRIPTION
## Summary
- allow nav links to trigger navigation before menu closes by deferring close
- adjust nav toggle tests for async close behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b088f613b08320a2a3dd4d7932c1f2