### PR TITLE
refactor token validation return

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -2,6 +2,7 @@ const jwt = require('jsonwebtoken');
 
 const SECRET = process.env.JWT_SECRET || 'dev-secret';
 const EXPIRES_IN = process.env.JWT_EXPIRES_IN || '1h';
+const INVALID = { valid: false, token: null, payload: null };
 
 function generateToken(name){
   return jwt.sign({ name }, SECRET, { expiresIn: EXPIRES_IN });
@@ -9,15 +10,15 @@ function generateToken(name){
 
 function validateToken(headerOrString) {
   const prefix = 'Bearer ';
-  if (typeof headerOrString !== 'string' || !headerOrString.startsWith(prefix)) {
-    return { valid: false, token: null, payload: null };
-  }
-  const token = headerOrString.slice(prefix.length);
   try {
+    if (typeof headerOrString !== 'string' || !headerOrString.startsWith(prefix)) {
+      return INVALID;
+    }
+    const token = headerOrString.slice(prefix.length);
     const payload = jwt.verify(token, SECRET);
     return { valid: true, token, payload };
   } catch (e) {
-    return { valid: false, token: null, payload: null };
+    return INVALID;
   }
 }
 


### PR DESCRIPTION
## Summary
- centralize invalid token result
- unify failure returns
- check Bearer prefix inside try block

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0acd4438483209decf391d0c31fc6