### PR TITLE
Allow header to expand based on content

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -927,8 +927,7 @@ section[data-tab=Intervencijos] .interv-toggle {
 }
 
 header {
-  height: var(--header-height);
-  line-height: var(--header-height);
+  min-height: var(--header-height);
   --line: color-mix(in srgb, #2d3b4f, white 20%);
   --ink: color-mix(in srgb, #e9f2fb, white 10%);
   position: sticky;

--- a/docs/css/scss/_topbar.scss
+++ b/docs/css/scss/_topbar.scss
@@ -1,8 +1,7 @@
 @use 'variables' as *;
 
 header {
-  height: var(--header-height);
-  line-height: var(--header-height);
+  min-height: var(--header-height);
   --line: color-mix(in srgb, #2d3b4f, white 20%);
   --ink: color-mix(in srgb, #e9f2fb, white 10%);
   position: sticky;


### PR DESCRIPTION
## Summary
- use `min-height` on top bar header and drop `line-height` so multiple toolbar rows can determine height
- update compiled docs CSS to rely on dynamic `--header-height` variable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b86358d48320baccb77933a9ad15