### PR TITLE
Refactor mobile action bars

### DIFF
--- a/docs/assets/partials/topbar.html
+++ b/docs/assets/partials/topbar.html
@@ -23,14 +23,8 @@
   <div class="header-actions">
     <div class="toolbar" id="mobileActions" hidden>
       <button type="button" class="btn" id="actionsToggle" aria-controls="actionsMenu" aria-expanded="false"></button>
-      <div class="menu" id="actionsMenu" hidden></div>
-      <div class="toolbar" id="arrivalBar">
-          <button type="button" class="btn primary" id="btnAtvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>ATVYKO</button>
-        <div id="arrivalTimer" class="btn primary arrival-timer" aria-live="polite"></div>
-      </div>
-      <div class="toolbar" id="sessionBar">
-        <select id="sessionSelect" class="w-auto"></select>
-          <button type="button" class="btn" id="btnNewSession"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Naujas</button>
+      <div class="menu" id="actionsMenu" hidden>
+        <div id="mobileBars"></div>
       </div>
     </div>
     <div class="toolbar">

--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -99,21 +99,17 @@ function applyTopbarLocalization(root){
 
 function initActionsMenu(){
   const container=document.getElementById('mobileActions');
-  if(container){
-    container.querySelector('#arrivalBar')?.remove();
-    container.querySelector('#sessionBar')?.remove();
-  }
   const toggle=document.getElementById('actionsToggle');
   const menu=document.getElementById('actionsMenu');
+  const mobileBars=document.getElementById('mobileBars');
   const arrival=document.getElementById('arrivalBar');
   const session=document.getElementById('sessionBar');
   const centerWrap=document.querySelector('.header-center');
-  if(!container || !toggle || !menu || !arrival || !session || !centerWrap) return;
+  if(!container || !toggle || !menu || !mobileBars || !arrival || !session || !centerWrap) return;
   const mq=window.matchMedia(`(max-width: ${NAV_BREAKPOINT}px)`);
   const update=()=>{
     if(mq.matches){
-      menu.appendChild(arrival);
-      menu.appendChild(session);
+      mobileBars.append(arrival, session);
       container.hidden=false;
     }else{
       centerWrap.append(arrival, session);

--- a/public/assets/partials/topbar.html
+++ b/public/assets/partials/topbar.html
@@ -23,14 +23,8 @@
   <div class="header-actions">
     <div class="toolbar" id="mobileActions" hidden>
       <button type="button" class="btn" id="actionsToggle" aria-controls="actionsMenu" aria-expanded="false"></button>
-      <div class="menu" id="actionsMenu" hidden></div>
-      <div class="toolbar" id="arrivalBar">
-          <button type="button" class="btn primary" id="btnAtvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>ATVYKO</button>
-        <div id="arrivalTimer" class="btn primary arrival-timer" aria-live="polite"></div>
-      </div>
-      <div class="toolbar" id="sessionBar">
-        <select id="sessionSelect" class="w-auto"></select>
-          <button type="button" class="btn" id="btnNewSession"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Naujas</button>
+      <div class="menu" id="actionsMenu" hidden>
+        <div id="mobileBars"></div>
       </div>
     </div>
     <div class="toolbar">

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -102,21 +102,17 @@ function applyTopbarLocalization(root){
 
 function initActionsMenu(){
   const container=document.getElementById('mobileActions');
-  if(container){
-    container.querySelector('#arrivalBar')?.remove();
-    container.querySelector('#sessionBar')?.remove();
-  }
   const toggle=document.getElementById('actionsToggle');
   const menu=document.getElementById('actionsMenu');
+  const mobileBars=document.getElementById('mobileBars');
   const arrival=document.getElementById('arrivalBar');
   const session=document.getElementById('sessionBar');
   const centerWrap=document.querySelector('.header-center');
-  if(!container || !toggle || !menu || !arrival || !session || !centerWrap) return;
+  if(!container || !toggle || !menu || !mobileBars || !arrival || !session || !centerWrap) return;
   const mq=window.matchMedia(`(max-width: ${NAV_BREAKPOINT}px)`);
   const update=()=>{
     if(mq.matches){
-      menu.appendChild(arrival);
-      menu.appendChild(session);
+      mobileBars.append(arrival, session);
       container.hidden=false;
     }else{
       centerWrap.append(arrival, session);


### PR DESCRIPTION
## Summary
- remove duplicate arrival/session toolbars from mobile header
- add mobileBars placeholder for mobile menu
- move toolbars into placeholder in JS

## Testing
- `npm run test:client`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68b0cd946ce08320a125afc2e96d1f44