### PR TITLE
Remove top bar action buttons

### DIFF
--- a/docs/assets/partials/topbar.html
+++ b/docs/assets/partials/topbar.html
@@ -27,18 +27,7 @@
         <div id="mobileBars"></div>
       </div>
     </div>
-    <div class="toolbar">
-      <details class="more-actions">
-        <summary class="btn"></summary>
-        <div class="menu">
-            <button type="button" class="btn" id="btnCopy"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>Kopijuoti</button>
-            <button type="button" class="btn" id="btnSave"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>Išsaugoti</button>
-            <button type="button" class="btn ghost" id="btnClear"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>Išvalyti</button>
-            <button type="button" class="btn" id="btnPdf"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>PDF</button>
-            <button type="button" class="btn warn" id="btnPrint"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>Spausdinti</button>
-        </div>
-      </details>
-    </div>
+    <div class="toolbar" id="desktopActions"></div>
     <div class="status-wrap">
       <div id="userList" class="user-list"></div>
       <div id="saveStatus" aria-live="polite"></div>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -141,7 +141,7 @@ function clampNumberInputs(){
 async function init(){
   initTheme();
   await initTopbar();
-  setupHeaderActions({ validateForm, saveAll });
+  setupHeaderActions({ validateForm });
   connectSocket({
     onSessions: list => {
       const sel = $('#sessionSelect');

--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -1,4 +1,4 @@
-import { ACTIONS_LABEL, MORE_LABEL } from '../constants.js';
+import { ACTIONS_LABEL } from '../constants.js';
 
 const NAV_BREAKPOINT = 768;
 let navMq;
@@ -93,8 +93,6 @@ export async function initTopbar(){
 function applyTopbarLocalization(root){
   const actionsToggle=root?.querySelector('#actionsToggle');
   if(actionsToggle) actionsToggle.textContent=ACTIONS_LABEL;
-  const moreSummary=root?.querySelector('.more-actions summary');
-  if(moreSummary) moreSummary.textContent=MORE_LABEL;
 }
 
 function initActionsMenu(){

--- a/docs/js/constants.js
+++ b/docs/js/constants.js
@@ -11,4 +11,3 @@ export const TEAM_ROLES = [
 ];
 
 export const ACTIONS_LABEL = 'Veiksmai ▾';
-export const MORE_LABEL = 'Daugiau ▾';

--- a/docs/js/headerActions.js
+++ b/docs/js/headerActions.js
@@ -2,17 +2,17 @@ import { $ } from './utils.js';
 import { notify } from './alerts.js';
 import { startArrivalTimer } from './arrival.js';
 import { showTab } from './tabs.js';
-import { sessionKey, getAuthToken, logout } from './sessionManager.js';
+import { getAuthToken, logout } from './sessionManager.js';
 import bodyMap from './bodyMap.js';
 
-export function setupHeaderActions({ validateForm, saveAll }){
+export function setupHeaderActions({ validateForm }){
   const btnAtvyko=document.getElementById('btnAtvyko');
   if(btnAtvyko) btnAtvyko.addEventListener('click', ()=>startArrivalTimer(true));
 
   const arrivalTimer=document.getElementById('arrivalTimer');
   if(arrivalTimer) arrivalTimer.addEventListener('dblclick',()=>startArrivalTimer(true));
 
-  const copyButtons=[$('#btnCopy'), $('#btnCopyReport')].filter(Boolean);
+  const copyButtons=[$('#btnCopyReport')].filter(Boolean);
   copyButtons.forEach(btn=>btn.addEventListener('click',async()=>{
     try{
       await navigator.clipboard.writeText($('#output').value||'');
@@ -22,13 +22,7 @@ export function setupHeaderActions({ validateForm, saveAll }){
     }
   }));
 
-  const btnSave=$('#btnSave');
-  if(btnSave) btnSave.addEventListener('click',()=>{ if(validateForm()){ saveAll(); notify({message:'Išsaugota naršyklėje.', type:'success'}); }});
-
-  const btnClear=$('#btnClear');
-  if(btnClear) btnClear.addEventListener('click',async()=>{ if(await notify({type:'confirm', message:'Išvalyti viską?'})){ localStorage.removeItem(sessionKey()); location.reload(); }});
-
-  const pdfButtons=[$('#btnPdf'), $('#btnPdfReport')].filter(Boolean);
+  const pdfButtons=[$('#btnPdfReport')].filter(Boolean);
   pdfButtons.forEach(btn=>btn.addEventListener('click', async () => {
     if(!validateForm()) return;
     showTab('Santrauka');
@@ -46,7 +40,7 @@ export function setupHeaderActions({ validateForm, saveAll }){
     }
   }));
 
-  const printButtons=[$('#btnPrint'), $('#btnPrintReport')].filter(Boolean);
+  const printButtons=[$('#btnPrintReport')].filter(Boolean);
   printButtons.forEach(btn=>btn.addEventListener('click', async () => {
     if(!validateForm()) return;
     const prevTab=localStorage.getItem('v10_activeTab');
@@ -77,14 +71,14 @@ export function setupHeaderActions({ validateForm, saveAll }){
     if(prevTab) showTab(prevTab);
   }));
 
-  const menu=document.querySelector('.more-actions .menu');
-  if(menu && getAuthToken() && !document.getElementById('btnLogout')){
+  const actionsBar=document.getElementById('desktopActions');
+  if(actionsBar && getAuthToken() && !document.getElementById('btnLogout')){
     const btn=document.createElement('button');
     btn.type='button';
     btn.className='btn';
     btn.id='btnLogout';
     btn.textContent='Logout';
     btn.addEventListener('click',()=>logout());
-    menu.appendChild(btn);
+    actionsBar.appendChild(btn);
   }
 }

--- a/public/assets/partials/topbar.html
+++ b/public/assets/partials/topbar.html
@@ -27,18 +27,7 @@
         <div id="mobileBars"></div>
       </div>
     </div>
-    <div class="toolbar">
-      <details class="more-actions">
-        <summary class="btn"></summary>
-        <div class="menu">
-            <button type="button" class="btn" id="btnCopy"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>Kopijuoti</button>
-            <button type="button" class="btn" id="btnSave"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>Išsaugoti</button>
-            <button type="button" class="btn ghost" id="btnClear"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>Išvalyti</button>
-            <button type="button" class="btn" id="btnPdf"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>PDF</button>
-            <button type="button" class="btn warn" id="btnPrint"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>Spausdinti</button>
-        </div>
-      </details>
-    </div>
+    <div class="toolbar" id="desktopActions"></div>
     <div class="status-wrap">
       <div id="userList" class="user-list"></div>
       <div id="saveStatus" aria-live="polite"></div>

--- a/public/js/__tests__/headerActions.test.js
+++ b/public/js/__tests__/headerActions.test.js
@@ -1,12 +1,8 @@
 import { setupHeaderActions } from '../headerActions.js';
 
 describe('setupHeaderActions', () => {
-  test('calls saveAll when save button clicked and valid', () => {
-    const saveAll = jest.fn();
-    const validateForm = jest.fn(() => true);
-    document.body.innerHTML = `<button id="btnSave"></button>`;
-    setupHeaderActions({ validateForm, saveAll });
-    document.getElementById('btnSave').click();
-    expect(saveAll).toHaveBeenCalled();
+  test('handles missing action buttons gracefully', () => {
+    document.body.innerHTML = '';
+    expect(() => setupHeaderActions({ validateForm: () => true })).not.toThrow();
   });
 });

--- a/public/js/__tests__/patient.test.js
+++ b/public/js/__tests__/patient.test.js
@@ -10,11 +10,9 @@ let saveAll, loadAll, generateReport, setupHeaderActions, initBodyMap, setCurren
 
 const setupDom = () => {
   document.body.innerHTML = `
-    <button id="btnCopy"></button>
-    <button id="btnSave"></button>
-    <button id="btnClear"></button>
-    <button id="btnPrint"></button>
-    <button id="btnPdf"></button>
+    <button id="btnCopyReport"></button>
+    <button id="btnPdfReport"></button>
+    <button id="btnPrintReport"></button>
     <button id="btnAtvyko"></button>
     <button id="btnGCS15"></button>
     <button id="btnGCSCalc"></button>
@@ -90,7 +88,7 @@ describe('patient fields', () => {
     ({ initBodyMap } = require('../bodyMap.js'));
     setCurrentSessionId('test');
     initBodyMap(()=>{});
-    setupHeaderActions({ validateForm: () => true, saveAll });
+    setupHeaderActions({ validateForm: () => true });
     require('../app.js');
     mockJsPDF.mockClear();
     mockSave.mockClear();
@@ -206,7 +204,7 @@ describe('patient fields', () => {
     document.getElementById('patient_age').value='25';
     document.getElementById('patient_sex').value='M';
     document.getElementById('patient_history').value='H123';
-    document.getElementById('btnPdf').click();
+    document.getElementById('btnPdfReport').click();
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(mockJsPDF).toHaveBeenCalled();
     expect(mockSave).toHaveBeenCalledWith('report.pdf');
@@ -224,7 +222,7 @@ describe('patient fields', () => {
     document.getElementById('patient_age').value='25';
     document.getElementById('patient_sex').value='M';
     document.getElementById('patient_history').value='H123';
-    document.getElementById('btnPrint').click();
+    document.getElementById('btnPrintReport').click();
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(openMock).toHaveBeenCalled();
     expect(win.focus).toHaveBeenCalled();

--- a/public/js/__tests__/topbarLocalization.test.js
+++ b/public/js/__tests__/topbarLocalization.test.js
@@ -1,5 +1,5 @@
 import { initTopbar } from '../components/topbar.js';
-import { ACTIONS_LABEL, MORE_LABEL } from '../constants.js';
+import { ACTIONS_LABEL } from '../constants.js';
 import fs from 'fs';
 import path from 'path';
 
@@ -13,6 +13,9 @@ describe('topbar localization', () => {
     };
     await initTopbar();
     expect(document.getElementById('actionsToggle').textContent).toBe(ACTIONS_LABEL);
-    expect(document.querySelector('.more-actions summary').textContent).toBe(MORE_LABEL);
+    expect(document.querySelector('.more-actions')).toBeNull();
+    ['btnCopy','btnSave','btnClear','btnPdf','btnPrint'].forEach(id=>{
+      expect(document.getElementById(id)).toBeNull();
+    });
   });
 });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -121,7 +121,7 @@ function clampNumberInputs(){
 async function init(){
   initTheme();
   await initTopbar();
-  setupHeaderActions({ validateForm, saveAll });
+  setupHeaderActions({ validateForm });
   connectSocket({
     onSessions: list => {
       const sel = $('#sessionSelect');

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -1,4 +1,4 @@
-import { ACTIONS_LABEL, MORE_LABEL } from '../constants.js';
+import { ACTIONS_LABEL } from '../constants.js';
 import { notify } from '../alerts.js';
 
 const NAV_BREAKPOINT = 768;
@@ -96,8 +96,6 @@ export async function initTopbar(){
 function applyTopbarLocalization(root){
   const actionsToggle=root?.querySelector('#actionsToggle');
   if(actionsToggle) actionsToggle.textContent=ACTIONS_LABEL;
-  const moreSummary=root?.querySelector('.more-actions summary');
-  if(moreSummary) moreSummary.textContent=MORE_LABEL;
 }
 
 function initActionsMenu(){

--- a/public/js/constants.js
+++ b/public/js/constants.js
@@ -11,4 +11,3 @@ export const TEAM_ROLES = [
 ];
 
 export const ACTIONS_LABEL = 'Veiksmai ▾';
-export const MORE_LABEL = 'Daugiau ▾';

--- a/public/js/headerActions.js
+++ b/public/js/headerActions.js
@@ -2,17 +2,17 @@ import { $ } from './utils.js';
 import { notify } from './alerts.js';
 import { startArrivalTimer } from './arrival.js';
 import { showTab } from './tabs.js';
-import { sessionKey, getAuthToken, logout } from './sessionManager.js';
+import { getAuthToken, logout } from './sessionManager.js';
 import bodyMap from './bodyMap.js';
 
-export function setupHeaderActions({ validateForm, saveAll }){
+export function setupHeaderActions({ validateForm }){
   const btnAtvyko=document.getElementById('btnAtvyko');
   if(btnAtvyko) btnAtvyko.addEventListener('click', ()=>startArrivalTimer(true));
 
   const arrivalTimer=document.getElementById('arrivalTimer');
   if(arrivalTimer) arrivalTimer.addEventListener('dblclick',()=>startArrivalTimer(true));
 
-  const copyButtons=[$('#btnCopy'), $('#btnCopyReport')].filter(Boolean);
+  const copyButtons=[$('#btnCopyReport')].filter(Boolean);
   copyButtons.forEach(btn=>btn.addEventListener('click',async()=>{
     try{
       await navigator.clipboard.writeText($('#output').value||'');
@@ -22,13 +22,7 @@ export function setupHeaderActions({ validateForm, saveAll }){
     }
   }));
 
-  const btnSave=$('#btnSave');
-  if(btnSave) btnSave.addEventListener('click',()=>{ if(validateForm()){ saveAll(); notify({message:'Išsaugota naršyklėje.', type:'success'}); }});
-
-  const btnClear=$('#btnClear');
-  if(btnClear) btnClear.addEventListener('click',async()=>{ if(await notify({type:'confirm', message:'Išvalyti viską?'})){ localStorage.removeItem(sessionKey()); location.reload(); }});
-
-  const pdfButtons=[$('#btnPdf'), $('#btnPdfReport')].filter(Boolean);
+  const pdfButtons=[$('#btnPdfReport')].filter(Boolean);
   pdfButtons.forEach(btn=>btn.addEventListener('click', async () => {
     if(!validateForm()) return;
     showTab('Santrauka');
@@ -46,7 +40,7 @@ export function setupHeaderActions({ validateForm, saveAll }){
     }
   }));
 
-  const printButtons=[$('#btnPrint'), $('#btnPrintReport')].filter(Boolean);
+  const printButtons=[$('#btnPrintReport')].filter(Boolean);
   printButtons.forEach(btn=>btn.addEventListener('click', async () => {
     if(!validateForm()) return;
     const prevTab=localStorage.getItem('v10_activeTab');
@@ -77,14 +71,14 @@ export function setupHeaderActions({ validateForm, saveAll }){
     if(prevTab) showTab(prevTab);
   }));
 
-  const menu=document.querySelector('.more-actions .menu');
-  if(menu && getAuthToken() && !document.getElementById('btnLogout')){
+  const actionsBar=document.getElementById('desktopActions');
+  if(actionsBar && getAuthToken() && !document.getElementById('btnLogout')){
     const btn=document.createElement('button');
     btn.type='button';
     btn.className='btn';
     btn.id='btnLogout';
     btn.textContent='Logout';
     btn.addEventListener('click',()=>logout());
-    menu.appendChild(btn);
+    actionsBar.appendChild(btn);
   }
 }


### PR DESCRIPTION
## Summary
- Drop copy, save, clear, PDF and print buttons from the header, leaving only the container for logout
- Simplify header actions to handle only report-level controls and update localization checks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0dcee5f648320b3f794584970fd4b