### PR TITLE
Remove actions button from topbar

### DIFF
--- a/docs/assets/partials/topbar.html
+++ b/docs/assets/partials/topbar.html
@@ -21,12 +21,6 @@
     </div>
   </div>
   <div class="header-actions">
-    <div class="toolbar" id="mobileActions" hidden>
-      <button type="button" class="btn" id="actionsToggle" aria-controls="actionsMenu" aria-expanded="false"></button>
-      <div class="menu" id="actionsMenu" hidden>
-        <div id="mobileBars"></div>
-      </div>
-    </div>
     <div class="toolbar" id="desktopActions"></div>
     <div class="status-wrap">
       <div id="userList" class="user-list"></div>

--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -1,4 +1,3 @@
-import { ACTIONS_LABEL } from '../constants.js';
 
 const NAV_BREAKPOINT = 768;
 let navMq;
@@ -73,7 +72,6 @@ export async function initTopbar(){
   }catch(e){
     console.error('Failed to load topbar', e);
   }
-  applyTopbarLocalization(header);
   if(typeof ResizeObserver==='function'){
     const updateHeight=entries=>{
       for(const entry of entries){
@@ -86,54 +84,4 @@ export async function initTopbar(){
   const toggle=document.getElementById('navToggle');
   const nav=document.querySelector('nav');
   initNavToggle(toggle, nav);
-
-  initActionsMenu();
-}
-
-function applyTopbarLocalization(root){
-  const actionsToggle=root?.querySelector('#actionsToggle');
-  if(actionsToggle) actionsToggle.textContent=ACTIONS_LABEL;
-}
-
-function initActionsMenu(){
-  const container=document.getElementById('mobileActions');
-  const toggle=document.getElementById('actionsToggle');
-  const menu=document.getElementById('actionsMenu');
-  const mobileBars=document.getElementById('mobileBars');
-  const arrival=document.getElementById('arrivalBar');
-  const session=document.getElementById('sessionBar');
-  const centerWrap=document.querySelector('.header-center');
-  if(!container || !toggle || !menu || !mobileBars || !arrival || !session || !centerWrap) return;
-  const mq=window.matchMedia(`(max-width: ${NAV_BREAKPOINT}px)`);
-  const update=()=>{
-    if(mq.matches){
-      mobileBars.append(arrival, session);
-      container.hidden=false;
-    }else{
-      centerWrap.append(arrival, session);
-      container.hidden=true;
-      menu.hidden=true;
-      toggle.setAttribute('aria-expanded','false');
-    }
-  };
-  mq.addEventListener('change', update);
-  update();
-  toggle.addEventListener('click', ()=>{
-    const expanded=toggle.getAttribute('aria-expanded')==='true';
-    toggle.setAttribute('aria-expanded', String(!expanded));
-    menu.hidden=expanded;
-  });
-  document.addEventListener('click', e=>{
-    if(!container.contains(e.target)){
-      menu.hidden=true;
-      toggle.setAttribute('aria-expanded','false');
-    }
-  });
-  document.addEventListener('keydown', e=>{
-    if(e.key==='Escape'){
-      menu.hidden=true;
-      toggle.setAttribute('aria-expanded','false');
-      toggle.focus();
-    }
-  });
 }

--- a/docs/js/constants.js
+++ b/docs/js/constants.js
@@ -9,5 +9,3 @@ export const TEAM_ROLES = [
   'Chirurgas',
   'Ortopedas'
 ];
-
-export const ACTIONS_LABEL = 'Veiksmai ▾';

--- a/public/assets/partials/topbar.html
+++ b/public/assets/partials/topbar.html
@@ -28,12 +28,6 @@
     </div>
   </div>
   <div class="header-actions">
-    <div class="toolbar" id="mobileActions" hidden>
-      <button type="button" class="btn" id="actionsToggle" aria-controls="actionsMenu" aria-expanded="false"></button>
-      <div class="menu" id="actionsMenu" hidden>
-        <div id="mobileBars"></div>
-      </div>
-    </div>
     <div class="toolbar" id="desktopActions"></div>
     <div class="status-wrap">
       <div id="userList" class="user-list"></div>

--- a/public/js/__tests__/topbarLocalization.test.js
+++ b/public/js/__tests__/topbarLocalization.test.js
@@ -1,10 +1,9 @@
 import { initTopbar } from '../components/topbar.js';
-import { ACTIONS_LABEL } from '../constants.js';
 import fs from 'fs';
 import path from 'path';
 
-describe('topbar localization', () => {
-  test('inserts localized labels', async () => {
+describe('topbar', () => {
+  test('loads without actions button', async () => {
     const html = fs.readFileSync(path.join(__dirname, '../../assets/partials/topbar.html'), 'utf8');
     global.fetch = jest.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve(html) }));
     document.body.innerHTML = '<header id="appHeader"></header><nav></nav>';
@@ -12,8 +11,7 @@ describe('topbar localization', () => {
       return { matches: false, addEventListener(){}, removeEventListener(){}, addListener(){}, removeListener(){} };
     };
     await initTopbar();
-    expect(document.getElementById('actionsToggle').textContent).toBe(ACTIONS_LABEL);
-    expect(document.querySelector('.more-actions')).toBeNull();
+    expect(document.getElementById('actionsToggle')).toBeNull();
     ['btnCopy','btnSave','btnClear','btnPdf','btnPrint'].forEach(id=>{
       expect(document.getElementById(id)).toBeNull();
     });

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -1,4 +1,3 @@
-import { ACTIONS_LABEL } from '../constants.js';
 import { notify } from '../alerts.js';
 
 const NAV_BREAKPOINT = 768;
@@ -76,7 +75,6 @@ export async function initTopbar(){
     header.innerHTML='<div class="wrap"><button type="button" class="btn" id="retryTopbar">Retry</button></div>';
     header.querySelector('#retryTopbar')?.addEventListener('click', initTopbar);
   }
-  applyTopbarLocalization(header);
   if(typeof ResizeObserver==='function'){
     const updateHeight=entries=>{
       for(const entry of entries){
@@ -89,54 +87,4 @@ export async function initTopbar(){
   const toggle=document.getElementById('navToggle');
   const nav=document.querySelector('nav');
   initNavToggle(toggle, nav);
-
-  initActionsMenu();
-}
-
-function applyTopbarLocalization(root){
-  const actionsToggle=root?.querySelector('#actionsToggle');
-  if(actionsToggle) actionsToggle.textContent=ACTIONS_LABEL;
-}
-
-function initActionsMenu(){
-  const container=document.getElementById('mobileActions');
-  const toggle=document.getElementById('actionsToggle');
-  const menu=document.getElementById('actionsMenu');
-  const mobileBars=document.getElementById('mobileBars');
-  const arrival=document.getElementById('arrivalBar');
-  const session=document.getElementById('sessionBar');
-  const centerWrap=document.querySelector('.header-center');
-  if(!container || !toggle || !menu || !mobileBars || !arrival || !session || !centerWrap) return;
-  const mq=window.matchMedia(`(max-width: ${NAV_BREAKPOINT}px)`);
-  const update=()=>{
-    if(mq.matches){
-      mobileBars.append(arrival, session);
-      container.hidden=false;
-    }else{
-      centerWrap.append(arrival, session);
-      container.hidden=true;
-      menu.hidden=true;
-      toggle.setAttribute('aria-expanded','false');
-    }
-  };
-  mq.addEventListener('change', update);
-  update();
-  toggle.addEventListener('click', ()=>{
-    const expanded=toggle.getAttribute('aria-expanded')==='true';
-    toggle.setAttribute('aria-expanded', String(!expanded));
-    menu.hidden=expanded;
-  });
-  document.addEventListener('click', e=>{
-    if(!container.contains(e.target)){
-      menu.hidden=true;
-      toggle.setAttribute('aria-expanded','false');
-    }
-  });
-  document.addEventListener('keydown', e=>{
-    if(e.key==='Escape'){
-      menu.hidden=true;
-      toggle.setAttribute('aria-expanded','false');
-      toggle.focus();
-    }
-  });
 }

--- a/public/js/constants.js
+++ b/public/js/constants.js
@@ -9,5 +9,3 @@ export const TEAM_ROLES = [
   'Chirurgas',
   'Ortopedas'
 ];
-
-export const ACTIONS_LABEL = 'Veiksmai ▾';


### PR DESCRIPTION
## Summary
- remove mobile "Veiksmai" actions button from topbar and associated script
- drop unused actions label constant and localization
- adjust tests to reflect absence of actions button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0e9d2aefc8320b996a5efc21e0472