### PR TITLE
Fix body map marks rendering issue

### DIFF
--- a/docs/js/components/BodyMap.js
+++ b/docs/js/components/BodyMap.js
@@ -351,7 +351,10 @@ export default class BodyMap {
     if (!this.pointInBody(x, y, side)) return;
     const use = document.createElementNS('http://www.w3.org/2000/svg', 'use');
     const symbol = TOOL_SYMBOL[type];
-    if (symbol) use.setAttribute('href', symbol);
+    if (symbol) {
+      use.setAttribute('href', symbol);
+      use.setAttributeNS('http://www.w3.org/1999/xlink', 'href', symbol);
+    }
     use.setAttribute('transform', `translate(${x},${y})`);
     const mid = id || ++this.markSeq;
     use.dataset.id = mid;

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -347,7 +347,10 @@ export default class BodyMap {
     if (!this.pointInBody(x, y, side)) return;
     const use = document.createElementNS('http://www.w3.org/2000/svg', 'use');
     const symbol = TOOL_SYMBOL[type];
-    if (symbol) use.setAttribute('href', symbol);
+    if (symbol) {
+      use.setAttribute('href', symbol);
+      use.setAttributeNS('http://www.w3.org/1999/xlink', 'href', symbol);
+    }
     use.setAttribute('transform', `translate(${x},${y})`);
     const mid = id || ++this.markSeq;
     use.dataset.id = mid;


### PR DESCRIPTION
## Summary
- ensure SVG <use> elements set both `href` and `xlink:href` so marks appear on the body map
- mirror update in docs build

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ee8c495083208bd54e54a177bed4