### PR TITLE
Use archive icon for patient sessions

### DIFF
--- a/docs/js/sessionUI.js
+++ b/docs/js/sessionUI.js
@@ -102,9 +102,10 @@ export async function initSessions(){
 
       const archive=document.createElement('button');
       archive.type='button';
-      archive.textContent=s.archived?'Unarchive':'Archive';
       archive.className='btn ghost';
-      archive.setAttribute('aria-label', s.archived ? 'Unarchive session' : 'Archive session');
+      archive.innerHTML='<svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5"/><line x1="10" y1="12" x2="14" y2="12"/></svg>';
+      archive.setAttribute('aria-label', s.archived ? 'Išarchyvuoti' : 'Archyvuoti');
+      archive.title = s.archived ? 'Išarchyvuoti' : 'Archyvuoti';
       archive.addEventListener('click', async () => {
         const token=getAuthToken();
         if(token && typeof fetch==='function'){

--- a/public/js/sessionUI.js
+++ b/public/js/sessionUI.js
@@ -95,9 +95,10 @@ export async function initSessions(){
 
       const archive=document.createElement('button');
       archive.type='button';
-      archive.textContent=s.archived?'Unarchive':'Archive';
       archive.className='btn ghost';
-      archive.setAttribute('aria-label', s.archived ? 'Unarchive session' : 'Archive session');
+      archive.innerHTML='<svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5"/><line x1="10" y1="12" x2="14" y2="12"/></svg>';
+      archive.setAttribute('aria-label', s.archived ? 'Išarchyvuoti' : 'Archyvuoti');
+      archive.title = s.archived ? 'Išarchyvuoti' : 'Archyvuoti';
       archive.addEventListener('click', async () => {
         const token=getAuthToken();
         if(token && typeof fetch==='function'){


### PR DESCRIPTION
## Summary
- Replace patient archive button with an SVG icon
- Show hover text "Archyvuoti" when archiving sessions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b14509ee748320bb9750a7920fb5b7