### PR TITLE
Add helmet middleware for security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^4.18.2",
+        "helmet": "^8.1.0",
         "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.2",
         "jspdf": "^2.5.1",
@@ -5939,6 +5940,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-encoding-sniffer": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^4.18.2",
+    "helmet": "^8.1.0",
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
     "jspdf": "^2.5.1",

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,7 @@ const Joi = require('joi');
 const validate = require('./validate');
 const { validateToken, generateToken } = require('./auth');
 const { dbSchema, sessionDataSchema } = require('./dbSchema');
+const helmet = require('helmet');
 
 const PORT = process.env.PORT || 3000;
 const DB_FILE = process.env.DB_FILE || path.join(__dirname, 'db.json');
@@ -58,6 +59,7 @@ function saveDB(){
 let db;
 
 const app = express();
+app.use(helmet());
 app.use(express.json({ limit: '1mb' }));
 // Serve static assets from the public directory
 app.use(express.static(path.join(__dirname, '..', 'public')));


### PR DESCRIPTION
## Summary
- add helmet to server for enhanced security
- install helmet dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b182d00f5883209795a195cc001d50