### PR TITLE
Validate archived flag for session API

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -81,6 +81,10 @@ const sessionListItemSchema = Joi.object({
 
 const sessionsListSchema = Joi.array().items(sessionListItemSchema);
 
+const sessionArchiveSchema = Joi.object({
+  archived: Joi.boolean().required()
+});
+
 /* sessionDataSchema is imported from dbSchema */
 
 /* ===== Auth ===== */
@@ -173,14 +177,11 @@ app.put('/api/sessions/:id', auth, validate(sessionSchema), async (req, res) => 
   res.json({ ok: true });
 });
 
-app.patch('/api/sessions/:id/archive', auth, async (req, res) => {
+app.patch('/api/sessions/:id/archive', auth, validate(sessionArchiveSchema), async (req, res) => {
   const id = req.params.id;
   const session = db.sessions.find(s => s.id === id);
   if (!session) return res.status(404).json({ error: 'Not found' });
   const { archived } = req.body;
-  if (typeof archived !== 'boolean') {
-    return res.status(400).json({ error: '"archived" must be a boolean' });
-  }
   session.archived = archived;
   await saveDB();
   io.emit('sessions', db.sessions);

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -119,6 +119,27 @@ describe('server API', () => {
     expect(fakeDB.sessions[0].archived).toBe(false);
   });
 
+  test('rejects invalid archived values', async () => {
+    const token = await login('ian');
+    const create = await request(app)
+      .post('/api/sessions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'bad-arch' });
+    const id = create.body.id;
+    const invalidType = await request(app)
+      .patch(`/api/sessions/${id}/archive`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ archived: 'yes' });
+    expect(invalidType.statusCode).toBe(400);
+    expect(invalidType.body).toEqual({ error: '"archived" must be a boolean' });
+    const missing = await request(app)
+      .patch(`/api/sessions/${id}/archive`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(missing.statusCode).toBe(400);
+    expect(missing.body).toEqual({ error: '"archived" is required' });
+  });
+
   test('requires name when creating session', async () => {
     const token = await login('dave');
     const res = await request(app)


### PR DESCRIPTION
## Summary
- add Joi schema for archive flag
- validate `/api/sessions/:id/archive` payloads
- test invalid archived values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1875c7f1c8320a9eb3ad19f75d8f1