### PR TITLE
Require JWT secret configuration for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,19 @@ npm install
 
 ## Running the Server
 
-Start the application backend:
+Set the required JWT secret and start the application backend:
 
 ```bash
+export JWT_SECRET="your-secret"
 node server/start.js
 ```
 
-Alternatively, use the provided `npm start` script.
+Alternatively, set `JWT_SECRET` and use the provided `npm start` script.
 
 ## Environment Variables
 
+- `JWT_SECRET` – Secret used to sign JSON Web Tokens. **Required**; the
+  server will not start without it.
 - `ALLOWED_ORIGINS` – Comma-separated list of origins allowed for
   Socket.IO connections. If unset, all origins are permitted.
 

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,6 +1,9 @@
 const jwt = require('jsonwebtoken');
 
-const SECRET = process.env.JWT_SECRET || 'dev-secret';
+const SECRET = process.env.JWT_SECRET;
+if (!SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
 const EXPIRES_IN = process.env.JWT_EXPIRES_IN || '1h';
 const INVALID = { valid: false, token: null, payload: null };
 


### PR DESCRIPTION
## Summary
- throw an error if `JWT_SECRET` env var is unset
- document the required `JWT_SECRET` variable and setup instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b357ba2cec83208033b6c73c18b47c