### PR TITLE
Add creation timestamp for session sorting

### DIFF
--- a/public/js/__tests__/sessionUI.test.js
+++ b/public/js/__tests__/sessionUI.test.js
@@ -1,5 +1,5 @@
 jest.mock('../sessionApi.js', () => ({
-  getSessions: jest.fn(() => Promise.resolve([{ id: '1', name: 'One', archived: false }])),
+  getSessions: jest.fn(() => Promise.resolve([{ id: '1', name: 'One', archived: false, created: 1 }])),
   saveSessions: jest.fn()
 }));
 
@@ -22,7 +22,7 @@ describe('sessionUI', () => {
   test('populateSessionSelect renders options', () => {
     const { populateSessionSelect } = require('../sessionUI.js');
     const sel = document.createElement('select');
-    populateSessionSelect(sel, [{ id: '1', name: 'One', archived: false }]);
+    populateSessionSelect(sel, [{ id: '1', name: 'One', archived: false, created: 1 }]);
     expect(sel.querySelectorAll('option').length).toBe(1);
   });
 

--- a/public/js/sessionUI.js
+++ b/public/js/sessionUI.js
@@ -16,7 +16,7 @@ export function populateSessionSelect(sel, sessions, { query = '', sortBy = 'cre
   let list=sessions.filter(s=>(showArchived || !s.archived) && (!q || s.name.toLowerCase().includes(q)));
   list=list.slice();
   if(sortBy==='name') list.sort((a,b)=>a.name.localeCompare(b.name));
-  else list.sort((a,b)=>parseInt(a.id,36)-parseInt(b.id,36));
+  else list.sort((a,b)=>(a.created||0)-(b.created||0));
   list.forEach(s=>{ const opt=document.createElement('option'); opt.value=s.id; opt.textContent=s.name; sel.appendChild(opt); });
   return list;
 }
@@ -199,7 +199,7 @@ export async function initSessions(){
     sortSelect?.addEventListener('change', ()=>render());
     if(!sessions.length){
       const id=Date.now().toString(36);
-      sessions=[{id,name:'Pacientas Nr.1', archived:false}];
+      sessions=[{id,name:'Pacientas Nr.1', archived:false, created:Date.now()}];
       await saveSessions(sessions);
       currentSessionId=id;
       setCurrentSessionId(id);
@@ -214,7 +214,7 @@ export async function initSessions(){
     const name=await notify({type:'prompt', message:'Paciento ID'});
     if(!name) return;
     const id=Date.now().toString(36);
-    sessions.push({id,name, archived:false});
+    sessions.push({id,name, archived:false, created:Date.now()});
     await saveSessions(sessions);
     currentSessionId=id;
     setCurrentSessionId(id);

--- a/server/dbSchema.js
+++ b/server/dbSchema.js
@@ -22,7 +22,8 @@ const sessionDataSchema = Joi.object({
 const sessionSchema = Joi.object({
   id: Joi.string().required(),
   name: Joi.string().min(1).max(100).required(),
-  archived: Joi.boolean().default(false)
+  archived: Joi.boolean().default(false),
+  created: Joi.number().required()
 });
 
 const userSchema = Joi.string().min(1).max(50);


### PR DESCRIPTION
## Summary
- track a `created` timestamp on sessions and validate it
- sort sessions by `created` instead of parsing IDs
- update tests and schema for the new field

## Testing
- `npm run test:client`
- `npm run test:server`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3ee9e6318832082706e2b88ae659e