### PR TITLE
Fix mobile nav overlay on desktop

### DIFF
--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -43,8 +43,10 @@ export function initNavToggle(toggle, nav){
     toggle.setAttribute('aria-expanded','true');
     nav.removeAttribute('aria-hidden');
     nav.removeAttribute('hidden');
-    if(overlay) overlay.hidden=false;
-    document.body.style.overflow='hidden';
+    if(!navMq || navMq.matches){
+      if(overlay) overlay.hidden=false;
+      document.body.style.overflow='hidden';
+    }
     const items=nav.querySelectorAll(focusableSel);
     if(items.length) items[0].focus();
     document.addEventListener('keydown', trap);
@@ -58,11 +60,11 @@ export function initNavToggle(toggle, nav){
   nav.addEventListener('click',e=>{
     if(e.target.closest('.tab')) close();
   });
-  navMq=typeof matchMedia==='function' ? matchMedia(`(min-width: ${NAV_BREAKPOINT}px)`) : null;
+  navMq=typeof matchMedia==='function' ? matchMedia(`(max-width: ${NAV_BREAKPOINT - 1}px)`) : null;
   if(navMq){
-    navMqListener=e=>{ e.matches ? open() : close(); };
+    navMqListener=e=>{ e.matches ? close() : open(); };
     navMq.addEventListener('change', navMqListener);
-    navMq.matches ? open() : close();
+    navMq.matches ? close() : open();
   }else{
     close();
   }


### PR DESCRIPTION
## Summary
- open nav without overlay or scroll lock on desktop sizes
- switch nav toggle media query to use max-width breakpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5152718048320b1cd508efe51bd0b