### PR TITLE
fix: prevent topbar toggle from stealing focus

### DIFF
--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -13,6 +13,7 @@ export function initNavToggle(toggle, nav){
   toggle.setAttribute('aria-expanded','false');
   const overlay=document.querySelector('.nav-overlay');
   const focusableSel='a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+  let focusToggle=false;
   function close(){
     document.body.classList.remove('nav-open');
     toggle.setAttribute('aria-expanded','false');
@@ -21,7 +22,10 @@ export function initNavToggle(toggle, nav){
     if(overlay) overlay.hidden=true;
     document.body.style.overflow='';
     document.removeEventListener('keydown', trap);
-    toggle.focus();
+    if(focusToggle){
+      toggle.focus();
+      focusToggle=false;
+    }
   }
   function trap(e){
     if(e.key==='Tab'){
@@ -35,6 +39,7 @@ export function initNavToggle(toggle, nav){
         if(document.activeElement===last){ e.preventDefault(); first.focus(); }
       }
     }else if(e.key==='Escape'){
+      focusToggle=true;
       close();
     }
   }
@@ -50,13 +55,18 @@ export function initNavToggle(toggle, nav){
     document.addEventListener('keydown', trap);
   }
   toggle.addEventListener('click',()=>{
-    document.body.classList.contains('nav-open') ? close() : open();
+    if(document.body.classList.contains('nav-open')){
+      focusToggle=true;
+      close();
+    }else{
+      open();
+    }
   });
   if(overlay){
-    overlay.addEventListener('click', close);
+    overlay.addEventListener('click', ()=>{ focusToggle=true; close(); });
   }
   nav.addEventListener('click',e=>{
-    if(e.target.closest('.tab')) close();
+    if(e.target.closest('.tab')){ focusToggle=true; close(); }
   });
   navMq=typeof matchMedia==='function' ? matchMedia(`(min-width: ${NAV_BREAKPOINT}px)`) : null;
   if(navMq){
@@ -73,6 +83,7 @@ export function initPatientMenuToggle(toggle, menu){
   const overlay=document.querySelector('.patient-menu-overlay');
   const focusableSel='a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
   const mq=typeof matchMedia==='function' ? matchMedia(`(min-width: ${NAV_BREAKPOINT}px)`) : null;
+  let focusToggle=false;
   function close(){
     document.body.classList.remove('patient-menu-open');
     toggle.setAttribute('aria-expanded','false');
@@ -81,7 +92,10 @@ export function initPatientMenuToggle(toggle, menu){
     if(overlay) overlay.hidden=true;
     document.body.style.overflow='';
     document.removeEventListener('keydown', trap);
-    toggle.focus();
+    if(focusToggle){
+      toggle.focus();
+      focusToggle=false;
+    }
   }
   function trap(e){
     if(e.key==='Tab'){
@@ -95,6 +109,7 @@ export function initPatientMenuToggle(toggle, menu){
         if(document.activeElement===last){ e.preventDefault(); first.focus(); }
       }
     }else if(e.key==='Escape'){
+      focusToggle=true;
       close();
     }
   }
@@ -110,9 +125,14 @@ export function initPatientMenuToggle(toggle, menu){
     document.addEventListener('keydown', trap);
   }
   toggle.addEventListener('click',()=>{
-    document.body.classList.contains('patient-menu-open') ? close() : open();
+    if(document.body.classList.contains('patient-menu-open')){
+      focusToggle=true;
+      close();
+    }else{
+      open();
+    }
   });
-  if(overlay){ overlay.addEventListener('click', close); }
+  if(overlay){ overlay.addEventListener('click', ()=>{ focusToggle=true; close(); }); }
   const update=()=>{ if(mq && mq.matches) open(); else close(); };
   if(mq){ mq.addEventListener('change', update); }
   update();

--- a/public/js/__tests__/navToggle.test.js
+++ b/public/js/__tests__/navToggle.test.js
@@ -1,10 +1,11 @@
 describe('initNavToggle',()=>{
   const { initNavToggle } = require('../components/topbar.js');
-  let toggle, nav, tabs;
+  let toggle, nav, tabs, overlay;
   beforeEach(()=>{
-    document.body.innerHTML=`<button id="navToggle">Menu</button><nav id="tabs"><a href="#" class="tab">One</a><a href="#" class="tab">Two</a></nav>`;
+    document.body.innerHTML=`<button id="navToggle">Menu</button><nav id="tabs"><a href="#" class="tab">One</a><a href="#" class="tab">Two</a></nav><div class="nav-overlay"></div>`;
     toggle=document.getElementById('navToggle');
     nav=document.getElementById('tabs');
+    overlay=document.querySelector('.nav-overlay');
     initNavToggle(toggle, nav);
     tabs=nav.querySelectorAll('.tab');
   });
@@ -20,6 +21,10 @@ describe('initNavToggle',()=>{
     expect(document.activeElement).toBe(tabs[0]);
   });
 
+  test('does not focus toggle on init',()=>{
+    expect(document.activeElement).not.toBe(toggle);
+  });
+
   test('closes on Escape key',()=>{
     toggle.click();
     document.dispatchEvent(new KeyboardEvent('keydown',{key:'Escape'}));
@@ -32,6 +37,15 @@ describe('initNavToggle',()=>{
   test('closes when tab clicked',()=>{
     toggle.click();
     tabs[0].click();
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(nav.getAttribute('aria-hidden')).toBe('true');
+    expect(document.body.classList.contains('nav-open')).toBe(false);
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  test('closes when overlay clicked',()=>{
+    toggle.click();
+    overlay.click();
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     expect(nav.getAttribute('aria-hidden')).toBe('true');
     expect(document.body.classList.contains('nav-open')).toBe(false);

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -13,6 +13,7 @@ export function initNavToggle(toggle, nav){
   toggle.setAttribute('aria-expanded','false');
   const overlay=document.querySelector('.nav-overlay');
   const focusableSel='a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+  let focusToggle=false;
   function close(){
     document.body.classList.remove('nav-open');
     toggle.setAttribute('aria-expanded','false');
@@ -21,7 +22,10 @@ export function initNavToggle(toggle, nav){
     if(overlay) overlay.hidden=true;
     document.body.style.overflow='';
     document.removeEventListener('keydown', trap);
-    toggle.focus();
+    if(focusToggle){
+      toggle.focus();
+      focusToggle=false;
+    }
   }
   function trap(e){
     if(e.key==='Tab'){
@@ -35,6 +39,7 @@ export function initNavToggle(toggle, nav){
         if(document.activeElement===last){ e.preventDefault(); first.focus(); }
       }
     }else if(e.key==='Escape'){
+      focusToggle=true;
       close();
     }
   }
@@ -52,13 +57,18 @@ export function initNavToggle(toggle, nav){
     document.addEventListener('keydown', trap);
   }
   toggle.addEventListener('click',()=>{
-    document.body.classList.contains('nav-open') ? close() : open();
+    if(document.body.classList.contains('nav-open')){
+      focusToggle=true;
+      close();
+    }else{
+      open();
+    }
   });
   if(overlay){
-    overlay.addEventListener('click', close);
+    overlay.addEventListener('click', ()=>{ focusToggle=true; close(); });
   }
   nav.addEventListener('click',e=>{
-    if(e.target.closest('.tab')) close();
+    if(e.target.closest('.tab')){ focusToggle=true; close(); }
   });
   navMq=typeof matchMedia==='function' ? matchMedia(`(max-width: ${NAV_BREAKPOINT - 1}px)`) : null;
   if(navMq){
@@ -75,6 +85,7 @@ export function initPatientMenuToggle(toggle, menu){
   const overlay=document.querySelector('.patient-menu-overlay');
   const focusableSel='a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
   const mq=typeof matchMedia==='function' ? matchMedia(`(min-width: ${NAV_BREAKPOINT}px)`) : null;
+  let focusToggle=false;
   function close(){
     document.body.classList.remove('patient-menu-open');
     toggle.setAttribute('aria-expanded','false');
@@ -83,7 +94,10 @@ export function initPatientMenuToggle(toggle, menu){
     if(overlay) overlay.hidden=true;
     document.body.style.overflow='';
     document.removeEventListener('keydown', trap);
-    toggle.focus();
+    if(focusToggle){
+      toggle.focus();
+      focusToggle=false;
+    }
   }
   function trap(e){
     if(e.key==='Tab'){
@@ -97,6 +111,7 @@ export function initPatientMenuToggle(toggle, menu){
         if(document.activeElement===last){ e.preventDefault(); first.focus(); }
       }
     }else if(e.key==='Escape'){
+      focusToggle=true;
       close();
     }
   }
@@ -112,9 +127,14 @@ export function initPatientMenuToggle(toggle, menu){
     document.addEventListener('keydown', trap);
   }
   toggle.addEventListener('click',()=>{
-    document.body.classList.contains('patient-menu-open') ? close() : open();
+    if(document.body.classList.contains('patient-menu-open')){
+      focusToggle=true;
+      close();
+    }else{
+      open();
+    }
   });
-  if(overlay){ overlay.addEventListener('click', close); }
+  if(overlay){ overlay.addEventListener('click', ()=>{ focusToggle=true; close(); }); }
   const update=()=>{ if(mq && mq.matches) open(); else close(); };
   if(mq){ mq.addEventListener('change', update); }
   update();


### PR DESCRIPTION
## Summary
- avoid focusing nav and patient menu toggles on programmatic close
- restore focus only after user-initiated close events
- add regression tests for initial focus and overlay closing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b522014b2883209370c8bdb85066d2