### PR TITLE
fix: preserve nav on desktop tab clicks

### DIFF
--- a/public/js/__tests__/navToggle.test.js
+++ b/public/js/__tests__/navToggle.test.js
@@ -1,40 +1,58 @@
 describe('initNavToggle',()=>{
   const { initNavToggle } = require('../components/topbar.js');
   let toggle, nav, tabs;
-  beforeEach(()=>{
+
+  function setup(matches){
     document.body.innerHTML=`<button id="navToggle">Menu</button><nav id="tabs"><a href="#" class="tab">One</a><a href="#" class="tab">Two</a></nav>`;
     toggle=document.getElementById('navToggle');
     nav=document.getElementById('tabs');
+    global.matchMedia = jest.fn().mockReturnValue({ matches, addEventListener: jest.fn(), removeEventListener: jest.fn() });
     initNavToggle(toggle, nav);
     tabs=nav.querySelectorAll('.tab');
+  }
+
+  describe('mobile',()=>{
+    beforeEach(()=>setup(false));
+
+    test('opens menu and traps focus',()=>{
+      toggle.click();
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
+      expect(nav.hasAttribute('aria-hidden')).toBe(false);
+      expect(document.body.classList.contains('nav-open')).toBe(true);
+      expect(document.activeElement).toBe(tabs[0]);
+      tabs[1].focus();
+      document.dispatchEvent(new KeyboardEvent('keydown',{key:'Tab'}));
+      expect(document.activeElement).toBe(tabs[0]);
+    });
+
+    test('closes on Escape key',()=>{
+      toggle.click();
+      document.dispatchEvent(new KeyboardEvent('keydown',{key:'Escape'}));
+      expect(toggle.getAttribute('aria-expanded')).toBe('false');
+      expect(nav.getAttribute('aria-hidden')).toBe('true');
+      expect(document.body.classList.contains('nav-open')).toBe(false);
+      expect(document.activeElement).toBe(toggle);
+    });
+
+    test('closes when tab clicked',()=>{
+      toggle.click();
+      tabs[0].click();
+      expect(toggle.getAttribute('aria-expanded')).toBe('false');
+      expect(nav.getAttribute('aria-hidden')).toBe('true');
+      expect(document.body.classList.contains('nav-open')).toBe(false);
+      expect(document.activeElement).toBe(toggle);
+    });
   });
 
-  test('opens menu and traps focus',()=>{
-    toggle.click();
-    expect(toggle.getAttribute('aria-expanded')).toBe('true');
-    expect(nav.hasAttribute('aria-hidden')).toBe(false);
-    expect(document.body.classList.contains('nav-open')).toBe(true);
-    expect(document.activeElement).toBe(tabs[0]);
-    tabs[1].focus();
-    document.dispatchEvent(new KeyboardEvent('keydown',{key:'Tab'}));
-    expect(document.activeElement).toBe(tabs[0]);
-  });
+  describe('desktop',()=>{
+    beforeEach(()=>setup(true));
 
-  test('closes on Escape key',()=>{
-    toggle.click();
-    document.dispatchEvent(new KeyboardEvent('keydown',{key:'Escape'}));
-    expect(toggle.getAttribute('aria-expanded')).toBe('false');
-    expect(nav.getAttribute('aria-hidden')).toBe('true');
-    expect(document.body.classList.contains('nav-open')).toBe(false);
-    expect(document.activeElement).toBe(toggle);
-  });
-
-  test('closes when tab clicked',()=>{
-    toggle.click();
-    tabs[0].click();
-    expect(toggle.getAttribute('aria-expanded')).toBe('false');
-    expect(nav.getAttribute('aria-hidden')).toBe('true');
-    expect(document.body.classList.contains('nav-open')).toBe(false);
-    expect(document.activeElement).toBe(toggle);
+    test('does not close when tab clicked',()=>{
+      tabs[0].click();
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
+      expect(nav.hasAttribute('aria-hidden')).toBe(false);
+      expect(document.body.classList.contains('nav-open')).toBe(true);
+    });
   });
 });
+

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -56,7 +56,7 @@ export function initNavToggle(toggle, nav){
     overlay.addEventListener('click', close);
   }
   nav.addEventListener('click',e=>{
-    if(e.target.closest('.tab')) close();
+    if(e.target.closest('.tab') && (navMq ? !navMq.matches : window.innerWidth < NAV_BREAKPOINT)) close();
   });
   navMq=typeof matchMedia==='function' ? matchMedia(`(min-width: ${NAV_BREAKPOINT}px)`) : null;
   if(navMq){


### PR DESCRIPTION
## Summary
- only close navigation on tab clicks when viewport is below the nav breakpoint
- cover mobile vs desktop behavior in nav toggle tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b56d93d94c8320a4baf0b160aab161