### PR TITLE
Show nav overlay only on small viewports

### DIFF
--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -42,8 +42,13 @@ export function initNavToggle(toggle, nav){
     toggle.setAttribute('aria-expanded','true');
     nav.removeAttribute('aria-hidden');
     nav.removeAttribute('hidden');
-    if(overlay) overlay.hidden=false;
-    document.body.style.overflow='hidden';
+    if(!navMq || !navMq.matches){
+      if(overlay) overlay.hidden=false;
+      document.body.style.overflow='hidden';
+    }else{
+      if(overlay) overlay.hidden=true;
+      document.body.style.overflow='';
+    }
     const items=nav.querySelectorAll(focusableSel);
     if(items.length) items[0].focus();
     document.addEventListener('keydown', trap);


### PR DESCRIPTION
## Summary
- only show nav overlay and disable background scroll on small screens

## Testing
- `node --experimental-loader data:text/javascript, --no-warnings <<'NODE'\nimport { JSDOM } from 'jsdom';\nimport * as topbar from 'file:///tmp/topbar.mjs';\n\nfunction createMatchMedia(matches){\n  return query => ({\n    matches,\n    addEventListener(){},\n    removeEventListener(){},\n  });\n}\n\n(async () => {\n  // mobile: no matchMedia\n  let dom = new JSDOM(`<body><button id="toggle"></button><nav hidden aria-hidden="true"><a href="#">Link</a></nav><div class="nav-overlay" hidden></div></body>`);\n  global.document = dom.window.document;\n  global.window = dom.window;\n  global.matchMedia = undefined;\n  topbar.initNavToggle(document.getElementById('toggle'), document.querySelector('nav'));\n  document.getElementById('toggle').click();\n  console.log('mobile overlay hidden?', document.querySelector('.nav-overlay').hidden);\n  console.log('mobile body overflow', document.body.style.overflow);\n\n  // desktop: matchMedia matches true\n  dom = new JSDOM(`<body><button id="toggle2"></button><nav hidden aria-hidden="true"><a href="#">Link</a></nav><div class="nav-overlay" hidden></div></body>`);\n  global.document = dom.window.document;\n  global.window = dom.window;\n  global.matchMedia = createMatchMedia(true);\n  topbar.initNavToggle(document.getElementById('toggle2'), document.querySelector('nav'));\n  document.getElementById('toggle2').click();\n  console.log('desktop overlay hidden?', document.querySelector('.nav-overlay').hidden);\n  console.log('desktop body overflow', document.body.style.overflow);\n})();\nNODE`
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b5a33053508320acf2b084e32f9133