### PR TITLE
Fix navigation hiding when tabs are clicked

### DIFF
--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -59,9 +59,9 @@ export function initNavToggle(toggle, nav){
   if(overlay){
     overlay.addEventListener('click', close);
   }
-  nav.addEventListener('click',e=>{
-    if(e.target.closest('.tab')) close();
-  });
+  // Clicking a tab should no longer hide the navigation menu. The handler
+  // that previously closed the menu on tab clicks has been removed to keep
+  // the navigation visible.
   navMq=typeof matchMedia==='function' ? matchMedia(`(min-width: ${NAV_BREAKPOINT}px)`) : null;
   if(navMq){
     navMqListener=e=>{ e.matches ? open() : close(); };

--- a/public/js/__tests__/navToggle.test.js
+++ b/public/js/__tests__/navToggle.test.js
@@ -34,13 +34,13 @@ describe('initNavToggle',()=>{
       expect(document.activeElement).toBe(toggle);
     });
 
-    test('closes when tab clicked',()=>{
+    test('does not close when tab clicked',()=>{
       toggle.click();
       tabs[0].click();
-      expect(toggle.getAttribute('aria-expanded')).toBe('false');
-      expect(nav.getAttribute('aria-hidden')).toBe('true');
-      expect(document.body.classList.contains('nav-open')).toBe(false);
-      expect(document.activeElement).toBe(toggle);
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
+      expect(nav.hasAttribute('aria-hidden')).toBe(false);
+      expect(document.body.classList.contains('nav-open')).toBe(true);
+      expect(document.activeElement).toBe(tabs[0]);
     });
   });
 

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -56,9 +56,10 @@ export function initNavToggle(toggle, nav){
   if(overlay){
     overlay.addEventListener('click', close);
   }
-  nav.addEventListener('click',e=>{
-    if(e.target.closest('.tab') && (navMq ? !navMq.matches : window.innerWidth < NAV_BREAKPOINT)) close();
-  });
+  // Previously, clicking on a navigation tab would close the navigation
+  // when viewed on smaller screens. This caused the navigation to hide
+  // unexpectedly. The click handler has been removed so the navigation
+  // remains visible after selecting a tab.
   navMq=typeof matchMedia==='function' ? matchMedia(`(min-width: ${NAV_BREAKPOINT}px)`) : null;
   if(navMq){
     navMqListener=e=>{ e.matches ? open() : close(); };


### PR DESCRIPTION
## Summary
- remove handler that hid navigation after selecting a tab
- adjust nav toggle tests to expect menu to stay open
- mirror change in docs build output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5a573f8f083208255ab1a986e03f9