### PR TITLE
Keep desktop navigation visible after tab clicks

### DIFF
--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -59,6 +59,12 @@ export function initNavToggle(toggle, nav){
   if(overlay){
     overlay.addEventListener('click', close);
   }
+  // Ensure the navigation stays open on desktop after tab clicks.
+  nav.addEventListener('click',()=>{
+    if(navMq && navMq.matches){
+      setTimeout(open);
+    }
+  });
   // Clicking a tab should no longer hide the navigation menu. The handler
   // that previously closed the menu on tab clicks has been removed to keep
   // the navigation visible.

--- a/public/js/__tests__/navToggle.test.js
+++ b/public/js/__tests__/navToggle.test.js
@@ -53,6 +53,20 @@ describe('initNavToggle',()=>{
       expect(nav.hasAttribute('aria-hidden')).toBe(false);
       expect(document.body.classList.contains('nav-open')).toBe(true);
     });
+
+    test('reopens if another handler hides it', () => {
+      jest.useFakeTimers();
+      tabs[0].addEventListener('click', () => {
+        nav.setAttribute('hidden','');
+        nav.setAttribute('aria-hidden','true');
+        document.body.classList.remove('nav-open');
+      });
+      tabs[0].click();
+      jest.runAllTimers();
+      expect(nav.hasAttribute('hidden')).toBe(false);
+      expect(document.body.classList.contains('nav-open')).toBe(true);
+      jest.useRealTimers();
+    });
   });
 });
 

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -56,6 +56,12 @@ export function initNavToggle(toggle, nav){
   if(overlay){
     overlay.addEventListener('click', close);
   }
+  // Ensure the navigation stays open on desktop after tab clicks.
+  nav.addEventListener('click', () => {
+    if(navMq && navMq.matches){
+      setTimeout(open);
+    }
+  });
   // Previously, clicking on a navigation tab would close the navigation
   // when viewed on smaller screens. This caused the navigation to hide
   // unexpectedly. The click handler has been removed so the navigation


### PR DESCRIPTION
## Summary
- keep top navigation menu visible on desktop after selecting a tab
- add regression test ensuring nav reopens if other handlers hide it

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5a7dd0f808320b5846be5c54d8d9d