### PR TITLE
fix: close navigation after selecting a page

### DIFF
--- a/public/js/__tests__/navToggle.test.js
+++ b/public/js/__tests__/navToggle.test.js
@@ -34,13 +34,13 @@ describe('initNavToggle',()=>{
       expect(document.activeElement).toBe(toggle);
     });
 
-    test('does not close when tab clicked',()=>{
+    test('closes when tab clicked',()=>{
       toggle.click();
       tabs[0].click();
-      expect(toggle.getAttribute('aria-expanded')).toBe('true');
-      expect(nav.hasAttribute('aria-hidden')).toBe(false);
-      expect(document.body.classList.contains('nav-open')).toBe(true);
-      expect(document.activeElement).toBe(tabs[0]);
+      expect(toggle.getAttribute('aria-expanded')).toBe('false');
+      expect(nav.getAttribute('aria-hidden')).toBe('true');
+      expect(document.body.classList.contains('nav-open')).toBe(false);
+      expect(document.activeElement).toBe(toggle);
     });
   });
 

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -56,16 +56,15 @@ export function initNavToggle(toggle, nav){
   if(overlay){
     overlay.addEventListener('click', close);
   }
-  // Ensure the navigation stays open on desktop after tab clicks.
+  // Close the navigation after selecting a tab on small screens while
+  // keeping it open on desktop.
   nav.addEventListener('click', () => {
     if(navMq && navMq.matches){
       setTimeout(open);
+    }else{
+      close();
     }
   });
-  // Previously, clicking on a navigation tab would close the navigation
-  // when viewed on smaller screens. This caused the navigation to hide
-  // unexpectedly. The click handler has been removed so the navigation
-  // remains visible after selecting a tab.
   navMq=typeof matchMedia==='function' ? matchMedia(`(min-width: ${NAV_BREAKPOINT}px)`) : null;
   if(navMq){
     navMqListener=e=>{ e.matches ? open() : close(); };


### PR DESCRIPTION
## Summary
- Close the navigation menu after choosing a tab on small screens
- Keep navigation open on desktop and update unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5eec756188320ac4baaae8bab42d0