### PR TITLE
feat: add offline caching and background sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ debugging:
 After refreshing authentication tokens, call `setAuthToken()` followed
 by `reconnectSocket()` to manually re-establish the connection.
 
+## Offline Support
+
+The application registers a service worker to cache static assets and to
+queue session data when saves fail. Changes made while offline are stored
+locally and sent to the server automatically once connectivity returns.
+
+### Testing Service Worker Changes
+
+Service workers are aggressively cached by browsers. After modifying
+`public/sw.js`:
+
+1. Run the development server and load the app to register the worker.
+2. Use your browser's developer tools (Application → Service Workers) to
+   **Unregister** the worker or perform a hard reload to pick up changes.
+3. To test background sync, switch the network panel to “Offline,” make
+   some edits, then go back online; the queued data should sync
+   automatically.
+
 ## Stylesheets
 
 The CSS is generated from Sass files in `css/scss`:

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -121,6 +121,9 @@ function clampNumberInputs(){
 
 /* ===== Init modules ===== */
 async function init(){
+  if(typeof navigator !== 'undefined' && 'serviceWorker' in navigator){
+    navigator.serviceWorker.register('/sw.js');
+  }
   await initTopbar();
   setupHeaderActions({ validateForm });
   connectSocket({

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -58,6 +58,13 @@ export async function saveAll(){
       if(!res.ok) throw new Error(res.status);
       if(statusEl){ statusEl.textContent='Saved'; statusEl.classList.remove('offline'); }
     }catch(e){
+      if(typeof navigator !== 'undefined' && 'serviceWorker' in navigator){
+        const msg = { type: 'queue-session', id: currentSessionId, data, token: authToken };
+        navigator.serviceWorker.ready.then(reg => {
+          reg.active?.postMessage(msg);
+          reg.sync.register('sync-sessions');
+        });
+      }
       if(statusEl){ statusEl.textContent='Save failed'; statusEl.classList.add('offline'); }
     }
   } else if(statusEl){

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,122 @@
+const CACHE_NAME = 'trauma-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/css/main.css',
+  '/js/app.js'
+];
+
+const SYNC_TAG = 'sync-sessions';
+const DB_NAME = 'trauma-sync';
+const STORE_NAME = 'queue';
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+    ))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if(event.request.method !== 'GET') return;
+  event.respondWith(
+    fetch(event.request).then(res => {
+      const copy = res.clone();
+      caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+      return res;
+    }).catch(() => caches.match(event.request))
+  );
+});
+
+self.addEventListener('message', event => {
+  const msg = event.data || {};
+  if(msg.type === 'queue-session'){
+    event.waitUntil(
+      queueRequest(msg.id, msg.data, msg.token).then(() => {
+        return self.registration.sync.register(SYNC_TAG);
+      })
+    );
+  }
+});
+
+self.addEventListener('sync', event => {
+  if(event.tag === SYNC_TAG){
+    event.waitUntil(processQueue());
+  }
+});
+
+function openDb(){
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME);
+    };
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+async function queueRequest(id, data, token){
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put({ data, token }, id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function getAll(){
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const dataReq = store.getAll();
+    const keyReq = store.getAllKeys();
+    tx.oncomplete = () => {
+      const items = keyReq.result.map((id, i) => ({ id, value: dataReq.result[i] }));
+      resolve(items);
+    };
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function clear(id){
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function processQueue(){
+  const items = await getAll();
+  for(const { id, value } of items){
+    const { data, token } = value;
+    try{
+      const res = await fetch(`/api/sessions/${id}/data`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + token
+        },
+        body: JSON.stringify(data)
+      });
+      if(res.ok) await clear(id);
+    }catch(e){
+      // Leave in queue for next sync
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add service worker with asset caching and background sync queue
- register service worker during app initialization
- enqueue failed session saves for background sync
- document offline support and developer testing steps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5efc5ffb88320993cb55cea7ec674