### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/docs/assets/partials/topbar.html
+++ b/docs/assets/partials/topbar.html
@@ -21,7 +21,9 @@
     </div>
   </div>
   <div class="header-actions">
-    <div class="toolbar" id="desktopActions"></div>
+    <div class="toolbar" id="desktopActions">
+      <button type="button" class="btn" id="btnTheme">Light mode</button>
+    </div>
     <div class="status-wrap">
       <div id="userList" class="user-list"></div>
       <div id="saveStatus" aria-live="polite"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sunkios traumos forma</title>
 <script>
-  document.documentElement.classList.add('dark','js');
+  const savedTheme = localStorage.getItem('trauma_theme') || 'dark';
+  document.documentElement.classList.add(savedTheme,'js');
 </script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/main.css">

--- a/docs/js/headerActions.js
+++ b/docs/js/headerActions.js
@@ -2,7 +2,7 @@ import { $ } from './utils.js';
 import { notify } from './alerts.js';
 import { startArrivalTimer } from './arrival.js';
 import { showTab } from './tabs.js';
-import { getAuthToken, logout } from './sessionManager.js';
+import { getAuthToken, logout, setTheme } from './sessionManager.js';
 import bodyMap from './bodyMap.js';
 
 export function setupHeaderActions({ validateForm }){
@@ -72,13 +72,34 @@ export function setupHeaderActions({ validateForm }){
   }));
 
   const actionsBar=document.getElementById('desktopActions');
-  if(actionsBar && getAuthToken() && !document.getElementById('btnLogout')){
-    const btn=document.createElement('button');
-    btn.type='button';
-    btn.className='btn';
-    btn.id='btnLogout';
-    btn.textContent='Logout';
-    btn.addEventListener('click',()=>logout());
-    actionsBar.appendChild(btn);
+  if(actionsBar){
+    let themeBtn=document.getElementById('btnTheme');
+    if(!themeBtn){
+      themeBtn=document.createElement('button');
+      themeBtn.type='button';
+      themeBtn.className='btn';
+      themeBtn.id='btnTheme';
+      actionsBar.appendChild(themeBtn);
+    }
+    const updateThemeBtn=()=>{
+      const dark=document.documentElement.classList.contains('dark');
+      themeBtn.textContent=dark?'Light mode':'Dark mode';
+    };
+    themeBtn.addEventListener('click',()=>{
+      const next=document.documentElement.classList.contains('dark')?'light':'dark';
+      setTheme(next);
+      updateThemeBtn();
+    });
+    updateThemeBtn();
+
+    if(getAuthToken() && !document.getElementById('btnLogout')){
+      const btn=document.createElement('button');
+      btn.type='button';
+      btn.className='btn';
+      btn.id='btnLogout';
+      btn.textContent='Logout';
+      btn.addEventListener('click',()=>logout());
+      actionsBar.appendChild(btn);
+    }
   }
 }

--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -3,13 +3,20 @@ import bodyMap from './bodyMap.js';
 
 let authToken = localStorage.getItem('trauma_token') || null;
 let currentSessionId = localStorage.getItem('trauma_current_session') || null;
+let theme = localStorage.getItem('trauma_theme') || 'dark';
 
 const MAX_FIELD_LENGTH = 500;
 const limit = (val, max = MAX_FIELD_LENGTH) => (val || '').toString().slice(0, max);
 
+export function setTheme(t){
+  theme = t === 'light' ? 'light' : 'dark';
+  localStorage.setItem('trauma_theme', theme);
+  document.documentElement.classList.remove('light','dark');
+  document.documentElement.classList.add(theme);
+}
+
 export function initTheme(){
-  document.documentElement.classList.remove('light');
-  document.documentElement.classList.add('dark');
+  setTheme(theme);
 }
 
 export function sessionKey(){

--- a/public/assets/partials/topbar.html
+++ b/public/assets/partials/topbar.html
@@ -34,7 +34,9 @@
     </div>
   </div>
   <div class="header-actions">
-    <div class="toolbar" id="desktopActions"></div>
+    <div class="toolbar" id="desktopActions">
+      <button type="button" class="btn" id="btnTheme">Light mode</button>
+    </div>
     <div class="status-wrap">
       <div id="userList" class="user-list"></div>
       <div id="saveStatus" aria-live="polite"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sunkios traumos forma</title>
 <script>
-  document.documentElement.classList.add('dark','js');
+  const savedTheme = localStorage.getItem('trauma_theme') || 'dark';
+  document.documentElement.classList.add(savedTheme,'js');
 </script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/main.css">

--- a/public/js/__tests__/headerActions.test.js
+++ b/public/js/__tests__/headerActions.test.js
@@ -1,8 +1,25 @@
 import { setupHeaderActions } from '../headerActions.js';
+import { setTheme } from '../sessionManager.js';
 
 describe('setupHeaderActions', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className='';
+    document.body.innerHTML='';
+    setTheme('dark');
+  });
+
   test('handles missing action buttons gracefully', () => {
-    document.body.innerHTML = '';
     expect(() => setupHeaderActions({ validateForm: () => true })).not.toThrow();
+  });
+
+  test('toggles theme when btnTheme is present', () => {
+    document.body.innerHTML='<div id="desktopActions"><button id="btnTheme" class="btn"></button></div>';
+    setupHeaderActions({ validateForm: () => true });
+    const btn=document.getElementById('btnTheme');
+    expect(btn.textContent).toBe('Light mode');
+    btn.click();
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+    expect(btn.textContent).toBe('Dark mode');
   });
 });

--- a/public/js/headerActions.js
+++ b/public/js/headerActions.js
@@ -73,23 +73,24 @@ export function setupHeaderActions({ validateForm }){
 
   const actionsBar=document.getElementById('desktopActions');
   if(actionsBar){
-    if(!document.getElementById('btnTheme')){
-      const themeBtn=document.createElement('button');
+    let themeBtn=document.getElementById('btnTheme');
+    if(!themeBtn){
+      themeBtn=document.createElement('button');
       themeBtn.type='button';
       themeBtn.className='btn';
       themeBtn.id='btnTheme';
-      const updateThemeBtn=()=>{
-        const dark=document.documentElement.classList.contains('dark');
-        themeBtn.textContent=dark?'Light mode':'Dark mode';
-      };
-      themeBtn.addEventListener('click',()=>{
-        const next=document.documentElement.classList.contains('dark')?'light':'dark';
-        setTheme(next);
-        updateThemeBtn();
-      });
-      updateThemeBtn();
       actionsBar.appendChild(themeBtn);
     }
+    const updateThemeBtn=()=>{
+      const dark=document.documentElement.classList.contains('dark');
+      themeBtn.textContent=dark?'Light mode':'Dark mode';
+    };
+    themeBtn.addEventListener('click',()=>{
+      const next=document.documentElement.classList.contains('dark')?'light':'dark';
+      setTheme(next);
+      updateThemeBtn();
+    });
+    updateThemeBtn();
 
     if(getAuthToken() && !document.getElementById('btnLogout')){
       const btn=document.createElement('button');


### PR DESCRIPTION
## Summary
- Add theme switch button to header so users can toggle between dark and light modes
- Persist preferred theme across reloads and include feature in documentation build
- Add unit test covering theme toggle behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f0dfb37c832096319d6f0d72bf74