### PR TITLE
fix: sync color scheme with light mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark light">
 <title>Sunkios traumos forma</title>
 <script>
   const savedTheme = localStorage.getItem('trauma_theme') || 'dark';

--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -11,8 +11,12 @@ const limit = (val, max = MAX_FIELD_LENGTH) => (val || '').toString().slice(0, m
 export function setTheme(t){
   theme = t === 'light' ? 'light' : 'dark';
   localStorage.setItem('trauma_theme', theme);
-  document.documentElement.classList.remove('light','dark');
-  document.documentElement.classList.add(theme);
+  const root=document.documentElement;
+  root.classList.remove('light','dark');
+  root.classList.add(theme);
+  root.style.colorScheme=theme;
+  const meta=document.querySelector('meta[name="color-scheme"]');
+  if(meta) meta.content=theme==='dark'?'dark light':'light dark';
 }
 
 export function initTheme(){

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark light">
 <title>Sunkios traumos forma</title>
 <script>
   const savedTheme = localStorage.getItem('trauma_theme') || 'dark';

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -11,8 +11,12 @@ let theme = localStorage.getItem('trauma_theme') || 'dark';
 export function setTheme(t){
   theme = t === 'light' ? 'light' : 'dark';
   localStorage.setItem('trauma_theme', theme);
-  document.documentElement.classList.remove('light', 'dark');
-  document.documentElement.classList.add(theme);
+  const root=document.documentElement;
+  root.classList.remove('light','dark');
+  root.classList.add(theme);
+  root.style.colorScheme=theme;
+  const meta=document.querySelector('meta[name="color-scheme"]');
+  if(meta) meta.content=theme==='dark'?'dark light':'light dark';
 }
 
 export function initTheme(){


### PR DESCRIPTION
## Summary
- update session theme management to set document color-scheme and meta tag
- declare color scheme in HTML to ensure form controls follow theme

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b695a4296c83208a1a0a7295a7409d