### PR TITLE
Add SVG icons to timeline and report buttons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -490,13 +490,48 @@
           <option value="proc">Procedūros</option>
         <option value="vital">Gyvybiniai rodikliai</option>
       </select>
-      <button type="button" class="btn" id="timelineExport">Eksportuoti</button>
-      <button type="button" class="btn" id="timelineClear">Išvalyti</button>
+      <button type="button" class="btn" id="timelineExport">
+        <svg class="btn-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"/>
+        </svg>
+        Eksportuoti
+      </button>
+      <button type="button" class="btn" id="timelineClear">
+        <svg class="btn-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M6 18 18 6M6 6l12 12"/>
+        </svg>
+        Išvalyti
+      </button>
     </div>
     <div id="timelineGraph" class="timeline-graph mb-8"></div>
     <div id="timelineList" class="timeline-list"></div>
   </section>
-    <section class="card view" id="view-santrauka" data-tab="Santrauka"><h2>Sugeneruotas tekstas</h2><textarea id="output" placeholder="Santrauka sugeneruojama automatiškai"></textarea><div class="row mb-8"><button type="button" class="btn" id="btnCopyReport">Kopijuoti</button><button type="button" class="btn" id="btnPdfReport">PDF</button><button type="button" class="btn" id="btnPrintReport">Spausdinti</button></div><div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div></section>
+    <section class="card view" id="view-santrauka" data-tab="Santrauka">
+      <h2>Sugeneruotas tekstas</h2>
+      <textarea id="output" placeholder="Santrauka sugeneruojama automatiškai"></textarea>
+      <div class="row mb-8">
+        <button type="button" class="btn" id="btnCopyReport">
+          <svg class="btn-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"/>
+          </svg>
+          Kopijuoti
+        </button>
+        <button type="button" class="btn" id="btnPdfReport">
+          <svg class="btn-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"/>
+          </svg>
+          PDF
+        </button>
+        <button type="button" class="btn" id="btnPrintReport">
+          <svg class="btn-icon" aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M2.5 8a.5.5 0 1 0 0-1 .5.5 0 0 0 0 1"/>
+            <path d="M5 1a2 2 0 0 0-2 2v2H2a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h1v1a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-1h1a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-1V3a2 2 0 0 0-2-2zM4 3a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2H4zm1 5a2 2 0 0 0-2 2v1H2a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-1v-1a2 2 0 0 0-2-2zm7 2v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1"/>
+          </svg>
+          Spausdinti
+        </button>
+      </div>
+      <div class="hint">Tekstą galima įklijuoti į LIS/ESIS.</div>
+    </section>
   </div>
 </main>
 


### PR DESCRIPTION
## Summary
- prepend inline SVG icons to timeline export/clear buttons
- add SVG icons to report copy/PDF/print buttons using existing `btn-icon` styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b69f03e68c83209e1bdf3325ebfd3d