### PR TITLE
fix: restore page scrolling on desktop

### DIFF
--- a/public/js/__tests__/navToggle.test.js
+++ b/public/js/__tests__/navToggle.test.js
@@ -51,7 +51,7 @@ describe('initNavToggle',()=>{
       tabs[0].click();
       expect(toggle.getAttribute('aria-expanded')).toBe('true');
       expect(nav.hasAttribute('aria-hidden')).toBe(false);
-      expect(document.body.classList.contains('nav-open')).toBe(true);
+      expect(document.body.classList.contains('nav-open')).toBe(false);
     });
 
     test('reopens if another handler hides it', () => {
@@ -59,12 +59,12 @@ describe('initNavToggle',()=>{
       tabs[0].addEventListener('click', () => {
         nav.setAttribute('hidden','');
         nav.setAttribute('aria-hidden','true');
-        document.body.classList.remove('nav-open');
+        document.body.classList.add('nav-open');
       });
       tabs[0].click();
       jest.runAllTimers();
       expect(nav.hasAttribute('hidden')).toBe(false);
-      expect(document.body.classList.contains('nav-open')).toBe(true);
+      expect(document.body.classList.contains('nav-open')).toBe(false);
       jest.useRealTimers();
     });
   });

--- a/public/js/__tests__/patientMenuToggle.test.js
+++ b/public/js/__tests__/patientMenuToggle.test.js
@@ -1,21 +1,37 @@
 describe('initPatientMenuToggle',()=>{
   const { initPatientMenuToggle } = require('../components/topbar.js');
   let toggle, menu;
-  beforeEach(()=>{
-    document.body.innerHTML='<button id="patientMenuToggle">Menu</button><div id="sessionBar" hidden aria-hidden="true"></div><div class="patient-menu-overlay" hidden></div>';
-    toggle=document.getElementById('patientMenuToggle');
-    menu=document.getElementById('sessionBar');
-    global.matchMedia = jest.fn().mockReturnValue({ matches:false, addEventListener: jest.fn() });
-    initPatientMenuToggle(toggle, menu);
+  describe('mobile',()=>{
+    beforeEach(()=>{
+      document.body.innerHTML='<button id="patientMenuToggle">Menu</button><div id="sessionBar" hidden aria-hidden="true"></div><div class="patient-menu-overlay" hidden></div>';
+      toggle=document.getElementById('patientMenuToggle');
+      menu=document.getElementById('sessionBar');
+      global.matchMedia = jest.fn().mockReturnValue({ matches:false, addEventListener: jest.fn() });
+      initPatientMenuToggle(toggle, menu);
+    });
+    test('toggles menu visibility',()=>{
+      expect(document.body.classList.contains('patient-menu-open')).toBe(false);
+      expect(menu.hasAttribute('hidden')).toBe(true);
+      toggle.click();
+      expect(document.body.classList.contains('patient-menu-open')).toBe(true);
+      expect(menu.hasAttribute('hidden')).toBe(false);
+      toggle.click();
+      expect(document.body.classList.contains('patient-menu-open')).toBe(false);
+      expect(menu.hasAttribute('hidden')).toBe(true);
+    });
   });
-  test('toggles menu visibility',()=>{
-    expect(document.body.classList.contains('patient-menu-open')).toBe(false);
-    expect(menu.hasAttribute('hidden')).toBe(true);
-    toggle.click();
-    expect(document.body.classList.contains('patient-menu-open')).toBe(true);
-    expect(menu.hasAttribute('hidden')).toBe(false);
-    toggle.click();
-    expect(document.body.classList.contains('patient-menu-open')).toBe(false);
-    expect(menu.hasAttribute('hidden')).toBe(true);
+
+  describe('desktop',()=>{
+    beforeEach(()=>{
+      document.body.innerHTML='<button id="patientMenuToggle">Menu</button><div id="sessionBar" aria-hidden="false"></div><div class="patient-menu-overlay" hidden></div>';
+      toggle=document.getElementById('patientMenuToggle');
+      menu=document.getElementById('sessionBar');
+      global.matchMedia = jest.fn().mockReturnValue({ matches:true, addEventListener: jest.fn(), removeEventListener: jest.fn() });
+      initPatientMenuToggle(toggle, menu);
+    });
+    test('does not lock scroll',()=>{
+      expect(menu.hasAttribute('hidden')).toBe(false);
+      expect(document.body.classList.contains('patient-menu-open')).toBe(false);
+    });
   });
 });

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -39,11 +39,11 @@ export function initNavToggle(toggle, nav){
     }
   }
   function open(){
-    document.body.classList.add('nav-open');
+    const mobile=!navMq || !navMq.matches;
+    document.body.classList.toggle('nav-open', mobile);
     toggle.setAttribute('aria-expanded','true');
     nav.removeAttribute('aria-hidden');
     nav.removeAttribute('hidden');
-    const mobile=!navMq || !navMq.matches;
     if(overlay) overlay.hidden=!mobile;
     document.body.style.overflow=mobile ? 'hidden' : '';
     const items=nav.querySelectorAll(focusableSel);
@@ -106,11 +106,11 @@ export function initPatientMenuToggle(toggle, menu){
     }
   }
   function open(){
-    document.body.classList.add('patient-menu-open');
+    const mobile=!mq || !mq.matches;
+    document.body.classList.toggle('patient-menu-open', mobile);
     toggle.setAttribute('aria-expanded','true');
     menu.removeAttribute('hidden');
     menu.removeAttribute('aria-hidden');
-    const mobile=!mq || !mq.matches;
     if(overlay) overlay.hidden=!mobile;
     document.body.style.overflow=mobile ? 'hidden' : '';
     const items=menu.querySelectorAll(focusableSel);


### PR DESCRIPTION
## Summary
- only lock body scroll for navigation and patient menus on small screens
- cover desktop behavior in nav and patient menu tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6bee7724c8320870618abf9de848b