### PR TITLE
Consolidate session management into modal

### DIFF
--- a/docs/assets/partials/topbar.html
+++ b/docs/assets/partials/topbar.html
@@ -18,6 +18,7 @@
     <div class="toolbar" id="sessionBar">
       <select id="sessionSelect" class="w-auto"></select>
         <button type="button" class="btn icon-btn" id="btnNewSession" aria-label="Nauja sesija" title="Nauja sesija"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
+        <button type="button" class="btn" id="btnManageSessions">Manage patients</button>
     </div>
   </div>
   <div class="header-actions">

--- a/public/assets/partials/topbar.html
+++ b/public/assets/partials/topbar.html
@@ -27,9 +27,7 @@
         </div>
         <select id="sessionSelect" class="w-auto"></select>
         <button type="button" class="btn icon-btn" id="btnNewSession" aria-label="Nauja sesija" title="Nauja sesija"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
-        <button type="button" class="btn icon-btn" id="btnRenameSession" aria-label="Pervardyti" title="Pervardyti"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg></button>
-        <button type="button" class="btn icon-btn" id="btnArchiveSession" aria-label="Archyvuoti" title="Archyvuoti"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="20" height="5" x="2" y="3" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg></button>
-        <button type="button" class="btn icon-btn" id="btnDeleteSession" aria-label="Ištrinti" title="Ištrinti"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></button>
+        <button type="button" class="btn" id="btnManageSessions">Manage patients</button>
       </div>
     </div>
   </div>

--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,7 @@
     </div>
     <select id="sessionSelect" class="w-auto"></select>
     <button type="button" class="btn" id="btnNewSession">Naujas</button>
+    <button type="button" class="btn" id="btnManageSessions">Manage patients</button>
   </div>
 </header>
 <template id="chip-template">


### PR DESCRIPTION
## Summary
- Drop standalone rename/archive/delete buttons and handle actions in Manage Patients modal
- Add inline rename, archive, and delete controls per patient row
- Simplify top bar to only show New and Manage Patients buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6c10939888320a09e6c1ecf45faea