### PR TITLE
Detect and initialize theme before other modules

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,8 +6,14 @@
 <meta name="color-scheme" content="dark light">
 <title>Sunkios traumos forma</title>
 <script>
-  const savedTheme = localStorage.getItem('trauma_theme') || 'dark';
-  document.documentElement.classList.add(savedTheme,'js');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const savedTheme = localStorage.getItem('trauma_theme');
+  const theme = savedTheme || (prefersDark ? 'dark' : 'light');
+  document.documentElement.classList.add(theme, 'js');
+  document.documentElement.style.colorScheme = theme;
+  const meta = document.querySelector('meta[name="color-scheme"]');
+  if (meta) meta.content = theme === 'dark' ? 'dark light' : 'light dark';
+  window.initialTheme = theme;
 </script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/main.css">
@@ -540,6 +546,10 @@
 
 <script src="https://unpkg.com/vis-timeline@8.3.0/standalone/umd/vis-timeline-graph2d.min.js"></script>
 <script src="https://cdn.socket.io/4.7.5/socket.io.min.js" integrity="sha384-2huaZvOR9iDzHqslqwpR87isEmrfxqyWOF7hr7BY6KG0+hVKLoEXMPUJw3ynWuhO" crossorigin="anonymous"></script>
+<script type="module">
+  import { initTheme } from './js/sessionManager.js';
+  initTheme();
+</script>
 <script src="js/app.js" defer type="module"></script>
 </body>
 </html>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -9,7 +9,7 @@ import './components/modal.js';
 import { initValidation, validateVitals } from './validation.js';
 import { initTopbar } from './components/topbar.js';
 import { initCollapsibles } from './sections.js';
-import { initTheme, saveAll, loadAll, getCurrentSessionId } from './sessionManager.js';
+import { saveAll, loadAll, getCurrentSessionId } from './sessionManager.js';
 import { connectSocket, fetchUsers } from './sessionApi.js';
 import { initSessions, populateSessionSelect, updateUserList } from './sessionUI.js';
 import bodyMap from './bodyMap.js';
@@ -139,7 +139,6 @@ function clampNumberInputs(){
 
 /* ===== Init modules ===== */
 async function init(){
-  initTheme();
   await initTopbar();
   setupHeaderActions({ validateForm });
   connectSocket({

--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -3,7 +3,7 @@ import bodyMap from './bodyMap.js';
 
 let authToken = localStorage.getItem('trauma_token') || null;
 let currentSessionId = localStorage.getItem('trauma_current_session') || null;
-let theme = localStorage.getItem('trauma_theme') || 'dark';
+let theme = localStorage.getItem('trauma_theme') || (typeof window !== 'undefined' ? window.initialTheme : null) || 'dark';
 
 const MAX_FIELD_LENGTH = 500;
 const limit = (val, max = MAX_FIELD_LENGTH) => (val || '').toString().slice(0, max);

--- a/public/index.html
+++ b/public/index.html
@@ -6,8 +6,14 @@
 <meta name="color-scheme" content="dark light">
 <title>Sunkios traumos forma</title>
 <script>
-  const savedTheme = localStorage.getItem('trauma_theme') || 'dark';
-  document.documentElement.classList.add(savedTheme,'js');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const savedTheme = localStorage.getItem('trauma_theme');
+  const theme = savedTheme || (prefersDark ? 'dark' : 'light');
+  document.documentElement.classList.add(theme, 'js');
+  document.documentElement.style.colorScheme = theme;
+  const meta = document.querySelector('meta[name="color-scheme"]');
+  if (meta) meta.content = theme === 'dark' ? 'dark light' : 'light dark';
+  window.initialTheme = theme;
 </script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/main.css">
@@ -540,6 +546,10 @@
 
 <script src="https://unpkg.com/vis-timeline@8.3.0/standalone/umd/vis-timeline-graph2d.min.js"></script>
 <script src="https://cdn.socket.io/4.7.5/socket.io.min.js" integrity="sha384-2huaZvOR9iDzHqslqwpR87isEmrfxqyWOF7hr7BY6KG0+hVKLoEXMPUJw3ynWuhO" crossorigin="anonymous"></script>
+<script type="module">
+  import { initTheme } from './js/sessionManager.js';
+  initTheme();
+</script>
 <script src="js/app.js" defer type="module"></script>
 </body>
 </html>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,7 +9,7 @@ import './components/modal.js';
 import { initValidation, validateVitals } from './validation.js';
 import { initTopbar } from './components/topbar.js';
 import { initCollapsibles } from './sections.js';
-import { initTheme, saveAll, loadAll, getCurrentSessionId } from './sessionManager.js';
+import { saveAll, loadAll, getCurrentSessionId } from './sessionManager.js';
 import { connectSocket, fetchUsers } from './sessionApi.js';
 import { initSessions, populateSessionSelect, updateUserList } from './sessionUI.js';
 import bodyMap from './bodyMap.js';
@@ -26,7 +26,6 @@ import { init as initVitalsEvents } from './vitalsEvents.js';
 import { initChipGroups } from './chipData.js';
 export { validateVitals, createChipGroup };
 
-initTheme();
 
 /* ===== Imaging / Labs / Team ===== */
 function createChipGroup(selector, values){

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -6,7 +6,7 @@ import { updateDomToggles } from './domToggles.js';
 
 let authToken = localStorage.getItem('trauma_token') || null;
 let currentSessionId = localStorage.getItem('trauma_current_session') || null;
-let theme = localStorage.getItem('trauma_theme') || 'dark';
+let theme = localStorage.getItem('trauma_theme') || (typeof window !== 'undefined' ? window.initialTheme : null) || 'dark';
 
 export function setTheme(t){
   theme = t === 'light' ? 'light' : 'dark';


### PR DESCRIPTION
## Summary
- Detect system color scheme on page load, applying HTML class and color-scheme meta before render.
- Default to detected scheme in sessionManager when no user preference exists and expose initial theme globally.
- Initialize theme in index.html before other modules load; remove redundant call in app.js and mirror changes in docs.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6cb9a8c2083209d6ea6a86d7db514