### PR TITLE
Fix topbar path to restore buttons

### DIFF
--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -82,7 +82,8 @@ export async function initTopbar(){
   const header=document.getElementById('appHeader');
   if(!header || typeof fetch!=='function') return;
   try{
-    const res=await fetch('assets/partials/topbar.html');
+    const base=typeof window!=='undefined'? (window.location.pathname.endsWith('/')?window.location.pathname:window.location.pathname+'/') : '/';
+    const res=await fetch(base+'assets/partials/topbar.html');
     if(res.ok){
       header.innerHTML=await res.text();
     }

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -130,7 +130,8 @@ export async function initTopbar(){
   const header=document.getElementById('appHeader');
   if(!header || typeof fetch!=='function') return;
   try{
-    const res=await fetch('assets/partials/topbar.html');
+    const base=typeof window!=='undefined'? (window.location.pathname.endsWith('/')?window.location.pathname:window.location.pathname+'/') : '/';
+    const res=await fetch(base+'assets/partials/topbar.html');
     if(!res.ok) throw new Error(`HTTP ${res.status}`);
     header.innerHTML=await res.text();
   }catch(e){


### PR DESCRIPTION
## Summary
- Load topbar partial using current URL base so buttons render even when the app is served from nested paths

## Testing
- `npm test`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68b6d0ce2f7883208f8f609e0fbd86c5