### PR TITLE
fix: resolve topbar partial from current directory

### DIFF
--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -82,8 +82,10 @@ export async function initTopbar(){
   const header=document.getElementById('appHeader');
   if(!header || typeof fetch!=='function') return;
   try{
-    const base=typeof window!=='undefined'? (window.location.pathname.endsWith('/')?window.location.pathname:window.location.pathname+'/') : '/';
-    const res=await fetch(base+'assets/partials/topbar.html');
+    const base=typeof window!=='undefined'
+      ? new URL('.', window.location.href).pathname
+      : '/';
+    const res=await fetch(base + 'assets/partials/topbar.html');
     if(res.ok){
       header.innerHTML=await res.text();
     }

--- a/public/js/__tests__/topbarPath.test.js
+++ b/public/js/__tests__/topbarPath.test.js
@@ -1,0 +1,19 @@
+import { initTopbar } from '../components/topbar.js';
+
+describe('initTopbar path resolution', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<header id="appHeader"></header>';
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+    window.history.replaceState({}, '', '/');
+  });
+
+  test('fetches topbar relative to current directory', async () => {
+    window.history.replaceState({}, '', '/docs/index.html');
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('<div></div>') });
+    await initTopbar();
+    expect(global.fetch).toHaveBeenCalledWith('/docs/assets/partials/topbar.html');
+  });
+});

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -130,8 +130,10 @@ export async function initTopbar(){
   const header=document.getElementById('appHeader');
   if(!header || typeof fetch!=='function') return;
   try{
-    const base=typeof window!=='undefined'? (window.location.pathname.endsWith('/')?window.location.pathname:window.location.pathname+'/') : '/';
-    const res=await fetch(base+'assets/partials/topbar.html');
+    const base=typeof window!=='undefined'
+      ? new URL('.', window.location.href).pathname
+      : '/';
+    const res=await fetch(base + 'assets/partials/topbar.html');
     if(!res.ok) throw new Error(`HTTP ${res.status}`);
     header.innerHTML=await res.text();
   }catch(e){


### PR DESCRIPTION
## Summary
- compute topbar partial path relative to current directory
- add regression test for topbar path resolution

## Testing
- `npm run test:client`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68b6db5eaff4832080928b98f0897608