### PR TITLE
Fix patient menu expansion and remove session sorting

### DIFF
--- a/docs/assets/partials/topbar.html
+++ b/docs/assets/partials/topbar.html
@@ -12,7 +12,7 @@
   </div>
   <div class="header-center">
     <div class="toolbar" id="arrivalBar">
-        <button type="button" class="btn icon-btn primary" id="btnAtvyko" aria-label="Atvyko" title="Atvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg></button>
+        <button type="button" class="btn icon-btn primary" id="btnAtvyko" aria-label="Atvyko" title="Atvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>Atvyko</button>
       <span id="arrivalTimer" class="arrival-timer" aria-live="polite"></span>
     </div>
     <div class="toolbar" id="sessionBar">

--- a/docs/js/sessionUI.js
+++ b/docs/js/sessionUI.js
@@ -10,13 +10,13 @@ export function updateUserList(users){
   if(el) el.textContent = users.length ? `Prisijungę: ${users.join(', ')}` : '';
 }
 
-export function populateSessionSelect(sel, sessions, { query = '', sortBy = 'created' } = {}){
+export function populateSessionSelect(sel, sessions, { query = '' } = {}){
   sel.innerHTML='';
   const q=query.trim().toLowerCase();
-  let list=sessions.filter(s=>(showArchived || !s.archived) && (!q || s.name.toLowerCase().includes(q)));
-  list=list.slice();
-  if(sortBy==='name') list.sort((a,b)=>a.name.localeCompare(b.name));
-  else list.sort((a,b)=>(a.created||0)-(b.created||0));
+  const list=sessions
+    .filter(s=>(showArchived || !s.archived) && (!q || s.name.toLowerCase().includes(q)))
+    .slice()
+    .sort((a,b)=>(a.created||0)-(b.created||0));
   list.forEach(s=>{ const opt=document.createElement('option'); opt.value=s.id; opt.textContent=s.name; sel.appendChild(opt); });
   return list;
 }
@@ -25,7 +25,6 @@ export async function initSessions(){
   const select=$('#sessionSelect');
   if(!select) return;
   const searchInput=$('#sessionSearch');
-  const sortSelect=$('#sessionSort');
   let sessions=await getSessions();
   let currentSessionId=getCurrentSessionId();
   let modal=$('#sessionManagerModal');
@@ -185,7 +184,7 @@ export async function initSessions(){
     }
   }
   const render=(focusId)=>{
-      const filtered=populateSessionSelect(select, sessions, { query: searchInput?.value || '', sortBy: sortSelect?.value || 'created' });
+      const filtered=populateSessionSelect(select, sessions, { query: searchInput?.value || '' });
       if(currentSessionId && filtered.some(s=>s.id===currentSessionId)){
         select.value=currentSessionId;
       }else{
@@ -205,7 +204,6 @@ export async function initSessions(){
       render();
     });
     searchInput?.addEventListener('input', ()=>render());
-    sortSelect?.addEventListener('change', ()=>render());
     if(!sessions.length){
       const id=Date.now().toString(36);
       sessions=[{id,name:'Pacientas Nr.1', archived:false, created:Date.now()}];

--- a/public/assets/partials/topbar.html
+++ b/public/assets/partials/topbar.html
@@ -11,8 +11,8 @@
     </div>
   </div>
   <div class="header-center">
-    <div class="toolbar" id="arrivalBar">
-    <button type="button" class="btn icon-btn primary" id="btnAtvyko" aria-label="Atvyko" title="Atvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg></button>
+      <div class="toolbar" id="arrivalBar">
+      <button type="button" class="btn icon-btn primary" id="btnAtvyko" aria-label="Atvyko" title="Atvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>Atvyko</button>
       <span id="arrivalTimer" class="arrival-timer" aria-live="polite"></span>
     </div>
     <div class="patient-menu">
@@ -20,10 +20,6 @@
       <div class="toolbar patient-menu-content" id="sessionBar" hidden aria-hidden="true">
         <div class="session-filter">
           <input type="text" id="sessionSearch" placeholder="Search sessions">
-          <select id="sessionSort">
-            <option value="created">Sort by creation</option>
-            <option value="name">Sort by name</option>
-          </select>
         </div>
         <select id="sessionSelect" class="w-auto"></select>
         <button type="button" class="btn icon-btn" id="btnNewSession" aria-label="Nauja sesija" title="Nauja sesija"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>

--- a/public/index.html
+++ b/public/index.html
@@ -16,18 +16,14 @@
 <body>
 <a href="#views" class="skip-link">Skip to content</a>
 <header id="appHeader" role="banner">
-  <div class="toolbar" id="sessionBar">
-    <div class="session-filter">
-      <input type="text" id="sessionSearch" placeholder="Search sessions">
-      <select id="sessionSort">
-        <option value="created">Sort by creation</option>
-        <option value="name">Sort by name</option>
-      </select>
+    <div class="toolbar" id="sessionBar">
+      <div class="session-filter">
+        <input type="text" id="sessionSearch" placeholder="Search sessions">
+      </div>
+      <select id="sessionSelect" class="w-auto"></select>
+      <button type="button" class="btn" id="btnNewSession">Naujas</button>
+      <button type="button" class="btn" id="btnManageSessions">Manage patients</button>
     </div>
-    <select id="sessionSelect" class="w-auto"></select>
-    <button type="button" class="btn" id="btnNewSession">Naujas</button>
-    <button type="button" class="btn" id="btnManageSessions">Manage patients</button>
-  </div>
 </header>
 <template id="chip-template">
   <span class="chip-status-icon" aria-hidden="true">✗</span>

--- a/public/js/__tests__/patientMenuToggle.test.js
+++ b/public/js/__tests__/patientMenuToggle.test.js
@@ -23,15 +23,20 @@ describe('initPatientMenuToggle',()=>{
 
   describe('desktop',()=>{
     beforeEach(()=>{
-      document.body.innerHTML='<button id="patientMenuToggle">Menu</button><div id="sessionBar" aria-hidden="false"></div><div class="patient-menu-overlay" hidden></div>';
+      document.body.innerHTML='<button id="patientMenuToggle">Menu</button><div id="sessionBar" hidden aria-hidden="true"></div><div class="patient-menu-overlay" hidden></div>';
       toggle=document.getElementById('patientMenuToggle');
       menu=document.getElementById('sessionBar');
       global.matchMedia = jest.fn().mockReturnValue({ matches:true, addEventListener: jest.fn(), removeEventListener: jest.fn() });
       initPatientMenuToggle(toggle, menu);
     });
-    test('does not lock scroll',()=>{
+    test('toggles without locking scroll',()=>{
+      expect(menu.hasAttribute('hidden')).toBe(true);
+      expect(document.body.classList.contains('patient-menu-open')).toBe(false);
+      toggle.click();
       expect(menu.hasAttribute('hidden')).toBe(false);
       expect(document.body.classList.contains('patient-menu-open')).toBe(false);
+      toggle.click();
+      expect(menu.hasAttribute('hidden')).toBe(true);
     });
   });
 });

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -118,12 +118,13 @@ export function initPatientMenuToggle(toggle, menu){
     document.addEventListener('keydown', trap);
   }
   toggle.addEventListener('click',()=>{
-    document.body.classList.contains('patient-menu-open') ? close() : open();
+    menu.hasAttribute('hidden') ? open() : close();
   });
   if(overlay){ overlay.addEventListener('click', close); }
-  const update=()=>{ if(mq && mq.matches) open(); else close(); };
-  if(mq){ mq.addEventListener('change', update); }
-  update();
+  if(mq){
+    mq.addEventListener('change',()=>{ if(!menu.hasAttribute('hidden')) open(); });
+  }
+  close();
 }
 
 export async function initTopbar(){

--- a/public/js/sessionUI.js
+++ b/public/js/sessionUI.js
@@ -10,13 +10,13 @@ export function updateUserList(users){
   if(el) el.textContent = users.length ? `Prisijungę: ${users.join(', ')}` : '';
 }
 
-export function populateSessionSelect(sel, sessions, { query = '', sortBy = 'created' } = {}){
+export function populateSessionSelect(sel, sessions, { query = '' } = {}){
   sel.innerHTML='';
   const q=query.trim().toLowerCase();
-  let list=sessions.filter(s=>(showArchived || !s.archived) && (!q || s.name.toLowerCase().includes(q)));
-  list=list.slice();
-  if(sortBy==='name') list.sort((a,b)=>a.name.localeCompare(b.name));
-  else list.sort((a,b)=>(a.created||0)-(b.created||0));
+  const list=sessions
+    .filter(s=>(showArchived || !s.archived) && (!q || s.name.toLowerCase().includes(q)))
+    .slice()
+    .sort((a,b)=>(a.created||0)-(b.created||0));
   list.forEach(s=>{ const opt=document.createElement('option'); opt.value=s.id; opt.textContent=s.name; sel.appendChild(opt); });
   return list;
 }
@@ -25,7 +25,6 @@ export async function initSessions(){
   const select=$('#sessionSelect');
   if(!select) return;
   const searchInput=$('#sessionSearch');
-  const sortSelect=$('#sessionSort');
   let sessions=await getSessions();
   let currentSessionId=getCurrentSessionId();
   let modal=$('#sessionManagerModal');
@@ -185,7 +184,7 @@ export async function initSessions(){
     }
   }
   const render=(focusId)=>{
-      const filtered=populateSessionSelect(select, sessions, { query: searchInput?.value || '', sortBy: sortSelect?.value || 'created' });
+      const filtered=populateSessionSelect(select, sessions, { query: searchInput?.value || '' });
       if(currentSessionId && filtered.some(s=>s.id===currentSessionId)){
         select.value=currentSessionId;
       }else{
@@ -205,7 +204,6 @@ export async function initSessions(){
       render();
     });
     searchInput?.addEventListener('input', ()=>render());
-    sortSelect?.addEventListener('change', ()=>render());
     if(!sessions.length){
       const id=Date.now().toString(36);
       sessions=[{id,name:'Pacientas Nr.1', archived:false, created:Date.now()}];


### PR DESCRIPTION
## Summary
- Ensure patient menu starts closed and toggles correctly
- Remove session sorting UI and always sort by creation time
- Add visible "Atvyko" text to arrival button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6e8273c8083209704ea5e362de47c