### PR TITLE
Fix patient menu closing on desktop

### DIFF
--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -84,7 +84,7 @@ export function initPatientMenuToggle(menu){
   update();
   window.addEventListener('resize', update);
   document.addEventListener('click', e=>{
-    if(menu.hasAttribute('open') && !menu.contains(e.target)){
+    if(menu.hasAttribute('open') && (!mq || !mq.matches) && !menu.contains(e.target)){
       menu.removeAttribute('open');
       search?.classList.add('hidden');
     }

--- a/public/js/__tests__/patientMenuToggle.test.js
+++ b/public/js/__tests__/patientMenuToggle.test.js
@@ -22,4 +22,26 @@ describe('initPatientMenuToggle', () => {
     toggle.click();
     expect(search.classList.contains('hidden')).toBe(true);
   });
+
+  test('does not close on outside click on desktop', () => {
+    document.body.innerHTML = '<details id="patientMenu"><summary class="btn">Menu</summary><div class="menu"></div></details><div id="outside"></div>';
+    global.matchMedia = jest.fn().mockReturnValue({ matches: true, addEventListener: jest.fn() });
+    const menu = document.getElementById('patientMenu');
+    const outside = document.getElementById('outside');
+    initPatientMenuToggle(menu);
+    expect(menu.hasAttribute('open')).toBe(true);
+    outside.click();
+    expect(menu.hasAttribute('open')).toBe(true);
+  });
+
+  test('closes on outside click on mobile', () => {
+    document.body.innerHTML = '<details id="patientMenu"><summary class="btn">Menu</summary><div class="menu"></div></details><div id="outside"></div>';
+    global.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn() });
+    const menu = document.getElementById('patientMenu');
+    const outside = document.getElementById('outside');
+    initPatientMenuToggle(menu);
+    menu.setAttribute('open', '');
+    outside.click();
+    expect(menu.hasAttribute('open')).toBe(false);
+  });
 });

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -84,7 +84,7 @@ export function initPatientMenuToggle(menu){
   update();
   window.addEventListener('resize', update);
   document.addEventListener('click', e=>{
-    if(menu.hasAttribute('open') && !menu.contains(e.target)){
+    if(menu.hasAttribute('open') && (!mq || !mq.matches) && !menu.contains(e.target)){
       menu.removeAttribute('open');
       search?.classList.add('hidden');
     }


### PR DESCRIPTION
## Summary
- Prevent patient menu from closing on desktop when clicking elsewhere
- Add tests for patient menu behavior on desktop and mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b717fb5f7883208297f5aefa1a2175