### PR TITLE
perf: preconnect google fonts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,8 @@
   const savedTheme = localStorage.getItem('trauma_theme') || 'dark';
   document.documentElement.classList.add(savedTheme,'js');
 </script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/main.css">
 <link rel="stylesheet" href="https://unpkg.com/vis-timeline@8.3.0/styles/vis-timeline-graph2d.min.css">


### PR DESCRIPTION
## Summary
- add preconnect hints for Google Fonts

## Testing
- `npm run lint`
- `npm run test:client`
- `npm run test:server`
- `curl -I 'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap'`
- `curl -I -H 'User-Agent: Mozilla/5.0' -e 'https://fonts.googleapis.com' 'https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZg.ttf'` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b745631df48320a6a66a46b46ce0d3