### PR TITLE
feat: add theme color meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark light">
+<meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff">
+<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0c1218">
 <title>Sunkios traumos forma</title>
 <script>
   const savedTheme = localStorage.getItem('trauma_theme') || 'dark';


### PR DESCRIPTION
## Summary
- adjust index.html to include light/dark theme-color meta tags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c8b6876c83209c887e15db1fbea8