### PR TITLE
Use base URL for topbar partial

### DIFF
--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -100,7 +100,7 @@ export async function initTopbar(){
   const header=document.getElementById('appHeader');
   if(!header || typeof fetch!=='function') return;
   try{
-    const res=await fetch('assets/partials/topbar.html');
+    const res=await fetch(new URL('assets/partials/topbar.html', document.baseURI).href);
     if(!res.ok) throw new Error(`HTTP ${res.status}`);
     header.innerHTML=await res.text();
   }catch(e){

--- a/public/js/__tests__/topbarLocalization.test.js
+++ b/public/js/__tests__/topbarLocalization.test.js
@@ -5,7 +5,11 @@ import path from 'path';
 describe('topbar', () => {
   test('loads without actions button', async () => {
     const html = fs.readFileSync(path.join(__dirname, '../../assets/partials/topbar.html'), 'utf8');
-    global.fetch = jest.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve(html) }));
+    const url = new URL('assets/partials/topbar.html', document.baseURI).href;
+    global.fetch = jest.fn((u) => {
+      expect(u).toBe(url);
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(html) });
+    });
     document.body.innerHTML = '<header id="appHeader"></header><nav></nav>';
     window.matchMedia = window.matchMedia || function(){
       return { matches: false, addEventListener(){}, removeEventListener(){}, addListener(){}, removeListener(){} };

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -100,7 +100,7 @@ export async function initTopbar(){
   const header=document.getElementById('appHeader');
   if(!header || typeof fetch!=='function') return;
   try{
-    const res=await fetch('assets/partials/topbar.html');
+    const res=await fetch(new URL('assets/partials/topbar.html', document.baseURI).href);
     if(!res.ok) throw new Error(`HTTP ${res.status}`);
     header.innerHTML=await res.text();
   }catch(e){


### PR DESCRIPTION
## Summary
- use document.baseURI when building topbar partial URL
- verify new URL in topbar localization test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8144026588320bffe1f862be91be2