### PR TITLE
fix: use relative path for service worker

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -122,7 +122,9 @@ function clampNumberInputs(){
 /* ===== Init modules ===== */
 async function init(){
   if(typeof navigator !== 'undefined' && 'serviceWorker' in navigator){
-    navigator.serviceWorker.register('/sw.js');
+    // Use a relative path so the service worker is correctly located when the
+    // site is served from a subdirectory (e.g. GitHub Pages project sites).
+    navigator.serviceWorker.register('./sw.js');
   }
   await initTopbar();
   setupHeaderActions({ validateForm });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -122,7 +122,9 @@ function clampNumberInputs(){
 /* ===== Init modules ===== */
 async function init(){
   if(typeof navigator !== 'undefined' && 'serviceWorker' in navigator){
-    navigator.serviceWorker.register('/sw.js');
+    // Use a relative path so the service worker is correctly located when the
+    // site is served from a subdirectory (e.g. GitHub Pages project sites).
+    navigator.serviceWorker.register('./sw.js');
   }
   await initTopbar();
   setupHeaderActions({ validateForm });


### PR DESCRIPTION
## Summary
- use a relative path when registering the service worker so GitHub Pages project sites can locate the script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8337bb53883209524eadfbefb30bd