### PR TITLE
fix: prevent duplicate patient menu listeners

### DIFF
--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -75,25 +75,49 @@ export function initNavToggle(toggle, nav){
   }
 }
 
+let patientMenuResizeListener;
+let patientMenuDocListener;
+let patientMenuSearchListener;
+let patientMenuSearchToggle;
+
 export function initPatientMenuToggle(menu){
+  if(patientMenuResizeListener){
+    window.removeEventListener('resize', patientMenuResizeListener);
+    patientMenuResizeListener=null;
+  }
+  if(patientMenuDocListener){
+    document.removeEventListener('click', patientMenuDocListener);
+    patientMenuDocListener=null;
+  }
+  if(patientMenuSearchToggle && patientMenuSearchListener){
+    patientMenuSearchToggle.removeEventListener('click', patientMenuSearchListener);
+    patientMenuSearchToggle=null;
+    patientMenuSearchListener=null;
+  }
   if(!menu) return;
   const search=menu.querySelector('#patientSearch');
   const searchToggle=menu.querySelector('#patientSearchToggle');
   const mq=typeof matchMedia==='function' ? matchMedia('(min-width: 769px)') : null;
   const update=()=>{ if(mq && mq.matches) menu.setAttribute('open',''); else menu.removeAttribute('open'); };
   update();
-  window.addEventListener('resize', update);
-  document.addEventListener('click', e=>{
+  patientMenuResizeListener=update;
+  window.addEventListener('resize', patientMenuResizeListener);
+  patientMenuDocListener=e=>{
     if(menu.hasAttribute('open') && (!mq || !mq.matches) && !menu.contains(e.target)){
       menu.removeAttribute('open');
       search?.classList.add('hidden');
     }
-  });
-  searchToggle?.addEventListener('click',()=>{
+  };
+  document.addEventListener('click', patientMenuDocListener);
+  patientMenuSearchListener=()=>{
     search?.classList.toggle('hidden');
     if(!search?.classList.contains('hidden')) search.focus();
     else if(search) search.value='';
-  });
+  };
+  if(searchToggle){
+    searchToggle.addEventListener('click', patientMenuSearchListener);
+    patientMenuSearchToggle=searchToggle;
+  }
 }
 
 export async function initTopbar(){

--- a/public/js/__tests__/patientMenuToggle.test.js
+++ b/public/js/__tests__/patientMenuToggle.test.js
@@ -44,4 +44,18 @@ describe('initPatientMenuToggle', () => {
     outside.click();
     expect(menu.hasAttribute('open')).toBe(false);
   });
+
+  test('removes previous listeners on reinit', () => {
+    document.body.innerHTML = '<details id="patientMenu"><summary class="btn">Menu</summary><div class="menu"></div></details><div id="outside"></div>';
+    global.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn() });
+    const menu = document.getElementById('patientMenu');
+    const outside = document.getElementById('outside');
+    initPatientMenuToggle(menu);
+    initPatientMenuToggle(menu);
+    menu.setAttribute('open','');
+    const spy = jest.spyOn(menu, 'removeAttribute');
+    outside.click();
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
 });

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -75,25 +75,49 @@ export function initNavToggle(toggle, nav){
   }
 }
 
+let patientMenuResizeListener;
+let patientMenuDocListener;
+let patientMenuSearchListener;
+let patientMenuSearchToggle;
+
 export function initPatientMenuToggle(menu){
+  if(patientMenuResizeListener){
+    window.removeEventListener('resize', patientMenuResizeListener);
+    patientMenuResizeListener=null;
+  }
+  if(patientMenuDocListener){
+    document.removeEventListener('click', patientMenuDocListener);
+    patientMenuDocListener=null;
+  }
+  if(patientMenuSearchToggle && patientMenuSearchListener){
+    patientMenuSearchToggle.removeEventListener('click', patientMenuSearchListener);
+    patientMenuSearchToggle=null;
+    patientMenuSearchListener=null;
+  }
   if(!menu) return;
   const search=menu.querySelector('#patientSearch');
   const searchToggle=menu.querySelector('#patientSearchToggle');
   const mq=typeof matchMedia==='function' ? matchMedia('(min-width: 769px)') : null;
   const update=()=>{ if(mq && mq.matches) menu.setAttribute('open',''); else menu.removeAttribute('open'); };
   update();
-  window.addEventListener('resize', update);
-  document.addEventListener('click', e=>{
+  patientMenuResizeListener=update;
+  window.addEventListener('resize', patientMenuResizeListener);
+  patientMenuDocListener=e=>{
     if(menu.hasAttribute('open') && (!mq || !mq.matches) && !menu.contains(e.target)){
       menu.removeAttribute('open');
       search?.classList.add('hidden');
     }
-  });
-  searchToggle?.addEventListener('click',()=>{
+  };
+  document.addEventListener('click', patientMenuDocListener);
+  patientMenuSearchListener=()=>{
     search?.classList.toggle('hidden');
     if(!search?.classList.contains('hidden')) search.focus();
     else if(search) search.value='';
-  });
+  };
+  if(searchToggle){
+    searchToggle.addEventListener('click', patientMenuSearchListener);
+    patientMenuSearchToggle=searchToggle;
+  }
 }
 
 export async function initTopbar(){


### PR DESCRIPTION
## Summary
- track patient menu toggle listeners and remove old ones before reinitializing
- add regression test to ensure listeners aren't duplicated

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8697668088320b97924b07d531382