### PR TITLE
Ensure patient search toggle keeps menu open

### DIFF
--- a/public/js/__tests__/patientMenuToggle.test.js
+++ b/public/js/__tests__/patientMenuToggle.test.js
@@ -23,6 +23,17 @@ describe('initPatientMenuToggle', () => {
     expect(search.classList.contains('hidden')).toBe(true);
   });
 
+  test('keeps menu open when toggling search on mobile', () => {
+    document.body.innerHTML = '<details id="patientMenu"><summary class="btn">Menu</summary><div class="menu"><button id="patientSearchToggle"></button><input id="patientSearch" class="hidden"></div></details>';
+    global.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn() });
+    const menu = document.getElementById('patientMenu');
+    const toggle = document.getElementById('patientSearchToggle');
+    initPatientMenuToggle(menu);
+    menu.setAttribute('open', '');
+    toggle.click();
+    expect(menu.hasAttribute('open')).toBe(true);
+  });
+
   test('does not close on outside click on desktop', () => {
     document.body.innerHTML = '<details id="patientMenu"><summary class="btn">Menu</summary><div class="menu"></div></details><div id="outside"></div>';
     global.matchMedia = jest.fn().mockReturnValue({ matches: true, addEventListener: jest.fn() });

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -109,10 +109,13 @@ export function initPatientMenuToggle(menu){
     }
   };
   document.addEventListener('click', patientMenuDocListener);
-  patientMenuSearchListener=()=>{
+  patientMenuSearchListener=e=>{
+    e.stopPropagation();
+    e.preventDefault();
     search?.classList.toggle('hidden');
     if(!search?.classList.contains('hidden')) search.focus();
     else if(search) search.value='';
+    menu.setAttribute('open','');
   };
   if(searchToggle){
     searchToggle.addEventListener('click', patientMenuSearchListener);


### PR DESCRIPTION
## Summary
- Preserve patient menu state when the search toggle is used
- Stop propagation on search toggle click to avoid unintended closures
- Add unit test for mobile search toggle behavior

## Testing
- `npm run test:client`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68b8832420748320af610d92d7b7039a