### PR TITLE
Fix patient menu closing on mobile search

### DIFF
--- a/public/js/__tests__/patientMenuToggle.test.js
+++ b/public/js/__tests__/patientMenuToggle.test.js
@@ -47,6 +47,18 @@ describe('initPatientMenuToggle', () => {
     expect(menu.hasAttribute('open')).toBe(true);
   });
 
+  test('stays open on resize after search toggle on mobile', () => {
+    document.body.innerHTML = '<details id="patientMenu"><summary class="btn">Menu</summary><div class="menu"><button id="patientSearchToggle"></button><input id="patientSearch" class="hidden"></div></details>';
+    global.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn() });
+    const menu = document.getElementById('patientMenu');
+    const toggle = document.getElementById('patientSearchToggle');
+    initPatientMenuToggle(menu);
+    menu.setAttribute('open','');
+    toggle.click();
+    window.dispatchEvent(new Event('resize'));
+    expect(menu.hasAttribute('open')).toBe(true);
+  });
+
   test('does not close on outside click on desktop', () => {
     document.body.innerHTML = '<details id="patientMenu"><summary class="btn">Menu</summary><div class="menu"></div></details><div id="outside"></div>';
     global.matchMedia = jest.fn().mockReturnValue({ matches: true, addEventListener: jest.fn() });

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -75,15 +75,18 @@ export function initNavToggle(toggle, nav){
   }
 }
 
-let patientMenuResizeListener;
+let patientMenuMq;
+let patientMenuMqListener;
 let patientMenuDocListener;
 let patientMenuSearchListener;
 let patientMenuSearchToggle;
 
 export function initPatientMenuToggle(menu){
-  if(patientMenuResizeListener){
-    window.removeEventListener('resize', patientMenuResizeListener);
-    patientMenuResizeListener=null;
+  if(patientMenuMq && patientMenuMqListener){
+    if(typeof patientMenuMq.removeEventListener==='function'){
+      patientMenuMq.removeEventListener('change', patientMenuMqListener);
+    }
+    patientMenuMqListener=null;
   }
   if(patientMenuDocListener){
     document.removeEventListener('click', patientMenuDocListener);
@@ -97,13 +100,15 @@ export function initPatientMenuToggle(menu){
   if(!menu) return;
   const search=menu.querySelector('#patientSearch');
   const searchToggle=menu.querySelector('#patientSearchToggle');
-  const mq=typeof matchMedia==='function' ? matchMedia('(min-width: 769px)') : null;
-  const update=()=>{ if(mq && mq.matches) menu.setAttribute('open',''); else menu.removeAttribute('open'); };
+  patientMenuMq=typeof matchMedia==='function' ? matchMedia('(min-width: 769px)') : null;
+  const update=()=>{ if(patientMenuMq && patientMenuMq.matches) menu.setAttribute('open',''); else menu.removeAttribute('open'); };
   update();
-  patientMenuResizeListener=update;
-  window.addEventListener('resize', patientMenuResizeListener);
+  if(patientMenuMq){
+    patientMenuMqListener=update;
+    patientMenuMq.addEventListener('change', patientMenuMqListener);
+  }
   patientMenuDocListener=e=>{
-    if(menu.hasAttribute('open') && (!mq || !mq.matches) && !menu.contains(e.target)){
+    if(menu.hasAttribute('open') && (!patientMenuMq || !patientMenuMq.matches) && !menu.contains(e.target)){
       menu.removeAttribute('open');
       search?.classList.add('hidden');
     }


### PR DESCRIPTION
## Summary
- Keep patient menu open on mobile when virtual keyboard triggers resize by listening to media query changes instead of window resize
- Add regression test ensuring patient menu remains open after a resize event

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b88b27a974832091db333d793322e0