### PR TITLE
Fix patient menu search focus timing

### DIFF
--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -109,10 +109,19 @@ export function initPatientMenuToggle(menu){
     }
   };
   document.addEventListener('click', patientMenuDocListener);
-  patientMenuSearchListener=()=>{
+  patientMenuSearchListener=e=>{
+    e?.stopPropagation();
+    e?.preventDefault();
     search?.classList.toggle('hidden');
-    if(!search?.classList.contains('hidden')) search.focus();
-    else if(search) search.value='';
+    menu.setAttribute('open','');
+    if(!search?.classList.contains('hidden')){
+      requestAnimationFrame(()=>{
+        search.focus();
+        menu.setAttribute('open','');
+      });
+    }else if(search){
+      search.value='';
+    }
   };
   if(searchToggle){
     searchToggle.addEventListener('click', patientMenuSearchListener);

--- a/public/js/__tests__/patientMenuToggle.test.js
+++ b/public/js/__tests__/patientMenuToggle.test.js
@@ -59,6 +59,24 @@ describe('initPatientMenuToggle', () => {
     expect(menu.hasAttribute('open')).toBe(true);
   });
 
+  test('remains open when focusing search on mobile', () => {
+    document.body.innerHTML = '<details id="patientMenu"><summary class="btn">Menu</summary><div class="menu"><button id="patientSearchToggle"></button><input id="patientSearch" class="hidden"></div></details>';
+    global.matchMedia = jest.fn().mockReturnValue({ matches: false, addEventListener: jest.fn() });
+    const menu = document.getElementById('patientMenu');
+    const toggle = document.getElementById('patientSearchToggle');
+    initPatientMenuToggle(menu);
+    menu.setAttribute('open','');
+    const origRaf = global.requestAnimationFrame;
+    let raf;
+    global.requestAnimationFrame = cb => { raf = cb; };
+    toggle.click();
+    document.body.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(menu.hasAttribute('open')).toBe(false);
+    raf();
+    expect(menu.hasAttribute('open')).toBe(true);
+    global.requestAnimationFrame = origRaf;
+  });
+
   test('does not close on outside click on desktop', () => {
     document.body.innerHTML = '<details id="patientMenu"><summary class="btn">Menu</summary><div class="menu"></div></details><div id="outside"></div>';
     global.matchMedia = jest.fn().mockReturnValue({ matches: true, addEventListener: jest.fn() });

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -118,9 +118,15 @@ export function initPatientMenuToggle(menu){
     e.stopPropagation();
     e.preventDefault();
     search?.classList.toggle('hidden');
-    if(!search?.classList.contains('hidden')) search.focus();
-    else if(search) search.value='';
     menu.setAttribute('open','');
+    if(!search?.classList.contains('hidden')){
+      requestAnimationFrame(()=>{
+        search.focus();
+        menu.setAttribute('open','');
+      });
+    }else if(search){
+      search.value='';
+    }
   };
   if(searchToggle){
     searchToggle.addEventListener('click', patientMenuSearchListener);


### PR DESCRIPTION
## Summary
- focus patient search in rAF to avoid closing menu on mobile
- mirror patient menu focus fix in docs
- add regression test for search focus

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8968cf4748320afceb9b385406ff8