### PR TITLE
Fix nav focus when opening on mobile

### DIFF
--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -46,6 +46,7 @@ export function initNavToggle(toggle, nav){
   }
   function open(){
     const mobile=!navMq || !navMq.matches;
+    const wasClosed=!navOpen;
     navOpen=true;
     document.body.classList.toggle('nav-open', mobile);
     toggle.setAttribute('aria-expanded','true');
@@ -55,7 +56,7 @@ export function initNavToggle(toggle, nav){
       if(overlay) overlay.hidden=false;
       document.body.style.overflow='hidden';
       const items=nav.querySelectorAll(focusableSel);
-      if(items.length) items[0].focus();
+      if(wasClosed && items.length) items[0].focus();
       if(!trapActive){
         document.addEventListener('keydown', trap);
         trapActive=true;


### PR DESCRIPTION
## Summary
- Focus first nav item only when opening mobile menu
- Keep current focus when nav already open or on desktop

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b922e3997c83209b2eb6fa5bf7c247