### PR TITLE
Remove patient history field from activation view

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
         <h2>Traumos komandos aktyvacija <span class="badge">GMP rodikliai → auto</span></h2>
         <fieldset class="collapsible" id="activation-patient">
           <legend>Pacientas</legend>
-          <div class="grid cols-3 cols-auto">
+          <div class="grid cols-2 cols-auto">
             <div>
               <label for="patient_age">Amžius</label>
               <input id="patient_age" type="number" min="0" max="120" required aria-describedby="patient_age_hint" title="Amžius 0-120">
@@ -61,11 +61,6 @@
                 <option value="O">Kita / nenurodyta</option>
               </select>
               <div class="hint" id="patient_sex_hint">Pasirinkite lytį</div>
-            </div>
-            <div>
-              <label for="patient_history">Ligos istorijos nr.</label>
-              <input id="patient_history" type="text" required aria-describedby="patient_history_hint" title="Įveskite ligos istorijos numerį">
-              <div class="hint" id="patient_history_hint">Privalomas laukas</div>
             </div>
           </div>
         </fieldset>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -193,8 +193,7 @@ async function init(){
 function validateForm(){
   const fields=[
     {el:$('#patient_age'),check:e=>e.value!=='' && +e.value>=0 && +e.value<=120,msg:'Amžius 0-120'},
-    {el:$('#patient_sex'),check:e=>e.value!=='',msg:'Pasirinkite lytį'},
-    {el:$('#patient_history'),check:e=>e.value.trim()!=='',msg:'Ligos istorijos nr. privalomas'}
+    {el:$('#patient_sex'),check:e=>e.value!=='',msg:'Pasirinkite lytį'}
   ];
   let ok=true;
   fields.forEach(({el,check,msg})=>{

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -29,8 +29,8 @@ export function bodymapSummary(){
 
 export function generateReport(){
   const out=[];
-  const patient={ age:$('#patient_age').value, sex:$('#patient_sex').value, history:$('#patient_history').value };
-  const patientLine=[patient.age?`Amžius ${patient.age}`:null, patient.sex?`Lytis ${patient.sex}`:null, patient.history?`Ligos istorijos nr. ${patient.history}`:null].filter(Boolean).join('; ');
+  const patient={ age:$('#patient_age').value, sex:$('#patient_sex').value };
+  const patientLine=[patient.age?`Amžius ${patient.age}`:null, patient.sex?`Lytis ${patient.sex}`:null].filter(Boolean).join('; ');
   if(patientLine){ out.push('--- Pacientas ---'); out.push(patientLine); }
   const red=listChips('#chips_red'), yellow=listChips('#chips_yellow');
   const gmp={ hr:$('#gmp_hr').value, rr:$('#gmp_rr').value, spo2:$('#gmp_spo2').value, sbp:$('#gmp_sbp').value, dbp:$('#gmp_dbp').value, gksa:$('#gmp_gksa').value, gksk:$('#gmp_gksk').value, gksm:$('#gmp_gksm').value, time:$('#gmp_time').value, mechanism:$('#gmp_mechanism').value, notes:$('#gmp_notes').value };

--- a/docs/js/validation.js
+++ b/docs/js/validation.js
@@ -40,7 +40,7 @@ export function validateField(el) {
 }
 
 export function validateVitals() {
-  const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm','#patient_age','#patient_sex','#patient_history'];
+  const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm','#patient_age','#patient_sex'];
   let ok = true;
   fields.forEach(sel => {
     const el = $(sel);
@@ -53,7 +53,7 @@ export function validateVitals() {
 }
 
 export function initValidation() {
-  const selectors = ['#patient_age','#patient_sex','#patient_history','#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm'];
+  const selectors = ['#patient_age','#patient_sex','#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm'];
   selectors.forEach(sel => {
     const el = $(sel);
     if (!el) return;

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
         <h2>Traumos komandos aktyvacija <span class="badge">GMP rodikliai → auto</span></h2>
         <fieldset class="collapsible" id="activation-patient">
           <legend>Pacientas</legend>
-          <div class="grid cols-3 cols-auto">
+          <div class="grid cols-2 cols-auto">
             <div>
               <label for="patient_age">Amžius</label>
               <input id="patient_age" type="number" min="0" max="120" required aria-describedby="patient_age_hint" title="Amžius 0-120">
@@ -61,11 +61,6 @@
                 <option value="O">Kita / nenurodyta</option>
               </select>
               <div class="hint" id="patient_sex_hint">Pasirinkite lytį</div>
-            </div>
-            <div>
-              <label for="patient_history">Ligos istorijos nr.</label>
-              <input id="patient_history" type="text" required aria-describedby="patient_history_hint" title="Įveskite ligos istorijos numerį">
-              <div class="hint" id="patient_history_hint">Privalomas laukas</div>
             </div>
           </div>
         </fieldset>

--- a/public/js/__tests__/patient.test.js
+++ b/public/js/__tests__/patient.test.js
@@ -64,7 +64,7 @@ const setupDom = () => {
   skinColor.className='chip-group';
   skinColor.dataset.single='true';
   skinColor.innerHTML='<button class="chip" data-value="Rausva"></button><button class="chip" data-value="Blyški"></button><button class="chip" data-value="Kita"></button>';
-  const textInputs=['a_notes','gmp_mechanism','gmp_notes','b_oxygen_type','b_dpv_fio2','d_pupil_left_note','d_pupil_right_note','d_notes','e_back_notes','e_abdomen_notes','e_other','spr_skyrius_kita','spr_ligonine','patient_history','c_skin_color_other'];
+  const textInputs=['a_notes','gmp_mechanism','gmp_notes','b_oxygen_type','b_dpv_fio2','d_pupil_left_note','d_pupil_right_note','d_notes','e_back_notes','e_abdomen_notes','e_other','spr_skyrius_kita','spr_ligonine','c_skin_color_other'];
   textInputs.forEach(id=>{ const i=document.createElement('input'); i.id=id; i.type='text'; document.body.appendChild(i); });
   const numberInputs=['b_rr','b_spo2','b_oxygen_liters','c_hr','c_sbp','c_dbp','c_caprefill','d_gksa','d_gksk','d_gksm','e_temp',
     'spr_hr','spr_rr','spr_spo2','spr_sbp','spr_dbp','spr_gksa','spr_gksk','spr_gksm','patient_age','gmp_hr','gmp_rr','gmp_spo2',
@@ -101,31 +101,25 @@ describe('patient fields', () => {
   test('persist with saveAll/loadAll', () => {
     document.getElementById('patient_age').value='25';
     document.getElementById('patient_sex').value='M';
-    document.getElementById('patient_history').value='H123';
     saveAll();
     const stored = JSON.parse(localStorage.getItem('trauma_v10_test'));
     expect(stored.patient_age).toBe('25');
     expect(stored.patient_sex).toBe('M');
-    expect(stored.patient_history).toBe('H123');
     document.getElementById('patient_age').value='';
     document.getElementById('patient_sex').value='';
-    document.getElementById('patient_history').value='';
     loadAll();
     expect(document.getElementById('patient_age').value).toBe('25');
     expect(document.getElementById('patient_sex').value).toBe('M');
-    expect(document.getElementById('patient_history').value).toBe('H123');
   });
 
   test('report includes patient info', () => {
     document.getElementById('patient_age').value='25';
     document.getElementById('patient_sex').value='M';
-    document.getElementById('patient_history').value='H123';
     generateReport();
     const report=document.getElementById('output').value;
     expect(report.startsWith('--- Pacientas ---')).toBe(true);
     expect(report).toContain('25');
     expect(report).toContain('M');
-    expect(report).toContain('H123');
   });
 
   test('new circulation fields persist and report', () => {
@@ -203,7 +197,6 @@ describe('patient fields', () => {
   test('PDF button generates file via jsPDF', async () => {
     document.getElementById('patient_age').value='25';
     document.getElementById('patient_sex').value='M';
-    document.getElementById('patient_history').value='H123';
     document.getElementById('btnPdfReport').click();
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(mockJsPDF).toHaveBeenCalled();
@@ -221,7 +214,6 @@ describe('patient fields', () => {
     const openMock = jest.spyOn(window, 'open').mockReturnValue(win);
     document.getElementById('patient_age').value='25';
     document.getElementById('patient_sex').value='M';
-    document.getElementById('patient_history').value='H123';
     document.getElementById('btnPrintReport').click();
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(openMock).toHaveBeenCalled();
@@ -235,7 +227,6 @@ describe('patient fields', () => {
   test('switching sessions clears patient fields', () => {
     document.getElementById('patient_age').value='40';
     document.getElementById('patient_sex').value='F';
-    document.getElementById('patient_history').value='hist';
     const { setChipActive } = require('../chips.js');
     const chip=document.querySelector('#c_skin_color_group .chip[data-value="Blyški"]');
     setChipActive(chip,true);
@@ -252,7 +243,6 @@ describe('patient fields', () => {
     loadAll();
     expect(document.getElementById('patient_age').value).toBe('');
     expect(document.getElementById('patient_sex').value).toBe('');
-    expect(document.getElementById('patient_history').value).toBe('');
     expect(document.querySelector('#c_skin_color_group .chip.active')).toBeNull();
     expect(card.querySelector('.act_chk').checked).toBe(false);
     expect(card.querySelector('.act_time').value).toBe('');

--- a/public/js/__tests__/report.test.js
+++ b/public/js/__tests__/report.test.js
@@ -13,7 +13,7 @@ describe('gksSum', () => {
 describe('generateReport circulation metrics', () => {
   test('includes VAS and shock index', () => {
     document.body.innerHTML = `
-      <input id="patient_age"><input id="patient_sex"><input id="patient_history">
+        <input id="patient_age"><input id="patient_sex">
       <input id="gmp_hr"><input id="gmp_rr"><input id="gmp_spo2"><input id="gmp_sbp"><input id="gmp_dbp">
       <input id="gmp_gksa"><input id="gmp_gksk"><input id="gmp_gksm"><input id="gmp_time"><input id="gmp_mechanism"><input id="gmp_notes">
       <input id="a_notes">

--- a/public/js/__tests__/validation.test.js
+++ b/public/js/__tests__/validation.test.js
@@ -34,24 +34,19 @@ describe('validateField', () => {
 
 describe('validateVitals', () => {
   test('checks required text and select fields', () => {
-    document.body.innerHTML = `
-      <input id="patient_age" type="number" value="25" required />
-      <select id="patient_sex" required>
-        <option value=""></option>
-        <option value="M">M</option>
-      </select>
-      <input id="patient_history" required />
-    `;
-    expect(validateVitals()).toBe(false);
-    const sexErr = document.querySelector('#patient_sex').nextElementSibling;
-    const histErr = document.querySelector('#patient_history').nextElementSibling;
-    expect(sexErr.textContent).toBe('Privalomas laukas');
-    expect(histErr.textContent).toBe('Privalomas laukas');
+      document.body.innerHTML = `
+        <input id="patient_age" type="number" value="25" required />
+        <select id="patient_sex" required>
+          <option value=""></option>
+          <option value="M">M</option>
+        </select>
+      `;
+      expect(validateVitals()).toBe(false);
+      const sexErr = document.querySelector('#patient_sex').nextElementSibling;
+      expect(sexErr.textContent).toBe('Privalomas laukas');
 
-    document.getElementById('patient_sex').value = 'M';
-    document.getElementById('patient_history').value = 'H123';
-    validateVitals();
-    expect(document.getElementById('patient_sex').classList.contains('invalid')).toBe(false);
-    expect(document.getElementById('patient_history').classList.contains('invalid')).toBe(false);
+      document.getElementById('patient_sex').value = 'M';
+      validateVitals();
+      expect(document.getElementById('patient_sex').classList.contains('invalid')).toBe(false);
+    });
   });
-});

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -193,8 +193,7 @@ async function init(){
 function validateForm(){
   const fields=[
     {el:$('#patient_age'),check:e=>e.value!=='' && +e.value>=0 && +e.value<=120,msg:'Amžius 0-120'},
-    {el:$('#patient_sex'),check:e=>e.value!=='',msg:'Pasirinkite lytį'},
-    {el:$('#patient_history'),check:e=>e.value.trim()!=='',msg:'Ligos istorijos nr. privalomas'}
+    {el:$('#patient_sex'),check:e=>e.value!=='',msg:'Pasirinkite lytį'}
   ];
   let ok=true;
   fields.forEach(({el,check,msg})=>{

--- a/public/js/report.js
+++ b/public/js/report.js
@@ -29,8 +29,8 @@ export function bodymapSummary(){
 
 export function generateReport(){
   const out=[];
-  const patient={ age:$('#patient_age').value, sex:$('#patient_sex').value, history:$('#patient_history').value };
-  const patientLine=[patient.age?`Amžius ${patient.age}`:null, patient.sex?`Lytis ${patient.sex}`:null, patient.history?`Ligos istorijos nr. ${patient.history}`:null].filter(Boolean).join('; ');
+  const patient={ age:$('#patient_age').value, sex:$('#patient_sex').value };
+  const patientLine=[patient.age?`Amžius ${patient.age}`:null, patient.sex?`Lytis ${patient.sex}`:null].filter(Boolean).join('; ');
   if(patientLine){ out.push('--- Pacientas ---'); out.push(patientLine); }
   const red=listChips('#chips_red'), yellow=listChips('#chips_yellow');
   const gmp={ hr:$('#gmp_hr').value, rr:$('#gmp_rr').value, spo2:$('#gmp_spo2').value, sbp:$('#gmp_sbp').value, dbp:$('#gmp_dbp').value, gksa:$('#gmp_gksa').value, gksk:$('#gmp_gksk').value, gksm:$('#gmp_gksm').value, time:$('#gmp_time').value, mechanism:$('#gmp_mechanism').value, notes:$('#gmp_notes').value };

--- a/public/js/validation.js
+++ b/public/js/validation.js
@@ -40,7 +40,7 @@ export function validateField(el) {
 }
 
 export function validateVitals() {
-  const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm','#patient_age','#patient_sex','#patient_history'];
+  const fields = ['#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm','#patient_age','#patient_sex'];
   let ok = true;
   fields.forEach(sel => {
     const el = $(sel);
@@ -53,7 +53,7 @@ export function validateVitals() {
 }
 
 export function initValidation() {
-  const selectors = ['#patient_age','#patient_sex','#patient_history','#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm'];
+  const selectors = ['#patient_age','#patient_sex','#gmp_hr','#gmp_rr','#gmp_spo2','#gmp_sbp','#gmp_dbp','#gmp_gksa','#gmp_gksk','#gmp_gksm','#d_gksa','#d_gksk','#d_gksm'];
   selectors.forEach(sel => {
     const el = $(sel);
     if (!el) return;


### PR DESCRIPTION
## Summary
- remove medical history number field from activation section
- update validation and report generation for new patient fields
- adjust tests and docs accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b935f5cdf483209aed014b29da5453