### PR TITLE
Fix jsPDF import for PDF generation

### DIFF
--- a/docs/js/headerActions.js
+++ b/docs/js/headerActions.js
@@ -29,7 +29,7 @@ export function setupHeaderActions({ validateForm }){
     const text = $('#output').value || '';
     try {
       const module = await import('./lib/jspdf.umd.min.js');
-      const { jsPDF } = module.default;
+      const { jsPDF } = module.default || module;
       const doc = new jsPDF();
       const lines = doc.splitTextToSize(text, 180);
       doc.text(lines, 10, 10);

--- a/public/js/headerActions.js
+++ b/public/js/headerActions.js
@@ -29,7 +29,7 @@ export function setupHeaderActions({ validateForm }){
     const text = $('#output').value || '';
     try {
       const module = await import('./lib/jspdf.umd.min.js');
-      const { jsPDF } = module.default;
+      const { jsPDF } = module.default || module;
       const doc = new jsPDF();
       const lines = doc.splitTextToSize(text, 180);
       doc.text(lines, 10, 10);


### PR DESCRIPTION
## Summary
- handle jsPDF dynamic import when the module has no default export
- mirror the fix in docs build

## Testing
- `npm test`
- `npm run lint`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68b940cf2268832096fbdba567102004