### PR TITLE
Set light theme as default

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,12 +3,12 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="color-scheme" content="dark light">
+<meta name="color-scheme" content="light dark">
 <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff">
 <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0c1218">
 <title>Sunkios traumos forma</title>
 <script>
-  const savedTheme = localStorage.getItem('trauma_theme') || 'dark';
+  const savedTheme = localStorage.getItem('trauma_theme') || 'light';
   document.documentElement.classList.add(savedTheme,'js');
 </script>
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -6,7 +6,7 @@ import { updateDomToggles } from './domToggles.js';
 
 let authToken = localStorage.getItem('trauma_token') || null;
 let currentSessionId = localStorage.getItem('trauma_current_session') || null;
-let theme = localStorage.getItem('trauma_theme') || 'dark';
+let theme = localStorage.getItem('trauma_theme') || 'light';
 
 export function setTheme(t){
   theme = t === 'light' ? 'light' : 'dark';

--- a/public/index.html
+++ b/public/index.html
@@ -3,12 +3,12 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="color-scheme" content="dark light">
+<meta name="color-scheme" content="light dark">
 <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff">
 <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0c1218">
 <title>Sunkios traumos forma</title>
 <script>
-  const savedTheme = localStorage.getItem('trauma_theme') || 'dark';
+  const savedTheme = localStorage.getItem('trauma_theme') || 'light';
   document.documentElement.classList.add(savedTheme,'js');
 </script>
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -6,7 +6,7 @@ import { updateDomToggles } from './domToggles.js';
 
 let authToken = localStorage.getItem('trauma_token') || null;
 let currentSessionId = localStorage.getItem('trauma_current_session') || null;
-let theme = localStorage.getItem('trauma_theme') || 'dark';
+let theme = localStorage.getItem('trauma_theme') || 'light';
 
 export function setTheme(t){
   theme = t === 'light' ? 'light' : 'dark';


### PR DESCRIPTION
## Summary
- default theme preference to light when no prior choice is saved
- ensure initial HTML uses light color scheme and class
- rebuild docs to include light theme default

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b944afaed08320a0deea2bc4d94a97