### PR TITLE
Handle missing body map SVG structure

### DIFF
--- a/docs/js/components/BodyMap.js
+++ b/docs/js/components/BodyMap.js
@@ -86,12 +86,18 @@ export default class BodyMap {
   /** Initialise DOM references and event listeners. */
   init(saveCb) {
     if (this.initialized) return;
+
+    this.svg = $('#bodySvg');
+    this.marks = $('#marks');
+    if (!this.svg || !this.marks) {
+      console.warn('BodyMap.init: missing SVG or marks element');
+      return;
+    }
+
     this.initialized = true;
 
     this.saveCb = typeof saveCb === 'function' ? saveCb : () => {};
 
-    this.svg = $('#bodySvg');
-    this.marks = $('#marks');
     this.tools = $$('.map-toolbar .tool[data-tool]');
     this.btnUndo = $('#btnUndo');
     this.btnRedo = $('#btnRedo');
@@ -185,22 +191,24 @@ export default class BodyMap {
     this.setTool(this.activeTool);
 
     // Brush drawing and erasing on SVG
-    this.svg.addEventListener('pointerdown', e => {
-      if (this.activeTool === TOOLS.BURN.char && this.inBody(e)) {
-        this.isDrawing = true;
-        this.drawBrush(e);
-      } else if (this.activeTool === TOOLS.BURN_ERASE.char) {
-        this.isDrawing = true;
-        this.eraseBrush(e);
-      }
-    });
-    this.svg.addEventListener('pointermove', e => {
-      if (this.activeTool === TOOLS.BURN.char && this.isDrawing && this.inBody(e)) {
-        this.drawBrush(e);
-      } else if (this.activeTool === TOOLS.BURN_ERASE.char && this.isDrawing) {
-        this.eraseBrush(e);
-      }
-    });
+    if (this.svg) {
+      this.svg.addEventListener('pointerdown', e => {
+        if (this.activeTool === TOOLS.BURN.char && this.inBody(e)) {
+          this.isDrawing = true;
+          this.drawBrush(e);
+        } else if (this.activeTool === TOOLS.BURN_ERASE.char) {
+          this.isDrawing = true;
+          this.eraseBrush(e);
+        }
+      });
+      this.svg.addEventListener('pointermove', e => {
+        if (this.activeTool === TOOLS.BURN.char && this.isDrawing && this.inBody(e)) {
+          this.drawBrush(e);
+        } else if (this.activeTool === TOOLS.BURN_ERASE.char && this.isDrawing) {
+          this.eraseBrush(e);
+        }
+      });
+    }
     document.addEventListener('pointerup', () => {
       if (this.isDrawing) {
         this.isDrawing = false;

--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -23,6 +23,16 @@ function setupDom() {
 }
 
 describe('BodyMap instance', () => {
+  test('init exits gracefully when SVG structure is incomplete', () => {
+    document.body.innerHTML = '<svg id="bodySvg"></svg>';
+    const bm = new BodyMap();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() => bm.init(() => {})).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+    expect(bm.initialized).toBe(false);
+    warn.mockRestore();
+  });
+
   test('addMark and serialize', () => {
     setupDom();
     const bm = new BodyMap();

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -100,12 +100,18 @@ export default class BodyMap {
   /** Initialise DOM references and event listeners. */
   init(saveCb) {
     if (this.initialized) return;
+
+    this.svg = $('#bodySvg');
+    this.marks = $('#marks');
+    if (!this.svg || !this.marks) {
+      console.warn('BodyMap.init: missing SVG or marks element');
+      return;
+    }
+
     this.initialized = true;
 
     this.saveCb = typeof saveCb === 'function' ? saveCb : () => {};
 
-    this.svg = $('#bodySvg');
-    this.marks = $('#marks');
     this.tools = $$('.map-toolbar .tool[data-tool]');
     this.btnUndo = $('#btnUndo');
     this.btnRedo = $('#btnRedo');
@@ -199,22 +205,24 @@ export default class BodyMap {
     this.setTool(this.activeTool);
 
     // Brush drawing and erasing on SVG
-    this.svg.addEventListener('pointerdown', e => {
-      if (this.activeTool === TOOLS.BURN.char && this.inBody(e)) {
-        this.isDrawing = true;
-        this.drawBrush(e);
-      } else if (this.activeTool === TOOLS.BURN_ERASE.char) {
-        this.isDrawing = true;
-        this.eraseBrush(e);
-      }
-    });
-    this.svg.addEventListener('pointermove', e => {
-      if (this.activeTool === TOOLS.BURN.char && this.isDrawing && this.inBody(e)) {
-        this.drawBrush(e);
-      } else if (this.activeTool === TOOLS.BURN_ERASE.char && this.isDrawing) {
-        this.eraseBrush(e);
-      }
-    });
+    if (this.svg) {
+      this.svg.addEventListener('pointerdown', e => {
+        if (this.activeTool === TOOLS.BURN.char && this.inBody(e)) {
+          this.isDrawing = true;
+          this.drawBrush(e);
+        } else if (this.activeTool === TOOLS.BURN_ERASE.char) {
+          this.isDrawing = true;
+          this.eraseBrush(e);
+        }
+      });
+      this.svg.addEventListener('pointermove', e => {
+        if (this.activeTool === TOOLS.BURN.char && this.isDrawing && this.inBody(e)) {
+          this.drawBrush(e);
+        } else if (this.activeTool === TOOLS.BURN_ERASE.char && this.isDrawing) {
+          this.eraseBrush(e);
+        }
+      });
+    }
     document.addEventListener('pointerup', () => {
       if (this.isDrawing) {
         this.isDrawing = false;


### PR DESCRIPTION
## Summary
- Guard BodyMap.init against missing SVG or marks elements, logging a warning and exiting
- Attach pointer event listeners only when an SVG is present
- Add test ensuring BodyMap.init handles incomplete SVG structures without throwing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9934f185483209ec27b4ab235b832