### PR TITLE
Handle missing body map layers gracefully

### DIFF
--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -33,6 +33,16 @@ describe('BodyMap instance', () => {
     warn.mockRestore();
   });
 
+  test('init skips zones for missing layer elements', () => {
+    setupDom();
+    document.querySelector('#layer-back').remove();
+    const bm = new BodyMap();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() => bm.init(() => {})).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   test('addMark and serialize', () => {
     setupDom();
     const bm = new BodyMap();

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -154,14 +154,19 @@ export default class BodyMap {
     if (this.svg && !this.svg.querySelector('.zone')) {
       const layers = { front: $('#layer-front'), back: $('#layer-back') };
       zones.forEach(z => {
-        let group = layers[z.side].querySelector('.zones');
+        const layer = layers[z.side];
+        if (!layer) {
+          console.warn(`BodyMap.init: missing layer-${z.side}`);
+          return; // skip zones for this side
+        }
+        let group = layer.querySelector('.zones');
         if (!group) {
           group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
           group.classList.add('zones');
-          const shape = layers[z.side].querySelector(`#${z.side}-shape`);
+          const shape = layer.querySelector(`#${z.side}-shape`);
           const tr = shape?.getAttribute('transform');
           if (tr) group.setAttribute('transform', tr);
-          layers[z.side].appendChild(group);
+          layer.appendChild(group);
         }
         const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
         path.classList.add('zone');


### PR DESCRIPTION
## Summary
- Skip building zones when a body map layer is absent
- Warn about missing layer elements for easier HTML debugging
- Add regression test to ensure BodyMap.init handles missing layers

## Testing
- `npx eslint public/js/components/BodyMap.js public/js/__tests__/bodyMap.test.js`
- `npx jest --config jest.config.js public/js/__tests__/bodyMap.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b99a4541008320ac677405652e4909