### PR TITLE
feat: split procedures into IT and other groups

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -359,8 +359,12 @@
           <div class="grid cols-3 cols-auto" id="other_meds"></div>
         </section>
         <section class="interv-group">
-          <button class="interv-toggle" aria-expanded="true">🛠 Procedūros</button>
-          <div class="grid cols-3 cols-auto" id="procedures"></div>
+          <button class="interv-toggle" aria-expanded="true">🛠 Procedūros – IT (intensyvios terapijos)</button>
+          <div class="grid cols-3 cols-auto" id="procedures_it"></div>
+        </section>
+        <section class="interv-group">
+          <button class="interv-toggle" aria-expanded="true">🛠 Procedūros – kitos</button>
+          <div class="grid cols-3 cols-auto" id="procedures_other"></div>
         </section>
       </div>
       <div class="hint mt-6">Paspaudus ant vaisto automatiškai užpildomi laikas ir standartinė dozė (galima koreguoti), o ant procedūros – tik laikas.</div>

--- a/docs/js/actions.js
+++ b/docs/js/actions.js
@@ -3,7 +3,8 @@ import { $, $$, nowHM } from './utils.js';
 export const PAIN_MEDS = ['Fentanilis','Paracetamolis','Ketoprofenas'];
 export const BLEEDING_MEDS = ['TXA','O- kraujas','Fibryga','Ca gliukonatas'];
 export const OTHER_MEDS = ['Ringerio tirpalas','Noradrenalinas','Metoklopramidas','Ondansetronas'];
-export const PROCS = ['Intubacija','Krikotirotomija','Pleuros drenažas','Adatinė dekompresija','Kūno šildymas','Turniketas','Dubens diržas','Gipsavimas','Siuvimas','Repocizija'];
+export const PROCS_IT = ['Intubacija','Krikotirotomija','Pleuros drenažas','Adatinė dekompresija'];
+export const PROCS_OTHER = ['Kūno šildymas','Turniketas','Dubens diržas','Gipsavimas','Siuvimas','Repocizija'];
 
 // Default doses for medications
 export const DEFAULT_DOSES = {
@@ -116,7 +117,8 @@ export function initActions(saveAll){
   const painWrap=$('#pain_meds');
   const bleedingWrap=$('#bleeding_meds');
   const otherWrap=$('#other_meds');
-  const procsWrap=$('#procedures');
+  const procsItWrap=$('#procedures_it');
+  const procsOtherWrap=$('#procedures_other');
   const sortedPainMeds = PAIN_MEDS.slice().sort((a,b)=>a.localeCompare(b));
   const sortedBleedingMeds = BLEEDING_MEDS.slice().sort((a,b)=>a.localeCompare(b));
   const sortedOtherMeds = OTHER_MEDS.slice().sort((a,b)=>a.localeCompare(b));
@@ -134,11 +136,14 @@ export function initActions(saveAll){
   otherFrag.appendChild(buildActionCard('med','Kita', saveAll, {custom:true}));
   otherWrap.appendChild(otherFrag);
 
-  const procsFrag=document.createDocumentFragment();
-  PROCS.forEach(n=>procsFrag.appendChild(buildActionCard('proc', n, saveAll)));
-  procsWrap.appendChild(procsFrag);
+  const procsItFrag=document.createDocumentFragment();
+  PROCS_IT.forEach(n=>procsItFrag.appendChild(buildActionCard('proc', n, saveAll)));
+  procsItWrap.appendChild(procsItFrag);
+  const procsOtherFrag=document.createDocumentFragment();
+  PROCS_OTHER.forEach(n=>procsOtherFrag.appendChild(buildActionCard('proc', n, saveAll)));
+  procsOtherWrap.appendChild(procsOtherFrag);
 
-  const wraps=[painWrap,bleedingWrap,otherWrap,procsWrap];
+  const wraps=[painWrap,bleedingWrap,otherWrap,procsItWrap,procsOtherWrap];
 
   function handleAction(e){
     const card=e.target.closest('.card');
@@ -176,7 +181,7 @@ export function initActions(saveAll){
 
   const medSearch=$('#medSearch');
   if(medSearch){
-    const medWraps=[painWrap,bleedingWrap,otherWrap,procsWrap];
+    const medWraps=[painWrap,bleedingWrap,otherWrap,procsItWrap,procsOtherWrap];
     medSearch.addEventListener('input',()=>{
       const q=medSearch.value.trim().toLowerCase();
       medWraps.forEach(wrap=>{

--- a/docs/js/report.js
+++ b/docs/js/report.js
@@ -78,13 +78,15 @@ export function generateReport(){
   out.push('\n--- E Kita ---'); out.push([$('#e_temp').value?('T '+$('#e_temp').value+'°C'):null, back==='Be pakitimų'?'Nugara: be pakitimų':(back==='Pakitimai'&&$('#e_back_notes').value?('Nugara: '+$('#e_back_notes').value):null), abdomen==='Be pakitimų'?'Pilvas: be pakitimų':(abdomen==='Pakitimai'&&$('#e_abdomen_notes').value?('Pilvas: '+$('#e_abdomen_notes').value):null), $('#e_other').value?('Kita: '+$('#e_other').value):null, bodymapSummary()].filter(Boolean).join(' | '));
 
   function collect(container){ return Array.from(container.children).map(card=>{ const on=card.querySelector('.act_chk').checked; if(!on) return null; const nameInput=card.querySelector('.act_custom_name'); const base=card.querySelector('.act_name').textContent.trim(); const customName=nameInput?nameInput.value.trim():''; const name=nameInput?customName:base; if(nameInput && !customName) return null; const time=card.querySelector('.act_time').value; const doseInput=card.querySelector('.act_dose'); const dose=doseInput?doseInput.value:''; const note=card.querySelector('.act_note').value; return [name, time?('laikas '+time):null, dose?('dozė '+dose):null, note?('pastabos '+note):null].filter(Boolean).join(' | '); }).filter(Boolean);}
-  const pain=collect($('#pain_meds')), bleeding=collect($('#bleeding_meds')), other=collect($('#other_meds')), procs=collect($('#procedures'));
-  if(pain.length||bleeding.length||other.length||procs.length){
+  const pain=collect($('#pain_meds')), bleeding=collect($('#bleeding_meds')), other=collect($('#other_meds')),
+    procsIt=collect($('#procedures_it')), procsOther=collect($('#procedures_other'));
+  if(pain.length||bleeding.length||other.length||procsIt.length||procsOther.length){
     out.push('\n--- Intervencijos ---');
     if(pain.length) out.push('Medikamentai (skausmo kontrolė):\n'+pain.join('\n'));
     if(bleeding.length) out.push('Medikamentai (kraujavimo kontrolė):\n'+bleeding.join('\n'));
     if(other.length) out.push('Medikamentai (kita):\n'+other.join('\n'));
-    if(procs.length) out.push('Procedūros:\n'+procs.join('\n'));
+    if(procsIt.length) out.push('Procedūros (IT):\n'+procsIt.join('\n'));
+    if(procsOther.length) out.push('Procedūros (kitos):\n'+procsOther.join('\n'));
   }
 
   let imgs=[...listChips('#imaging_ct'), ...listChips('#imaging_xray')];

--- a/docs/js/sessionManager.js
+++ b/docs/js/sessionManager.js
@@ -44,7 +44,10 @@ export async function saveAll(){
     ...serializeChips(CHIP_GROUPS)
   };
   function pack(container){ return Array.from(container.children).map(card=>({ name:limit(card.querySelector('.act_custom_name')?card.querySelector('.act_custom_name').value:card.querySelector('.act_name').textContent.trim()), on:card.querySelector('.act_chk').checked, time:limit(card.querySelector('.act_time').value), dose:limit(card.querySelector('.act_dose')?card.querySelector('.act_dose').value:''), note:limit(card.querySelector('.act_note').value) }));}
-  data['pain_meds']=pack($('#pain_meds')); data['bleeding_meds']=pack($('#bleeding_meds')); data['other_meds']=pack($('#other_meds')); data['procs']=pack($('#procedures'));
+  data['pain_meds']=pack($('#pain_meds'));
+  data['bleeding_meds']=pack($('#bleeding_meds'));
+  data['other_meds']=pack($('#other_meds'));
+  data['procs']=pack($('#procedures_it')).concat(pack($('#procedures_other')));
   data['bodymap_svg']=limit(bodyMap.serialize(), 200000);
   localStorage.setItem(sessionKey(), JSON.stringify(data));
   const statusEl = $('#saveStatus');
@@ -114,7 +117,10 @@ function loadRecords(data){
   unpack($('#pain_meds'),data['pain_meds']);
   unpack($('#bleeding_meds'),data['bleeding_meds']);
   unpack($('#other_meds'),data['other_meds']);
-  unpack($('#procedures'),data['procs']);
+  const procsArr=Array.isArray(data['procs'])?data['procs']:[];
+  const itCount=$('#procedures_it').children.length;
+  unpack($('#procedures_it'),procsArr.slice(0,itCount));
+  unpack($('#procedures_other'),procsArr.slice(itCount));
 }
 
 function loadBodyMap(data){

--- a/public/index.html
+++ b/public/index.html
@@ -359,8 +359,12 @@
           <div class="grid cols-3 cols-auto" id="other_meds"></div>
         </section>
         <section class="interv-group">
-          <button class="interv-toggle" aria-expanded="true">🛠 Procedūros</button>
-          <div class="grid cols-3 cols-auto" id="procedures"></div>
+          <button class="interv-toggle" aria-expanded="true">🛠 Procedūros – IT (intensyvios terapijos)</button>
+          <div class="grid cols-3 cols-auto" id="procedures_it"></div>
+        </section>
+        <section class="interv-group">
+          <button class="interv-toggle" aria-expanded="true">🛠 Procedūros – kitos</button>
+          <div class="grid cols-3 cols-auto" id="procedures_other"></div>
         </section>
       </div>
       <div class="hint mt-6">Paspaudus ant vaisto automatiškai užpildomi laikas ir standartinė dozė (galima koreguoti), o ant procedūros – tik laikas.</div>

--- a/public/js/__tests__/actions.test.js
+++ b/public/js/__tests__/actions.test.js
@@ -6,7 +6,8 @@ describe('initActions default doses', () => {
       <div id="pain_meds"></div>
       <div id="bleeding_meds"></div>
       <div id="other_meds"></div>
-      <div id="procedures"></div>
+      <div id="procedures_it"></div>
+      <div id="procedures_other"></div>
       <input id="medSearch" />
     `;
     initActions(() => {});
@@ -32,7 +33,8 @@ describe('initActions default doses', () => {
         <div id="pain_meds"></div>
         <div id="bleeding_meds"></div>
         <div id="other_meds"></div>
-        <div id="procedures"></div>
+        <div id="procedures_it"></div>
+        <div id="procedures_other"></div>
         <input id="medSearch" />
       `;
       initActions(() => {});
@@ -51,7 +53,8 @@ describe('initActions default doses', () => {
       <div id="pain_meds"></div>
       <div id="bleeding_meds"></div>
       <div id="other_meds"></div>
-      <div id="procedures"></div>
+      <div id="procedures_it"></div>
+      <div id="procedures_other"></div>
       <input id="medSearch" />
     `;
     initActions(() => {});
@@ -64,11 +67,12 @@ describe('initActions default doses', () => {
       <div id="pain_meds"></div>
       <div id="bleeding_meds"></div>
       <div id="other_meds"></div>
-      <div id="procedures"></div>
+      <div id="procedures_it"></div>
+      <div id="procedures_other"></div>
       <input id="medSearch" />
     `;
     initActions(() => {});
-    const procCard = document.querySelector('#procedures .card');
+    const procCard = document.querySelector('#procedures_it .card');
     expect(procCard.querySelector('.act_dose')).toBeNull();
   });
 });

--- a/public/js/__tests__/patient.test.js
+++ b/public/js/__tests__/patient.test.js
@@ -44,7 +44,7 @@ const setupDom = () => {
     'a_airway_group','b_breath_left_group','b_breath_right_group',
     'c_pulse_radial_group','c_pulse_femoral_group','c_skin_temp_group','c_skin_color_group',
     'd_pupil_left_group','d_pupil_right_group','spr_decision_group',
-    'pain_meds','bleeding_meds','other_meds','procedures','fastGrid','teamGrid','oxygenFields','dpvFields',
+    'pain_meds','bleeding_meds','other_meds','procedures_it','procedures_other','fastGrid','teamGrid','oxygenFields','dpvFields',
     'spr_skyrius_container','spr_ligonine_container','imaging_other'
   ];
   divIds.forEach(id=>{ const d=document.createElement('div'); d.id=id; document.body.appendChild(d); });

--- a/public/js/__tests__/report.test.js
+++ b/public/js/__tests__/report.test.js
@@ -22,7 +22,7 @@ describe('generateReport circulation metrics', () => {
       <input id="d_gksa"><input id="d_gksk"><input id="d_gksm"><input id="d_notes">
       <input id="e_temp"><input id="e_back_notes"><input id="e_abdomen_notes"><input id="e_other">
       <div id="imaging_ct"></div><div id="imaging_xray"></div><div id="imaging_other_group"></div><input id="imaging_other">
-      <div id="pain_meds"></div><div id="bleeding_meds"></div><div id="other_meds"></div><div id="procedures"></div>
+      <div id="pain_meds"></div><div id="bleeding_meds"></div><div id="other_meds"></div><div id="procedures_it"></div><div id="procedures_other"></div>
       <div id="labs_basic"></div>
       <input id="spr_time"><input id="spr_hr"><input id="spr_rr"><input id="spr_spo2"><input id="spr_sbp"><input id="spr_dbp">
       <input id="spr_gksa"><input id="spr_gksk"><input id="spr_gksm">

--- a/public/js/__tests__/sessionManager.test.js
+++ b/public/js/__tests__/sessionManager.test.js
@@ -94,7 +94,8 @@ describe('sessionManager utilities', () => {
       <div id="pain_meds"></div>
       <div id="bleeding_meds"></div>
       <div id="other_meds"></div>
-      <div id="procedures"></div>
+      <div id="procedures_it"></div>
+      <div id="procedures_other"></div>
     `;
     const mockFetch = jest.fn(() => Promise.resolve({ ok: true }));
     global.fetch = mockFetch;

--- a/public/js/actions.js
+++ b/public/js/actions.js
@@ -3,7 +3,8 @@ import { $, $$, nowHM } from './utils.js';
 export const PAIN_MEDS = ['Fentanilis','Paracetamolis','Ketoprofenas'];
 export const BLEEDING_MEDS = ['TXA','O- kraujas','Fibryga','Ca gliukonatas'];
 export const OTHER_MEDS = ['Ringerio tirpalas','Noradrenalinas','Metoklopramidas','Ondansetronas'];
-export const PROCS = ['Intubacija','Krikotirotomija','Pleuros drenažas','Adatinė dekompresija','Kūno šildymas','Turniketas','Dubens diržas','Gipsavimas','Siuvimas','Repocizija'];
+export const PROCS_IT = ['Intubacija','Krikotirotomija','Pleuros drenažas','Adatinė dekompresija'];
+export const PROCS_OTHER = ['Kūno šildymas','Turniketas','Dubens diržas','Gipsavimas','Siuvimas','Repocizija'];
 
 // Default doses for medications
 export const DEFAULT_DOSES = {
@@ -116,7 +117,8 @@ export function initActions(saveAll){
   const painWrap=$('#pain_meds');
   const bleedingWrap=$('#bleeding_meds');
   const otherWrap=$('#other_meds');
-  const procsWrap=$('#procedures');
+  const procsItWrap=$('#procedures_it');
+  const procsOtherWrap=$('#procedures_other');
   const sortedPainMeds = PAIN_MEDS.slice().sort((a,b)=>a.localeCompare(b));
   const sortedBleedingMeds = BLEEDING_MEDS.slice().sort((a,b)=>a.localeCompare(b));
   const sortedOtherMeds = OTHER_MEDS.slice().sort((a,b)=>a.localeCompare(b));
@@ -134,11 +136,14 @@ export function initActions(saveAll){
   otherFrag.appendChild(buildActionCard('med','Kita', saveAll, {custom:true}));
   otherWrap.appendChild(otherFrag);
 
-  const procsFrag=document.createDocumentFragment();
-  PROCS.forEach(n=>procsFrag.appendChild(buildActionCard('proc', n, saveAll)));
-  procsWrap.appendChild(procsFrag);
+  const procsItFrag=document.createDocumentFragment();
+  PROCS_IT.forEach(n=>procsItFrag.appendChild(buildActionCard('proc', n, saveAll)));
+  procsItWrap.appendChild(procsItFrag);
+  const procsOtherFrag=document.createDocumentFragment();
+  PROCS_OTHER.forEach(n=>procsOtherFrag.appendChild(buildActionCard('proc', n, saveAll)));
+  procsOtherWrap.appendChild(procsOtherFrag);
 
-  const wraps=[painWrap,bleedingWrap,otherWrap,procsWrap];
+  const wraps=[painWrap,bleedingWrap,otherWrap,procsItWrap,procsOtherWrap];
 
   function handleAction(e){
     const card=e.target.closest('.card');
@@ -176,7 +181,7 @@ export function initActions(saveAll){
 
   const medSearch=$('#medSearch');
   if(medSearch){
-    const medWraps=[painWrap,bleedingWrap,otherWrap,procsWrap];
+    const medWraps=[painWrap,bleedingWrap,otherWrap,procsItWrap,procsOtherWrap];
     medSearch.addEventListener('input',()=>{
       const q=medSearch.value.trim().toLowerCase();
       medWraps.forEach(wrap=>{

--- a/public/js/report.js
+++ b/public/js/report.js
@@ -78,13 +78,15 @@ export function generateReport(){
   out.push('\n--- E Kita ---'); out.push([$('#e_temp').value?('T '+$('#e_temp').value+'°C'):null, back==='Be pakitimų'?'Nugara: be pakitimų':(back==='Pakitimai'&&$('#e_back_notes').value?('Nugara: '+$('#e_back_notes').value):null), abdomen==='Be pakitimų'?'Pilvas: be pakitimų':(abdomen==='Pakitimai'&&$('#e_abdomen_notes').value?('Pilvas: '+$('#e_abdomen_notes').value):null), $('#e_other').value?('Kita: '+$('#e_other').value):null, bodymapSummary()].filter(Boolean).join(' | '));
 
   function collect(container){ return Array.from(container.children).map(card=>{ const on=card.querySelector('.act_chk').checked; if(!on) return null; const nameInput=card.querySelector('.act_custom_name'); const base=card.querySelector('.act_name').textContent.trim(); const customName=nameInput?nameInput.value.trim():''; const name=nameInput?customName:base; if(nameInput && !customName) return null; const time=card.querySelector('.act_time').value; const doseInput=card.querySelector('.act_dose'); const dose=doseInput?doseInput.value:''; const note=card.querySelector('.act_note').value; return [name, time?('laikas '+time):null, dose?('dozė '+dose):null, note?('pastabos '+note):null].filter(Boolean).join(' | '); }).filter(Boolean);}
-  const pain=collect($('#pain_meds')), bleeding=collect($('#bleeding_meds')), other=collect($('#other_meds')), procs=collect($('#procedures'));
-  if(pain.length||bleeding.length||other.length||procs.length){
+  const pain=collect($('#pain_meds')), bleeding=collect($('#bleeding_meds')), other=collect($('#other_meds')),
+    procsIt=collect($('#procedures_it')), procsOther=collect($('#procedures_other'));
+  if(pain.length||bleeding.length||other.length||procsIt.length||procsOther.length){
     out.push('\n--- Intervencijos ---');
     if(pain.length) out.push('Medikamentai (skausmo kontrolė):\n'+pain.join('\n'));
     if(bleeding.length) out.push('Medikamentai (kraujavimo kontrolė):\n'+bleeding.join('\n'));
     if(other.length) out.push('Medikamentai (kita):\n'+other.join('\n'));
-    if(procs.length) out.push('Procedūros:\n'+procs.join('\n'));
+    if(procsIt.length) out.push('Procedūros (IT):\n'+procsIt.join('\n'));
+    if(procsOther.length) out.push('Procedūros (kitos):\n'+procsOther.join('\n'));
   }
 
   let imgs=[...listChips('#imaging_ct'), ...listChips('#imaging_xray')];

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -44,7 +44,10 @@ export async function saveAll(){
     ...serializeChips(CHIP_GROUPS)
   };
   function pack(container){ return Array.from(container.children).map(card=>({ name:limit(card.querySelector('.act_custom_name')?card.querySelector('.act_custom_name').value:card.querySelector('.act_name').textContent.trim()), on:card.querySelector('.act_chk').checked, time:limit(card.querySelector('.act_time').value), dose:limit(card.querySelector('.act_dose')?card.querySelector('.act_dose').value:''), note:limit(card.querySelector('.act_note').value) }));}
-  data['pain_meds']=pack($('#pain_meds')); data['bleeding_meds']=pack($('#bleeding_meds')); data['other_meds']=pack($('#other_meds')); data['procs']=pack($('#procedures'));
+  data['pain_meds']=pack($('#pain_meds'));
+  data['bleeding_meds']=pack($('#bleeding_meds'));
+  data['other_meds']=pack($('#other_meds'));
+  data['procs']=pack($('#procedures_it')).concat(pack($('#procedures_other')));
   data['bodymap_svg']=limit(bodyMap.serialize(), 200000);
   localStorage.setItem(sessionKey(), JSON.stringify(data));
   const statusEl = $('#saveStatus');
@@ -114,7 +117,10 @@ function loadRecords(data){
   unpack($('#pain_meds'),data['pain_meds']);
   unpack($('#bleeding_meds'),data['bleeding_meds']);
   unpack($('#other_meds'),data['other_meds']);
-  unpack($('#procedures'),data['procs']);
+  const procsArr=Array.isArray(data['procs'])?data['procs']:[];
+  const itCount=$('#procedures_it').children.length;
+  unpack($('#procedures_it'),procsArr.slice(0,itCount));
+  unpack($('#procedures_other'),procsArr.slice(itCount));
 }
 
 function loadBodyMap(data){


### PR DESCRIPTION
## Summary
- separate procedure list into IT (intensyvios terapijos) and other categories on interventions page
- update actions, saving/loading, and reporting logic for new procedure groups
- adjust tests for new procedure containers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb1750ff888320a52979489c97ae86