### PR TITLE
Avoid redundant saves during body map state restores

### DIFF
--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -349,7 +349,7 @@ export default class BodyMap {
       this.updateUndoRedoButtons();
     }
     this.updateBurnDisplay();
-    this.saveCb();
+    if (record) this.saveCb();
   }
 
   removeBrush(id, record = true) {
@@ -373,7 +373,7 @@ export default class BodyMap {
       this.updateUndoRedoButtons();
     }
     this.updateBurnDisplay();
-    this.saveCb();
+    if (record) this.saveCb();
   }
 
   /** Add a new mark to the map. */
@@ -402,7 +402,7 @@ export default class BodyMap {
       this.redoStack = [];
       this.updateUndoRedoButtons();
     }
-    this.saveCb();
+    if (record) this.saveCb();
   }
 
   /** Begin dragging a mark. */
@@ -452,7 +452,7 @@ export default class BodyMap {
       this.redoStack = [];
       this.updateUndoRedoButtons();
     }
-    this.saveCb();
+    if (record) this.saveCb();
   }
 
   /**


### PR DESCRIPTION
## Summary
- conditionally fire save callback in body map add/remove helpers
- prevent load and undo/redo operations from triggering saves
- cover save callback behavior with regression tests

## Testing
- `npm test -- public/js/__tests__/bodyMap.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bb360123a483208c8cf919e0fa90b8