### PR TITLE
refactor: consolidate body map pointer handling

### DIFF
--- a/docs/js/components/BodyMap.js
+++ b/docs/js/components/BodyMap.js
@@ -164,25 +164,42 @@ export default class BodyMap {
       });
     }
 
-    // Cache zone elements and attach click/pointer handlers
+    const attachPointer = (el, handler) => {
+      let handled = false;
+      el.addEventListener('pointerdown', e => {
+        handled = true;
+        handler(e);
+        e.preventDefault();
+      });
+      el.addEventListener('pointerup', () => {
+        setTimeout(() => { handled = false; }, 0);
+      });
+      el.addEventListener('pointercancel', () => { handled = false; });
+      el.addEventListener('click', e => {
+        if (handled) {
+          handled = false;
+          return;
+        }
+        handler(e);
+      });
+    };
+
+    // Cache zone elements and attach pointer handlers
     $$('.zone', this.svg).forEach(el => {
       const id = el.dataset.zone;
       this.zoneMap.set(id, el);
       const handler = evt => {
-        if (evt.type === 'pointerdown') evt.preventDefault();
         const side = el.closest('#layer-back') ? 'back' : 'front';
         const p = this.svgPoint(evt);
         if (!this.pointInBody(p.x, p.y, side)) return;
         if (this.activeTool === TOOLS.BURN.char) {
-          if (evt.type === 'click') return; // avoid duplicate via click
           evt.stopPropagation();
           this.addBrush(p.x, p.y, this.brushSize);
         } else {
           this.addMark(p.x, p.y, this.activeTool, side, id);
         }
       };
-      el.addEventListener('click', handler);
-      el.addEventListener('pointerdown', handler);
+      attachPointer(el, handler);
     });
 
     // Tool buttons
@@ -229,13 +246,11 @@ export default class BodyMap {
       const el = document.getElementById(id);
       if (!el) return;
       const handler = evt => {
-        if (evt.type === 'pointerdown') evt.preventDefault();
         const p = this.svgPoint(evt);
         if (!this.pointInBody(p.x, p.y, el.dataset.side)) return;
         this.addMark(p.x, p.y, this.activeTool, el.dataset.side);
       };
-      el.addEventListener('click', handler);
-      el.addEventListener('pointerdown', handler);
+      attachPointer(el, handler);
     });
 
     // Mark selection and dragging

--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -114,6 +114,18 @@ describe('BodyMap instance', () => {
       expect(document.querySelectorAll('#marks use').length).toBe(1);
     });
 
+    test('pointerdown followed by click adds only one mark', () => {
+      setupDom();
+      const bm = new BodyMap();
+      bm.init(() => {});
+      bm.svgPoint = () => ({ x: 10, y: 10 });
+      const zone = document.querySelector('.zone[data-zone="front-torso"]');
+      zone.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+      zone.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+      zone.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(document.querySelectorAll('#marks use').length).toBe(1);
+    });
+
     test('pointer events move mark and save', () => {
       setupDom();
       const save = jest.fn();


### PR DESCRIPTION
## Summary
- avoid duplicate marks by unifying pointer and click listeners
- ensure body map silhouette and zones share single event mechanism
- add regression test for pointerdown followed by click

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbd3c6b8888320b5f3d1fb2295c53f