### PR TITLE
Simplify body map module

### DIFF
--- a/docs/js/bodyMap.js
+++ b/docs/js/bodyMap.js
@@ -1,15 +1,5 @@
 import BodyMap from './components/BodyMap.js';
 import { TOOLS } from './BodyMapTools.js';
 
-const bodyMap = new BodyMap();
-
-export default bodyMap;
-export { bodyMap, TOOLS };
-
-// Legacy named exports
-export const initBodyMap = (...args) => bodyMap.init(...args);
-export const addMark = (...args) => bodyMap.addMark(...args);
-export const serialize = (...args) => bodyMap.serialize(...args);
-export const load = (...args) => bodyMap.load(...args);
-export const counts = (...args) => bodyMap.counts(...args);
-export const zoneCounts = (...args) => bodyMap.zoneCounts(...args);
+export { TOOLS };
+export default new BodyMap();

--- a/public/js/__tests__/patient.test.js
+++ b/public/js/__tests__/patient.test.js
@@ -6,7 +6,7 @@ const mockJsPDF = jest.fn().mockImplementation(() => ({
 }));
 jest.mock('../lib/jspdf.umd.min.js', () => ({ __esModule: true, default: { jsPDF: mockJsPDF } }));
 
-let saveAll, loadAll, generateReport, setupHeaderActions, initBodyMap, setCurrentSessionId;
+let saveAll, loadAll, generateReport, setupHeaderActions, bodyMap, setCurrentSessionId;
 
 const setupDom = () => {
   document.body.innerHTML = `
@@ -85,9 +85,9 @@ describe('patient fields', () => {
     ({ saveAll, loadAll, setCurrentSessionId } = require('../sessionManager.js'));
     ({ generateReport } = require('../report.js'));
     ({ setupHeaderActions } = require('../headerActions.js'));
-    ({ initBodyMap } = require('../bodyMap.js'));
+    ({ default: bodyMap } = require('../bodyMap.js'));
     setCurrentSessionId('test');
-    initBodyMap(()=>{});
+    bodyMap.init(()=>{});
     setupHeaderActions({ validateForm: () => true });
     require('../app.js');
     mockJsPDF.mockClear();

--- a/public/js/bodyMap.js
+++ b/public/js/bodyMap.js
@@ -1,15 +1,5 @@
 import BodyMap from './components/BodyMap.js';
 import { TOOLS } from './BodyMapTools.js';
 
-const bodyMap = new BodyMap();
-
-export default bodyMap;
-export { bodyMap, TOOLS };
-
-// Legacy named exports
-export const initBodyMap = (...args) => bodyMap.init(...args);
-export const addMark = (...args) => bodyMap.addMark(...args);
-export const serialize = (...args) => bodyMap.serialize(...args);
-export const load = (...args) => bodyMap.load(...args);
-export const counts = (...args) => bodyMap.counts(...args);
-export const zoneCounts = (...args) => bodyMap.zoneCounts(...args);
+export { TOOLS };
+export default new BodyMap();


### PR DESCRIPTION
## Summary
- streamline bodyMap module to a single instance and tool export
- adjust patient tests to use the simplified bodyMap instance

## Testing
- `npm run test:client`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68bbdc60c8408320ae24cdb652a91550