### PR TITLE
Read BodyMap dimensions from SVG viewBox

### DIFF
--- a/docs/js/components/BodyMap.js
+++ b/docs/js/components/BodyMap.js
@@ -46,8 +46,8 @@ export default class BodyMap {
     this.brushBurns = [];
     this.isDrawing = false;
     this.pendingBrushes = [];
-    this.vbWidth = 1500;
-    this.vbHeight = 1100;
+    this.vbWidth = 0;
+    this.vbHeight = 0;
     // The total drawable area will be derived from the front and back
     // body silhouettes once the SVG is available.
     this.totalArea = 0;
@@ -124,8 +124,10 @@ export default class BodyMap {
     this.burnTotalEl = $('#burnTotal');
     this.brushSizeInput = $('#brushSize');
 
-    const vb = this.svg?.getAttribute('viewBox')?.split(/\s+/).map(Number);
-    if (vb) {
+    const vb = (this.svg?.getAttribute('viewBox') || '')
+      .split(/\s+/)
+      .map(Number);
+    if (vb.length === 4 && vb.every(n => !isNaN(n))) {
       this.vbWidth = vb[2];
       this.vbHeight = vb[3];
     }
@@ -236,6 +238,18 @@ export default class BodyMap {
         }
       };
       attachPointer(el, handler);
+    });
+
+    // Ensure zone bounding boxes reflect the actual SVG dimensions
+    this.zoneMap.forEach(el => {
+      if (typeof el.getBBox === 'function') {
+        try {
+          const b = el.getBBox();
+          el.dataset.bbox = `${b.x},${b.y},${b.x + b.width},${b.y + b.height}`;
+        } catch {
+          // ignore failures in environments without SVG geometry support
+        }
+      }
     });
 
     // Tool buttons

--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -7,7 +7,7 @@ const frontZone = zones.find(z => z.id === 'front-torso');
 
 function setupDom() {
   document.body.innerHTML = `
-    <svg id="bodySvg"><g id="layer-front"></g><g id="layer-back"></g><g id="marks"></g></svg>
+    <svg id="bodySvg" viewBox="0 0 1500 1090"><g id="layer-front"></g><g id="layer-back"></g><g id="marks"></g></svg>
     <div id="burnTotal"></div>
       <div class="map-toolbar">
         <button class="tool" data-tool="${TOOLS.WOUND.char}"></button>
@@ -24,7 +24,7 @@ function setupDom() {
 
 describe('BodyMap instance', () => {
   test('init exits gracefully when SVG structure is incomplete', () => {
-    document.body.innerHTML = '<svg id="bodySvg"></svg>';
+    document.body.innerHTML = '<svg id="bodySvg" viewBox="0 0 1500 1090"></svg>';
     const bm = new BodyMap();
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     expect(() => bm.init(() => {})).not.toThrow();

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -46,8 +46,8 @@ export default class BodyMap {
     this.brushBurns = [];
     this.isDrawing = false;
     this.pendingBrushes = [];
-    this.vbWidth = 1500;
-    this.vbHeight = 1100;
+    this.vbWidth = 0;
+    this.vbHeight = 0;
     // The total drawable area will be derived from the front and back
     // body silhouettes once the SVG is available.
     this.totalArea = 0;
@@ -124,8 +124,10 @@ export default class BodyMap {
     this.burnTotalEl = $('#burnTotal');
     this.brushSizeInput = $('#brushSize');
 
-    const vb = this.svg?.getAttribute('viewBox')?.split(/\s+/).map(Number);
-    if (vb) {
+    const vb = (this.svg?.getAttribute('viewBox') || '')
+      .split(/\s+/)
+      .map(Number);
+    if (vb.length === 4 && vb.every(n => !isNaN(n))) {
       this.vbWidth = vb[2];
       this.vbHeight = vb[3];
     }
@@ -241,6 +243,18 @@ export default class BodyMap {
         }
       };
       attachPointer(el, handler);
+    });
+
+    // Ensure zone bounding boxes reflect the actual SVG dimensions
+    this.zoneMap.forEach(el => {
+      if (typeof el.getBBox === 'function') {
+        try {
+          const b = el.getBBox();
+          el.dataset.bbox = `${b.x},${b.y},${b.x + b.width},${b.y + b.height}`;
+        } catch {
+          // ignore failures in environments without SVG geometry support
+        }
+      }
     });
 
     // Tool buttons


### PR DESCRIPTION
## Summary
- Drop hard-coded BodyMap viewBox dimensions and derive width/height from the SVG viewBox
- Recompute zone bounding boxes with actual SVG geometry
- Specify bodySvg viewBox in tests to match runtime expectations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc008daa1c83209dd6d33ec99a0e98