### PR TITLE
Shrink body map wound and bruise markers

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="css/main.css">
+<link rel="stylesheet" href="css/main.css?v=1.0.0">
 </head>
 <body>
 <a href="#views" class="skip-link">Skip to content</a>
@@ -309,12 +309,12 @@
       <svg id="bodySvg" viewBox="0 0 1500 1090" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <!-- Marker symbols -->
         <defs>
-          <symbol id="sym-wound" viewBox="-14 -14 28 28">
-            <circle r="14" class="mark-w"/>
+          <symbol id="sym-wound" viewBox="-7 -7 14 14">
+            <circle r="7" class="mark-w"/>
             <path d="M-10 0 L10 0 M0 -10 L0 10" class="mark-w"/>
           </symbol>
-          <symbol id="sym-bruise" viewBox="-10 -10 20 20">
-            <circle r="10" class="mark-b"/>
+          <symbol id="sym-bruise" viewBox="-5 -5 10 10">
+            <circle r="5" class="mark-b"/>
           </symbol>
         </defs>
 

--- a/public/index.html
+++ b/public/index.html
@@ -309,12 +309,12 @@
       <svg id="bodySvg" viewBox="0 0 1500 1090" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <!-- Marker symbols -->
         <defs>
-          <symbol id="sym-wound" viewBox="-14 -14 28 28">
-            <circle r="14" class="mark-w"/>
+          <symbol id="sym-wound" viewBox="-7 -7 14 14">
+            <circle r="7" class="mark-w"/>
             <path d="M-10 0 L10 0 M0 -10 L0 10" class="mark-w"/>
           </symbol>
-          <symbol id="sym-bruise" viewBox="-10 -10 20 20">
-            <circle r="10" class="mark-b"/>
+          <symbol id="sym-bruise" viewBox="-5 -5 10 10">
+            <circle r="5" class="mark-b"/>
           </symbol>
         </defs>
 

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -44,6 +44,8 @@ export default class BodyMap {
     this.redoStack = [];
     this.brushSize = 20;
     this.brushBurns = [];
+    // Scale factor applied to wound/bruise markers
+    this.markScale = 1;
     this.isDrawing = false;
     this.pendingBrushes = [];
     this.vbWidth = 0;
@@ -56,6 +58,12 @@ export default class BodyMap {
     this.drag = null;
     this.onDragMove = this.onDragMove.bind(this);
     this.onDragEnd = this.onDragEnd.bind(this);
+  }
+
+  /** Set scaling factor for wound and bruise markers. */
+  setMarkScale(scale) {
+    const s = parseFloat(scale);
+    if (!isNaN(s) && s > 0) this.markScale = s;
   }
 
   /** Determine whether event occurred within body silhouette. */
@@ -448,7 +456,9 @@ export default class BodyMap {
       use.setAttribute('href', symbol);
       use.setAttributeNS('http://www.w3.org/1999/xlink', 'href', symbol);
     }
-    use.setAttribute('transform', `translate(${x},${y})`);
+    const transforms = [`translate(${x},${y})`];
+    if (this.markScale !== 1) transforms.push(`scale(${this.markScale})`);
+    use.setAttribute('transform', transforms.join(' '));
     const mid = id || ++this.markSeq;
     use.dataset.id = mid;
     use.dataset.type = type;


### PR DESCRIPTION
## Summary
- Reduce wound and bruise marker SVGs to smaller viewBoxes and radii
- Allow configuring marker scale in BodyMap component and apply scaling when placing marks
- Rebuild static site so `docs/` reflects new marker sizes

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc1b58b7ec8320a199f48e6521ad09