### PR TITLE
Reduce body map marker size

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -144,6 +144,7 @@ async function init(){
     initCollapsibles();
   }
   bodyMap.init(saveAllDebounced);
+  bodyMap.setMarkScale(0.5);
   initChips(saveAllDebounced);
   initAutoActivate(saveAllDebounced);
   initActions(saveAllDebounced);

--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -55,6 +55,18 @@ describe('BodyMap instance', () => {
     expect(data.marks[0]).toMatchObject({ x: 10, y: 20, type: TOOLS.WOUND.char, side: 'front', zone: 'front-torso' });
   });
 
+  test('setMarkScale applies scaling to new marks', () => {
+    setupDom();
+    const bm = new BodyMap();
+    bm.init(() => {});
+    bm.setMarkScale(0.5);
+    bm.addMark(10, 20, TOOLS.WOUND.char, 'front', 'front-torso');
+    bm.addMark(30, 40, TOOLS.WOUND.char, 'back', 'back-torso');
+    const marks = document.querySelectorAll('#marks use');
+    expect(marks[0].getAttribute('transform')).toBe('translate(10,20) scale(0.5)');
+    expect(marks[1].getAttribute('transform')).toBe('translate(30,40) scale(0.5)');
+  });
+
   test('load restores marks and brushes', () => {
     setupDom();
     const bm = new BodyMap();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -144,6 +144,7 @@ async function init(){
     initCollapsibles();
   }
   bodyMap.init(saveAllDebounced);
+  bodyMap.setMarkScale(0.5);
   initChips(saveAllDebounced);
   initAutoActivate(saveAllDebounced);
   initActions(saveAllDebounced);


### PR DESCRIPTION
## Summary
- set mark scaling factor to 0.5 in body map initialisation for smaller wound/bruise markers
- add unit test verifying scaled markers on front and back silhouettes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc4494473c8320b1246bb6da8436b8