### PR TITLE
Reduce wound and bruise marker size

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -144,7 +144,7 @@ async function init(){
     initCollapsibles();
   }
   bodyMap.init(saveAllDebounced);
-  bodyMap.setMarkScale(0.5);
+  bodyMap.setMarkScale(0.35);
   initChips(saveAllDebounced);
   initAutoActivate(saveAllDebounced);
   initActions(saveAllDebounced);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -144,7 +144,7 @@ async function init(){
     initCollapsibles();
   }
   bodyMap.init(saveAllDebounced);
-  bodyMap.setMarkScale(0.5);
+  bodyMap.setMarkScale(0.35);
   initChips(saveAllDebounced);
   initAutoActivate(saveAllDebounced);
   initActions(saveAllDebounced);


### PR DESCRIPTION
## Summary
- shrink wound and bruise markers by reducing default mark scale to 0.35
- regenerate docs with updated setting

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc543c94348320b5f505cae17bf993