### PR TITLE
Pataisytas žymių dydis ir simbolių viewBox

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -314,8 +314,8 @@
       <svg id="bodySvg" viewBox="0 0 1500 1090" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <!-- Marker symbols -->
         <defs>
-          <symbol id="sym-wound" viewBox="-7 -7 14 14">
-            <circle r="7" class="mark-w"/>
+          <symbol id="sym-wound" viewBox="-10 -10 20 20">
+            <circle r="10" class="mark-w"/>
             <path d="M-10 0 L10 0 M0 -10 L0 10" class="mark-w"/>
           </symbol>
           <symbol id="sym-bruise" viewBox="-5 -5 10 10">

--- a/public/js/BodyMapTools.js
+++ b/public/js/BodyMapTools.js
@@ -1,6 +1,6 @@
 export const TOOLS = {
-  WOUND: { char: 'Ž', symbol: '#sym-wound' },
-  BRUISE: { char: 'S', symbol: '#sym-bruise' },
+  WOUND: { char: 'Ž', symbol: '#sym-wound', size: 14 },
+  BRUISE: { char: 'S', symbol: '#sym-bruise', size: 10 },
   BURN: { char: 'B', symbol: '' },
   BURN_ERASE: { char: 'E', symbol: '' }
 };

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -456,6 +456,9 @@ export default class BodyMap {
       use.setAttribute('href', symbol);
       use.setAttributeNS('http://www.w3.org/1999/xlink', 'href', symbol);
     }
+    const size = TOOLS[type]?.size || 14;
+    use.setAttribute('width', size);
+    use.setAttribute('height', size);
     const transforms = [`translate(${x},${y})`];
     if (this.markScale !== 1) transforms.push(`scale(${this.markScale})`);
     use.setAttribute('transform', transforms.join(' '));


### PR DESCRIPTION
## Santrauka
- nustatyti `width` ir `height` žymėms pagal įrankio dydį
- įrankiams pridėtas dydžio laukas
- sutvarkytas `sym-wound` viewBox, kad nebekirptų kontūrų

## Testai
- `npm run test:client`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68be75fc12688320970a63e00fcf0086