### PR TITLE
Correct SVG point calculation

### DIFF
--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -24,6 +24,15 @@ describe('BodyMap minimal', () => {
     expect(data.marks[0]).toMatchObject({ x: 10, y: 20, type: TOOLS.WOUND.char, zone: 'front-torso' });
   });
 
+  test('addBrush uses provided coordinates', () => {
+    setupDom();
+    const bm = new BodyMap();
+    bm.init(() => {});
+    const brush = bm.addBrush(15, 25, 5);
+    expect(brush.getAttribute('cx')).toBe('15');
+    expect(brush.getAttribute('cy')).toBe('25');
+  });
+
   test('load restores marks and brushes', () => {
     setupDom();
     const bm = new BodyMap();

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -75,8 +75,11 @@ export default class BodyMap {
     this.initialized = true;
   }
 
-  svgPoint(evt) {
-    return { x: evt.offsetX || 0, y: evt.offsetY || 0 };
+  svgPoint(evt){
+    const pt=this.svg.createSVGPoint();
+    pt.x=evt.clientX; pt.y=evt.clientY;
+    const {x,y}=pt.matrixTransform(this.svg.getScreenCTM().inverse());
+    return {x,y};
   }
 
   setTool(tool) { this.activeTool = tool; }


### PR DESCRIPTION
## Summary
- use SVG `matrixTransform` to convert click positions to SVG coordinates
- ensure brush marks store coordinates directly and add test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf2b0def948320877e05a30601edfe