### PR TITLE
Bind body map toolbar buttons

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -154,6 +154,21 @@ async function init(){
   initMechanismList();
   document.addEventListener('input', saveAllDebounced);
   initCirculation();
+  const toolBtns=$$('.map-toolbar .tool');
+  toolBtns.forEach(btn=>{
+    if(btn.dataset.tool===bodyMap.activeTool) btn.classList.add('active');
+    btn.addEventListener('click',()=>{
+      if(btn.dataset.tool){
+        bodyMap.setTool(btn.dataset.tool);
+        toolBtns.forEach(b=>b.classList.toggle('active', b===btn));
+      }
+    });
+  });
+  const btnClearMap=$('#btnClearMap');
+  if(btnClearMap) btnClearMap.addEventListener('click',()=>{
+    bodyMap.clear();
+    saveAllDebounced();
+  });
   const btnOxygen=$('#btnOxygen');
   if(btnOxygen) btnOxygen.addEventListener('click',()=>{
     const box=$('#oxygenFields');


### PR DESCRIPTION
## Summary
- Attach body map toolbar buttons to `bodyMap.setTool` and toggle active states.
- Hook clear button to wipe map and save changes.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1a24ba5c883209f2400cb2825ff6c