### PR TITLE
feat: add undo/redo for body map

### DIFF
--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -52,5 +52,30 @@ describe('BodyMap minimal', () => {
     expect(counts['front-torso'][TOOLS.WOUND.char]).toBe(1);
     expect(counts['front-torso'].burned).toBeGreaterThan(0);
   });
+
+  test('undo and redo revert mark operations', () => {
+    setupDom();
+    const bm = new BodyMap();
+    bm.init(() => {});
+    bm.addMark(10,20,TOOLS.WOUND.char,'front','front-torso');
+    expect(bm.marksLayer.querySelectorAll('use').length).toBe(1);
+    bm.undo();
+    expect(bm.marksLayer.querySelectorAll('use').length).toBe(0);
+    bm.redo();
+    expect(bm.marksLayer.querySelectorAll('use').length).toBe(1);
+  });
+
+  test('undo restores erased brush', () => {
+    setupDom();
+    const bm = new BodyMap();
+    bm.init(() => {});
+    bm.addBrush(10,10,5);
+    bm.eraseBrush(10,10,5);
+    expect(bm.brushLayer.querySelectorAll('circle').length).toBe(0);
+    bm.undo();
+    expect(bm.brushLayer.querySelectorAll('circle').length).toBe(1);
+    bm.redo();
+    expect(bm.brushLayer.querySelectorAll('circle').length).toBe(0);
+  });
 });
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -166,6 +166,10 @@ async function init(){
       }
     });
   });
+  const btnUndo=$('#btnUndo');
+  if(btnUndo) btnUndo.addEventListener('click',()=>{ bodyMap.undo(); saveAllDebounced(); });
+  const btnRedo=$('#btnRedo');
+  if(btnRedo) btnRedo.addEventListener('click',()=>{ bodyMap.redo(); saveAllDebounced(); });
   const btnClearMap=$('#btnClearMap');
   if(btnClearMap) btnClearMap.addEventListener('click',()=>{
     bodyMap.clear();


### PR DESCRIPTION
## Summary
- track user actions in `BodyMap` with new undo/redo stacks and methods
- wire undo/redo buttons in app initialization
- test undo/redo behaviour for marks and burns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1cee8044883208aa6c8d1dd795f63