### PR TITLE
Track burn area after brush edits

### DIFF
--- a/docs/js/components/BodyMap.js
+++ b/docs/js/components/BodyMap.js
@@ -111,6 +111,7 @@ export default class BodyMap {
     c.dataset.y = y;
     c.dataset.r = r;
     this.brushLayer.appendChild(c);
+    this.updateBurnTotal();
     return c;
   }
 
@@ -151,6 +152,13 @@ export default class BodyMap {
       return sum + Math.PI * r * r;
     }, 0);
     return (total * 100) / TOTAL_AREA;
+  }
+
+  updateBurnTotal() {
+    const el = document.querySelector('#burnTotal');
+    if (!el) return;
+    const pct = this.burnArea().toFixed(1);
+    el.textContent = `${pct}%`;
   }
 
   zoneCounts() {

--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -3,6 +3,7 @@ import { TOOLS } from '../BodyMapTools.js';
 
 function setupDom() {
   document.body.innerHTML = `
+    <div id="burnTotal"></div>
     <svg id="bodySvg"><g id="layer-front"></g><g id="layer-back"></g><g id="marks"></g></svg>
   `;
 }
@@ -76,6 +77,17 @@ describe('BodyMap minimal', () => {
     expect(bm.brushLayer.querySelectorAll('circle').length).toBe(1);
     bm.redo();
     expect(bm.brushLayer.querySelectorAll('circle').length).toBe(0);
+  });
+
+  test('burnTotal updates after brush changes', () => {
+    setupDom();
+    const bm = new BodyMap();
+    bm.init(() => {});
+    const totalEl = document.getElementById('burnTotal');
+    bm.addBrush(10,10,5);
+    expect(totalEl.textContent).toBe(`${bm.burnArea().toFixed(1)}%`);
+    bm.eraseBrush(10,10,5);
+    expect(totalEl.textContent).toBe(`${bm.burnArea().toFixed(1)}%`);
   });
 });
 

--- a/public/js/components/BodyMap.js
+++ b/public/js/components/BodyMap.js
@@ -127,6 +127,7 @@ export default class BodyMap {
     this.brushLayer.appendChild(c);
     this.undoStack.push({ type: 'addBrush', el: c });
     this.redoStack = [];
+    this.updateBurnTotal();
     return c;
   }
 
@@ -149,6 +150,7 @@ export default class BodyMap {
       this.undoStack.push({ type: 'eraseBrush', els: removed });
       this.redoStack = [];
     }
+    this.updateBurnTotal();
   }
 
   clear() {
@@ -190,6 +192,13 @@ export default class BodyMap {
       return sum + Math.PI * r * r;
     }, 0);
     return (total * 100) / TOTAL_AREA;
+  }
+
+  updateBurnTotal() {
+    const el = document.querySelector('#burnTotal');
+    if (!el) return;
+    const pct = this.burnArea().toFixed(1);
+    el.textContent = `${pct}%`;
   }
 
   zoneCounts() {


### PR DESCRIPTION
## Summary
- trigger `burnArea` after every brush add or erase
- update `#burnTotal` element with rounded percent
- test burn percent UI updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c245158b988320800aa461ee2748f8