### PR TITLE
feat: inline body map symbols for export

### DIFF
--- a/docs/js/headerActions.js
+++ b/docs/js/headerActions.js
@@ -52,8 +52,8 @@ export function setupHeaderActions({ validateForm }){
       doc.open();
       doc.write('<!DOCTYPE html><html><head><meta charset="utf-8"><title>Santrauka</title><link rel="stylesheet" href="/css/main.css"><style>body{font-family:sans-serif;padding:20px;} pre{white-space:pre-wrap;}</style></head><body></body></html>');
       doc.close();
-      const svg=doc.importNode(document.getElementById('bodySvg'), true);
-      await bodyMap.embedSilhouettes(svg);
+      let svg=doc.importNode(document.getElementById('bodySvg'), true);
+      svg=await bodyMap.embedSilhouettes(svg);
       const front=svg.querySelector('#layer-front');
       const back=svg.querySelector('#layer-back');
       if(front) front.classList.remove('hidden');

--- a/public/js/headerActions.js
+++ b/public/js/headerActions.js
@@ -52,8 +52,8 @@ export function setupHeaderActions({ validateForm }){
       doc.open();
       doc.write('<!DOCTYPE html><html><head><meta charset="utf-8"><title>Santrauka</title><link rel="stylesheet" href="/css/main.css"><style>body{font-family:sans-serif;padding:20px;} pre{white-space:pre-wrap;}</style></head><body></body></html>');
       doc.close();
-      const svg=doc.importNode(document.getElementById('bodySvg'), true);
-      await bodyMap.embedSilhouettes(svg);
+      let svg=doc.importNode(document.getElementById('bodySvg'), true);
+      svg=await bodyMap.embedSilhouettes(svg);
       const front=svg.querySelector('#layer-front');
       const back=svg.querySelector('#layer-back');
       if(front) front.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- inline `<use>` references in body map SVG for reliable printing/export
- invoke `embedSilhouettes` with returned SVG in header actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c24b6b940083209e8015f007609cf6