### PR TITLE
Fix map tool button listener

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -156,14 +156,12 @@ async function init(){
   initMechanismList();
   document.addEventListener('input', saveAllDebounced);
   initCirculation();
-  const toolBtns=$$('.map-toolbar .tool');
+  const toolBtns=$$('.map-toolbar .tool[data-tool]');
   toolBtns.forEach(btn=>{
     if(btn.dataset.tool===bodyMap.activeTool) btn.classList.add('active');
     btn.addEventListener('click',()=>{
-      if(btn.dataset.tool){
-        bodyMap.setTool(btn.dataset.tool);
-        toolBtns.forEach(b=>b.classList.toggle('active', b===btn));
-      }
+      bodyMap.setTool(btn.dataset.tool);
+      toolBtns.forEach(b=>b.classList.toggle('active', b===btn));
     });
   });
   const btnUndo=$('#btnUndo');


### PR DESCRIPTION
## Summary
- limit map toolbar tool handlers to buttons with `data-tool`
- keep undo, redo, clear and export buttons on their own listeners

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2c2300df8832088648c9631d6b126