### PR TITLE
Integrate wound editor with body map marks

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -22,6 +22,7 @@ import { init as initFastGrid } from './fastGrid.js';
 import { init as initTeamGrid } from './teamGrid.js';
 import { init as initMechanismList } from './mechanismList.js';
 import { initChipGroups } from './chipData.js';
+import woundEditor from './woundEditor.js';
 export { validateVitals, createChipGroup };
 
 initTheme();
@@ -145,6 +146,7 @@ async function init(){
   }
   bodyMap.init(saveAllDebounced);
   bodyMap.setMarkScale(0.35);
+  woundEditor.init(bodyMap);
   const brushSlider = $('#brushSize');
   if(brushSlider) brushSlider.addEventListener('input', e => bodyMap.setBrushSize(e.target.value));
   initChips(saveAllDebounced);


### PR DESCRIPTION
## Summary
- initialize woundEditor with bodyMap in app bootstrap
- open wound editor modal after creating or clicking a mark and save details to `dataset.details`
- ensure mark details persist through `bodyMap.serialize`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c32f8369e88320ad4044b7210972a6