### PR TITLE
Use fieldsets for pupil notes with proper aria handling

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -264,22 +264,18 @@
           </div>
         </fieldset>
       </div>
-      <div class="mt-8">
-        <label>Vyzdžiai – Kairė</label>
-        <div id="d_pupil_left_wrapper" aria-expanded="false">
-          <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"></div>
-          <label for="d_pupil_left_note" class="mt-6 hidden" hidden>Pastabos</label>
-          <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
-        </div>
-      </div>
-      <div class="mt-8">
-        <label>Vyzdžiai – Dešinė</label>
-        <div id="d_pupil_right_wrapper" aria-expanded="false">
-          <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"></div>
-          <label for="d_pupil_right_note" class="mt-6 hidden" hidden>Pastabos</label>
-          <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
-        </div>
-      </div>
+      <fieldset class="mt-8" id="d_pupil_left_wrapper" aria-expanded="false">
+        <legend>Vyzdžiai – Kairė</legend>
+        <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"></div>
+        <label for="d_pupil_left_note" class="mt-6 hidden" hidden>Pastabos</label>
+        <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
+      </fieldset>
+      <fieldset class="mt-8" id="d_pupil_right_wrapper" aria-expanded="false">
+        <legend>Vyzdžiai – Dešinė</legend>
+        <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"></div>
+        <label for="d_pupil_right_note" class="mt-6 hidden" hidden>Pastabos</label>
+        <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
+      </fieldset>
       <div class="row mt-8"><label class="m-0" for="d_notes">Pastabos</label><input id="d_notes" type="text" placeholder="Trumpai..."></div>
     </section>
 

--- a/docs/js/chips.js
+++ b/docs/js/chips.js
@@ -62,7 +62,7 @@ function togglePupilNote(side, chip){
     label.classList.toggle('hidden', !show);
   }
   if(!show) note.value='';
-  group.setAttribute('aria-expanded', show);
+  group.setAttribute('aria-expanded', show ? 'true' : 'false');
 }
 
 function toggleBackNote(chip){

--- a/docs/js/domToggles.js
+++ b/docs/js/domToggles.js
@@ -9,7 +9,7 @@ export function updateDomToggles(){
   leftNote.classList.toggle('hidden', !showLeftNote);
   if(leftLabel){ leftLabel.hidden = !showLeftNote; leftLabel.classList.toggle('hidden', !showLeftNote); }
   const leftWrapper = $('#d_pupil_left_wrapper');
-  if(leftWrapper) leftWrapper.setAttribute('aria-expanded', showLeftNote);
+  if(leftWrapper) leftWrapper.setAttribute('aria-expanded', showLeftNote ? 'true' : 'false');
 
   const showRightNote = $$('.chip.active', $('#d_pupil_right_group')).some(c => c.dataset.value === 'kita');
   const rightNote = $('#d_pupil_right_note');
@@ -18,7 +18,7 @@ export function updateDomToggles(){
   rightNote.classList.toggle('hidden', !showRightNote);
   if(rightLabel){ rightLabel.hidden = !showRightNote; rightLabel.classList.toggle('hidden', !showRightNote); }
   const rightWrapper = $('#d_pupil_right_wrapper');
-  if(rightWrapper) rightWrapper.setAttribute('aria-expanded', showRightNote);
+  if(rightWrapper) rightWrapper.setAttribute('aria-expanded', showRightNote ? 'true' : 'false');
 
   const showBack = $$('.chip.active', $('#e_back_group')).some(c => c.dataset.value === 'Pakitimai');
   const backNote = $('#e_back_notes');

--- a/public/index.html
+++ b/public/index.html
@@ -285,22 +285,18 @@
           </div>
         </fieldset>
       </div>
-      <div class="mt-8">
-        <label>Vyzdžiai – Kairė</label>
-        <div id="d_pupil_left_wrapper" aria-expanded="false">
-          <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"></div>
-          <label for="d_pupil_left_note" class="mt-6 hidden" hidden>Pastabos</label>
-          <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
-        </div>
-      </div>
-      <div class="mt-8">
-        <label>Vyzdžiai – Dešinė</label>
-        <div id="d_pupil_right_wrapper" aria-expanded="false">
-          <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"></div>
-          <label for="d_pupil_right_note" class="mt-6 hidden" hidden>Pastabos</label>
-          <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
-        </div>
-      </div>
+      <fieldset class="mt-8" id="d_pupil_left_wrapper" aria-expanded="false">
+        <legend>Vyzdžiai – Kairė</legend>
+        <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"></div>
+        <label for="d_pupil_left_note" class="mt-6 hidden" hidden>Pastabos</label>
+        <input id="d_pupil_left_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
+      </fieldset>
+      <fieldset class="mt-8" id="d_pupil_right_wrapper" aria-expanded="false">
+        <legend>Vyzdžiai – Dešinė</legend>
+        <div class="chip-group" id="d_pupil_right_group" data-single="true" aria-label="Vyzdžiai – Dešinė"></div>
+        <label for="d_pupil_right_note" class="mt-6 hidden" hidden>Pastabos</label>
+        <input id="d_pupil_right_note" type="text" placeholder="Pastabos..." class="mt-6 hidden" hidden>
+      </fieldset>
       <div class="row mt-8"><label class="m-0" for="d_notes">Pastabos</label><input id="d_notes" type="text" placeholder="Trumpai..."></div>
     </section>
 

--- a/public/js/__tests__/chips.test.js
+++ b/public/js/__tests__/chips.test.js
@@ -214,14 +214,15 @@ describe('chips', () => {
 
   test('toggles pupil note visibility and clears value when switching options', () => {
     document.body.innerHTML = `
-      <div id="d_pupil_left_wrapper" aria-expanded="false">
+      <fieldset id="d_pupil_left_wrapper" aria-expanded="false">
+        <legend>Vyzdžiai – Kairė</legend>
         <div id="d_pupil_left_group" data-single="true">
           <button type="button" class="chip" data-value="n.y." aria-pressed="false"></button>
           <button type="button" class="chip" data-value="kita" aria-pressed="false"></button>
         </div>
         <label for="d_pupil_left_note" class="hidden" hidden>Pastabos</label>
         <input id="d_pupil_left_note" class="hidden" hidden />
-      </div>
+      </fieldset>
     `;
     const { initChips } = require('../chips.js');
     initChips();

--- a/public/js/__tests__/sessionManager.test.js
+++ b/public/js/__tests__/sessionManager.test.js
@@ -58,9 +58,9 @@ describe('sessionManager utilities', () => {
   test('updateDomToggles responds to chip state', () => {
     document.body.innerHTML = `
       <div id="d_pupil_left_group"><span class="chip" data-value="kita"></span></div>
-      <div id="d_pupil_left_wrapper"><label for="d_pupil_left_note"></label><input id="d_pupil_left_note" class="hidden" /></div>
+      <fieldset id="d_pupil_left_wrapper"><label for="d_pupil_left_note"></label><input id="d_pupil_left_note" class="hidden" /></fieldset>
       <div id="d_pupil_right_group"></div>
-      <div id="d_pupil_right_wrapper"><label for="d_pupil_right_note"></label><input id="d_pupil_right_note" /></div>
+      <fieldset id="d_pupil_right_wrapper"><label for="d_pupil_right_note"></label><input id="d_pupil_right_note" /></fieldset>
       <div id="e_back_group"></div><div id="e_back_notes"></div>
       <div id="e_abdomen_group"></div><div id="e_abdomen_notes"></div>
       <div id="c_skin_color_group"></div><input id="c_skin_color_other" />

--- a/public/js/chips.js
+++ b/public/js/chips.js
@@ -62,7 +62,7 @@ function togglePupilNote(side, chip){
     label.classList.toggle('hidden', !show);
   }
   if(!show) note.value='';
-  group.setAttribute('aria-expanded', show);
+  group.setAttribute('aria-expanded', show ? 'true' : 'false');
 }
 
 function toggleBackNote(chip){

--- a/public/js/domToggles.js
+++ b/public/js/domToggles.js
@@ -9,7 +9,7 @@ export function updateDomToggles(){
   leftNote.classList.toggle('hidden', !showLeftNote);
   if(leftLabel){ leftLabel.hidden = !showLeftNote; leftLabel.classList.toggle('hidden', !showLeftNote); }
   const leftWrapper = $('#d_pupil_left_wrapper');
-  if(leftWrapper) leftWrapper.setAttribute('aria-expanded', showLeftNote);
+  if(leftWrapper) leftWrapper.setAttribute('aria-expanded', showLeftNote ? 'true' : 'false');
 
   const showRightNote = $$('.chip.active', $('#d_pupil_right_group')).some(c => c.dataset.value === 'kita');
   const rightNote = $('#d_pupil_right_note');
@@ -18,7 +18,7 @@ export function updateDomToggles(){
   rightNote.classList.toggle('hidden', !showRightNote);
   if(rightLabel){ rightLabel.hidden = !showRightNote; rightLabel.classList.toggle('hidden', !showRightNote); }
   const rightWrapper = $('#d_pupil_right_wrapper');
-  if(rightWrapper) rightWrapper.setAttribute('aria-expanded', showRightNote);
+  if(rightWrapper) rightWrapper.setAttribute('aria-expanded', showRightNote ? 'true' : 'false');
 
   const showBack = $$('.chip.active', $('#e_back_group')).some(c => c.dataset.value === 'Pakitimai');
   const backNote = $('#e_back_notes');


### PR DESCRIPTION
## Summary
- wrap left and right pupil sections in fieldsets with legends
- expose hidden pupil note fields inside the fieldsets
- ensure JS toggles use string `aria-expanded` values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3ef47fad4832093a3572787fc3455