### PR TITLE
Refactor pupil note toggles

### DIFF
--- a/public/js/__tests__/sessionManager.test.js
+++ b/public/js/__tests__/sessionManager.test.js
@@ -55,13 +55,34 @@ describe('sessionManager utilities', () => {
     expect(document.querySelector('#group .chip[data-value="b"]').classList.contains('active')).toBe(true);
   });
 
-  test('updateDomToggles responds to chip state', () => {
+  test('togglePupilNote responds to chip state', () => {
     document.body.innerHTML = `
       <div id="d_pupil_left_group"><span class="chip" data-value="kita"></span></div>
       <fieldset id="d_pupil_left_wrapper"><label for="d_pupil_left_note"></label><input id="d_pupil_left_note" class="hidden" /></fieldset>
-      <div id="d_pupil_right_group"></div>
-      <fieldset id="d_pupil_right_wrapper"><label for="d_pupil_right_note"></label><input id="d_pupil_right_note" /></fieldset>
-      <div id="e_back_group"></div><div id="e_back_notes"></div>
+      <div id="d_pupil_right_group"><span class="chip" data-value="kita"></span></div>
+      <fieldset id="d_pupil_right_wrapper"><label for="d_pupil_right_note"></label><input id="d_pupil_right_note" class="hidden" /></fieldset>
+    `;
+    const { togglePupilNote, setChipActive } = require('../chips.js');
+    const leftChip = document.querySelector('#d_pupil_left_group .chip');
+    const rightChip = document.querySelector('#d_pupil_right_group .chip');
+    togglePupilNote('left');
+    togglePupilNote('right');
+    expect(document.getElementById('d_pupil_left_note').classList.contains('hidden')).toBe(true);
+    expect(document.getElementById('d_pupil_right_note').classList.contains('hidden')).toBe(true);
+    setChipActive(leftChip, true);
+    togglePupilNote('left');
+    expect(document.getElementById('d_pupil_left_note').classList.contains('hidden')).toBe(false);
+    setChipActive(rightChip, true);
+    togglePupilNote('right');
+    expect(document.getElementById('d_pupil_right_note').classList.contains('hidden')).toBe(false);
+    setChipActive(leftChip, false);
+    togglePupilNote('left');
+    expect(document.getElementById('d_pupil_left_note').classList.contains('hidden')).toBe(true);
+  });
+
+  test('updateDomToggles toggles back notes based on chip state', () => {
+    document.body.innerHTML = `
+      <div id="e_back_group"><span class="chip" data-value="Pakitimai"></span></div><div id="e_back_notes" class="hidden"></div>
       <div id="e_abdomen_group"></div><div id="e_abdomen_notes"></div>
       <div id="c_skin_color_group"></div><input id="c_skin_color_other" />
       <div id="oxygenFields"></div><input id="b_oxygen_liters"><input id="b_oxygen_type">
@@ -77,12 +98,12 @@ describe('sessionManager utilities', () => {
       <div id="imaging_other" class="hidden"></div>
     `;
     const { updateDomToggles } = require('../domToggles.js');
-    const chip = document.querySelector('#d_pupil_left_group .chip');
+    const chip = document.querySelector('#e_back_group .chip');
     updateDomToggles();
-    expect(document.getElementById('d_pupil_left_note').classList.contains('hidden')).toBe(true);
+    expect(document.getElementById('e_back_notes').classList.contains('hidden')).toBe(true);
     chip.classList.add('active');
     updateDomToggles();
-    expect(document.getElementById('d_pupil_left_note').classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('e_back_notes').classList.contains('hidden')).toBe(false);
   });
 
   test('saveAll resolves and updates status text', async () => {

--- a/public/js/chips.js
+++ b/public/js/chips.js
@@ -48,21 +48,21 @@ export function setChipActive(chip, active){
   if(sr) sr.textContent=active?'selected':'not selected';
 }
 
-function togglePupilNote(side, chip){
-  const groupId = `d_pupil_${side}_group`;
-  if(chip.parentElement?.id !== groupId) return;
+export function togglePupilNote(side){
+  const group = $(`#d_pupil_${side}_group`);
   const note = $(`#d_pupil_${side}_note`);
-  const group = note.parentElement;
-  const show = chip.dataset.value==='kita' && isChipActive(chip);
+  if(!group || !note) return;
+  const show = $$('.chip.active', group).some(c => c.dataset.value === 'kita');
   note.hidden = !show;
   note.classList.toggle('hidden', !show);
-  const label = group.querySelector(`label[for="d_pupil_${side}_note"]`);
+  const label = $(`#d_pupil_${side}_wrapper label[for="d_pupil_${side}_note"]`);
   if(label){
     label.hidden = !show;
     label.classList.toggle('hidden', !show);
   }
   if(!show) note.value='';
-  group.setAttribute('aria-expanded', show ? 'true' : 'false');
+  const wrapper = $(`#d_pupil_${side}_wrapper`);
+  if(wrapper) wrapper.setAttribute('aria-expanded', show ? 'true' : 'false');
 }
 
 function toggleBackNote(chip){
@@ -122,6 +122,8 @@ export function initChips(saveAll){
     }
     setChipActive(chip, isChipActive(chip));
   });
+  togglePupilNote('left');
+  togglePupilNote('right');
   updateBreathGroups();
   if(listenersAdded) return;
   listenersAdded = true;
@@ -136,8 +138,8 @@ export function initChips(saveAll){
     } else {
       setChipActive(chip, !isChipActive(chip));
     }
-    togglePupilNote('left', chip);
-    togglePupilNote('right', chip);
+    togglePupilNote('left');
+    togglePupilNote('right');
     toggleBackNote(chip);
     toggleAbdomenNote(chip);
     toggleSkinColorNote(chip);

--- a/public/js/domToggles.js
+++ b/public/js/domToggles.js
@@ -2,24 +2,6 @@ import { $, $$ } from './utils.js';
 import { IMAGING_GROUPS } from './chipState.js';
 
 export function updateDomToggles(){
-  const showLeftNote = $$('.chip.active', $('#d_pupil_left_group')).some(c => c.dataset.value === 'kita');
-  const leftNote = $('#d_pupil_left_note');
-  const leftLabel = $('#d_pupil_left_wrapper label[for="d_pupil_left_note"]');
-  leftNote.hidden = !showLeftNote;
-  leftNote.classList.toggle('hidden', !showLeftNote);
-  if(leftLabel){ leftLabel.hidden = !showLeftNote; leftLabel.classList.toggle('hidden', !showLeftNote); }
-  const leftWrapper = $('#d_pupil_left_wrapper');
-  if(leftWrapper) leftWrapper.setAttribute('aria-expanded', showLeftNote ? 'true' : 'false');
-
-  const showRightNote = $$('.chip.active', $('#d_pupil_right_group')).some(c => c.dataset.value === 'kita');
-  const rightNote = $('#d_pupil_right_note');
-  const rightLabel = $('#d_pupil_right_wrapper label[for="d_pupil_right_note"]');
-  rightNote.hidden = !showRightNote;
-  rightNote.classList.toggle('hidden', !showRightNote);
-  if(rightLabel){ rightLabel.hidden = !showRightNote; rightLabel.classList.toggle('hidden', !showRightNote); }
-  const rightWrapper = $('#d_pupil_right_wrapper');
-  if(rightWrapper) rightWrapper.setAttribute('aria-expanded', showRightNote ? 'true' : 'false');
-
   const showBack = $$('.chip.active', $('#e_back_group')).some(c => c.dataset.value === 'Pakitimai');
   const backNote = $('#e_back_notes');
   backNote.style.display = showBack ? 'block' : 'none';


### PR DESCRIPTION
## Summary
- centralize pupil note visibility in chips.js with reusable `togglePupilNote`
- drop pupil logic from `updateDomToggles`
- add tests for pupil note and back note toggling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c407d6763c832085120e18987816a2