### PR TITLE
Handle hidden class when toggling GCS calc panel

### DIFF
--- a/public/js/gcs.js
+++ b/public/js/gcs.js
@@ -18,6 +18,7 @@ function setupGcsCalc(prefix){
 
   let firstFocusable, lastFocusable;
   const close=()=>{
+    panel.classList.add('hidden');
     panel.style.display='none';
     document.removeEventListener('keydown',onKey);
     document.removeEventListener('click',onDocClick);
@@ -49,8 +50,9 @@ function setupGcsCalc(prefix){
   if(btnClose) btnClose.addEventListener('click',close);
 
   return ()=>{
-    const hidden=panel.style.display==='none';
+    const hidden=getComputedStyle(panel).display==='none';
     if(hidden){
+      panel.classList.remove('hidden');
       panel.style.display='block';
       const focusables=panel.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
       firstFocusable=focusables[0];


### PR DESCRIPTION
## Summary
- ensure `setupGcsCalc` adds or removes the `hidden` class while toggling panel visibility
- use `getComputedStyle` to check current panel state

## Testing
- `npm run test:client`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68c56c0012cc83209fdb557549d5cc3e