### PR TITLE
Fix GCS calc div placement

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -283,8 +283,8 @@
               <span id="d_gcs_calc_total"></span>
             </div>
           </div>
+          </div>
         </fieldset>
-      </div>
       <fieldset class="mt-8" id="d_pupil_left_wrapper" aria-expanded="false">
         <legend>Vyzdžiai – Kairė</legend>
         <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -283,8 +283,8 @@
               <span id="d_gcs_calc_total"></span>
             </div>
           </div>
+          </div>
         </fieldset>
-      </div>
       <fieldset class="mt-8" id="d_pupil_left_wrapper" aria-expanded="false">
         <legend>Vyzdžiai – Kairė</legend>
         <div class="chip-group" id="d_pupil_left_group" data-single="true" aria-label="Vyzdžiai – Kairė"></div>


### PR DESCRIPTION
## Summary
- fix closing div placement in GCS block so pupil fields stay in D tab
- mirror fix in docs build

## Testing
- `npm test`
- `node -e "const {JSDOM}=require('jsdom');const fs=require('fs');const html=fs.readFileSync('public/index.html','utf8');const dom=new JSDOM(html);const document=dom.window.document;function showTab(name){document.querySelectorAll('.view').forEach(v=>{v.hidden=v.dataset.tab!==name;});}showTab('D – Sąmonė');const left=document.getElementById('d_pupil_left_wrapper');const right=document.getElementById('d_pupil_right_wrapper');console.log('In D hidden ancestor class?',left.closest('.hidden')?left.closest('.hidden').id:'null',right.closest('.hidden')?right.closest('.hidden').id:'null');showTab('A – Kvėpavimo takai');console.log('After switching, hidden ancestor id:',left.closest('[hidden]').id,right.closest('[hidden]').id);"`

------
https://chatgpt.com/codex/tasks/task_e_68c6aeda95f883209b08036f47758c24