### PR TITLE
Keep pulse and skin sections expanded by default

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -196,7 +196,7 @@
         </div>
       </fieldset>
 
-      <fieldset class="collapsible" id="circulation-pulses">
+      <fieldset class="collapsible" id="circulation-pulses" data-open="true">
         <legend>Pulsai</legend>
         <div class="grid cols-2">
           <div>
@@ -210,7 +210,7 @@
         </div>
       </fieldset>
 
-      <fieldset class="collapsible" id="circulation-skin">
+      <fieldset class="collapsible" id="circulation-skin" data-open="true">
         <legend>Oda</legend>
         <div class="grid cols-2">
           <div>

--- a/public/index.html
+++ b/public/index.html
@@ -196,7 +196,7 @@
         </div>
       </fieldset>
 
-      <fieldset class="collapsible" id="circulation-pulses">
+      <fieldset class="collapsible" id="circulation-pulses" data-open="true">
         <legend>Pulsai</legend>
         <div class="grid cols-2">
           <div>
@@ -210,7 +210,7 @@
         </div>
       </fieldset>
 
-      <fieldset class="collapsible" id="circulation-skin">
+      <fieldset class="collapsible" id="circulation-skin" data-open="true">
         <legend>Oda</legend>
         <div class="grid cols-2">
           <div>


### PR DESCRIPTION
## Summary
- keep "Pulsai" and "Oda" fieldsets expanded on page load

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6b61bbffc8320ac3bdab2fdad0828