### PR TITLE
Simplify top bar layout and unify button styles

### DIFF
--- a/docs/assets/partials/topbar.html
+++ b/docs/assets/partials/topbar.html
@@ -12,30 +12,26 @@
   </div>
   <div class="header-center">
     <div class="toolbar" id="arrivalBar">
-      <button type="button" class="btn icon-btn primary" id="btnAtvyko" aria-label="Atvyko" title="Atvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>Atvyko</button>
+      <button type="button" class="btn" id="btnAtvyko" aria-label="Atvyko" title="Atvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg><span class="btn-label">Atvyko</span></button>
       <span id="arrivalTimer" class="arrival-timer" aria-live="polite"></span>
     </div>
   </div>
   <div class="header-actions" role="toolbar">
+    <div class="patient-menu-container">
     <details id="patientMenu" class="patient-menu">
-      <summary class="btn" aria-label="Pacientai" hidden><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg><span id="patientMenuLabel" class="btn-label">Pacientas</span></summary>
+      <summary class="btn" aria-label="Pacientas"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg><span id="patientMenuLabel" class="btn-label">Pacientas</span></summary>
       <div class="menu">
-        <button type="button" id="patientSearchToggle" class="btn icon-btn" title="Search patients" aria-label="Search patients"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
-        <input id="patientSearch" class="btn hidden" type="search" placeholder="Search…">
+        <button type="button" id="patientSearchToggle" class="btn icon-btn" title="Paieška" aria-label="Paieška"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
+        <input id="patientSearch" class="btn hidden" type="search" placeholder="Paieška…">
         <select id="sessionSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
-        <button type="button" id="btnNewSession" title="Naujas pacientas" aria-label="Naujas pacientas" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg> <span class="btn-label">Naujas</span></button>
-        <button type="button" id="renamePatientBtn" title="Pervardyti pacientą" aria-label="Pervardyti pacientą" class="btn icon-btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></button>
+        <button type="button" id="btnNewSession" title="Naujas pacientas" aria-label="Naujas pacientas" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg><span class="btn-label">Naujas</span></button>
         <button type="button" id="deletePatientBtn" title="Ištrinti pacientą" aria-label="Ištrinti pacientą" class="btn icon-btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></button>
         <button type="button" id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" aria-label="Išsaugoti vietoje (naršyklėje)" class="btn icon-btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg></button>
       </div>
     </details>
+    </div>
     <div class="toolbar" id="desktopActions">
       <button type="button" class="btn icon-btn" id="btnTheme" aria-label="Tamsus režimas" title="Tamsus režimas"></button>
     </div>
-    <div class="status-wrap">
-      <div id="userList" class="user-list"></div>
-      <div id="saveStatus" aria-live="polite"></div>
-    </div>
   </div>
 </div>
-<div class="nav-overlay" hidden></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,19 +19,42 @@
 <body>
 <a href="#views" class="skip-link">Skip to content</a>
 <header id="appHeader" role="banner">
-  <div class="patient-menu-container">
-  <details id="patientMenu" class="patient-menu">
-    <summary class="btn" aria-label="Pacientai" hidden><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg><span id="patientMenuLabel" class="btn-label">Pacientas</span></summary>
-    <div class="menu">
-      <button type="button" id="patientSearchToggle" class="btn" title="Search patients" aria-label="Search patients"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
-      <input id="patientSearch" class="btn hidden" type="search" placeholder="Search…">
-      <select id="sessionSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
-      <button id="btnNewSession" title="Naujas pacientas" aria-label="Naujas pacientas" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg> <span class="btn-label">Naujas</span></button>
-      <button id="renamePatientBtn" title="Pervardyti pacientą" aria-label="Pervardyti pacientą" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></button>
-      <button id="deletePatientBtn" title="Ištrinti pacientą" aria-label="Ištrinti pacientą" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></button>
-      <button id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" aria-label="Išsaugoti vietoje (naršyklėje)" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg></button>
+  <div class="wrap">
+    <div class="header-left">
+      <button type="button" class="btn icon-btn" id="navToggle" aria-controls="tabs" aria-expanded="false" aria-label="Navigacijos meniu" title="Navigacijos meniu">
+        <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div>
+        <h1>Sunkios traumos forma</h1>
+        <div class="sub">Aktyvacija · ABCE · Santrauka <span id="activationIndicator" class="activation-dot"></span><span id="activationStatusText" class="sr-only" aria-live="polite"></span></div>
+      </div>
     </div>
-  </details>
+    <div class="header-center">
+      <div class="toolbar" id="arrivalBar">
+        <button type="button" class="btn" id="btnAtvyko" aria-label="Atvyko" title="Atvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg><span class="btn-label">Atvyko</span></button>
+        <span id="arrivalTimer" class="arrival-timer" aria-live="polite"></span>
+      </div>
+    </div>
+    <div class="header-actions" role="toolbar">
+      <div class="patient-menu-container">
+      <details id="patientMenu" class="patient-menu">
+        <summary class="btn" aria-label="Pacientas"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg><span id="patientMenuLabel" class="btn-label">Pacientas</span></summary>
+        <div class="menu">
+          <button type="button" id="patientSearchToggle" class="btn icon-btn" title="Paieška" aria-label="Paieška"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
+          <input id="patientSearch" class="btn hidden" type="search" placeholder="Paieška…">
+          <select id="sessionSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
+          <button type="button" id="btnNewSession" title="Naujas pacientas" aria-label="Naujas pacientas" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg><span class="btn-label">Naujas</span></button>
+          <button type="button" id="deletePatientBtn" title="Ištrinti pacientą" aria-label="Ištrinti pacientą" class="btn icon-btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></button>
+          <button type="button" id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" aria-label="Išsaugoti vietoje (naršyklėje)" class="btn icon-btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg></button>
+        </div>
+      </details>
+      </div>
+      <div class="toolbar" id="desktopActions">
+        <button type="button" class="btn icon-btn" id="btnTheme" aria-label="Tamsus režimas" title="Tamsus režimas"></button>
+      </div>
+    </div>
   </div>
 </header>
 <template id="chip-template">

--- a/docs/js/components/topbar.js
+++ b/docs/js/components/topbar.js
@@ -151,9 +151,10 @@ export async function initTopbar(){
     const ro=new ResizeObserver(updateHeight);
     ro.observe(header);
   }
-  const toggle=document.getElementById('navToggle');
   const nav=document.querySelector('nav');
-  initNavToggle(toggle, nav);
+  nav?.removeAttribute('hidden');
+  const toggle=document.getElementById('navToggle');
+  if(toggle && nav) initNavToggle(toggle, nav);
   const patientMenu=document.getElementById('patientMenu');
   initPatientMenuToggle(patientMenu);
 }

--- a/docs/js/sessionUI.js
+++ b/docs/js/sessionUI.js
@@ -28,7 +28,6 @@ export async function initSessions(){
   let sessions=await getSessions();
   let currentSessionId=getCurrentSessionId();
   const patientLabel=$('#patientMenuLabel');
-  const renameBtn=$('#renamePatientBtn');
   const deleteBtn=$('#deletePatientBtn');
   const saveBtn=$('#saveBtn');
   const render=()=>{
@@ -58,26 +57,6 @@ export async function initSessions(){
     setCurrentSessionId(currentSessionId);
   }
   render();
-
-  renameBtn?.addEventListener('click', async () => {
-    const id=getCurrentSessionId();
-    const session=sessions.find(s=>s.id===id);
-    if(!session) return;
-    const newName=await notify({type:'prompt', message:'Paciento ID', defaultValue: session.name});
-    if(!newName) return;
-    const trimmed=newName.trim();
-    if(!trimmed){
-      notify({ type:'error', message:'Pavadinimas negali būti tuščias.' });
-      return;
-    }
-    if(sessions.some(s=>s.id!==id && s.name.trim().toLowerCase()===trimmed.toLowerCase())){
-      notify({ type:'error', message:'Pacientas su tokiu pavadinimu jau egzistuoja.' });
-      return;
-    }
-    session.name=trimmed;
-    await saveSessions(sessions);
-    render();
-  });
 
   deleteBtn?.addEventListener('click', async () => {
     const id=getCurrentSessionId();

--- a/public/assets/partials/topbar.html
+++ b/public/assets/partials/topbar.html
@@ -12,20 +12,19 @@
   </div>
   <div class="header-center">
     <div class="toolbar" id="arrivalBar">
-      <button type="button" class="btn icon-btn primary" id="btnAtvyko" aria-label="Atvyko" title="Atvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>Atvyko</button>
+      <button type="button" class="btn" id="btnAtvyko" aria-label="Atvyko" title="Atvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg><span class="btn-label">Atvyko</span></button>
       <span id="arrivalTimer" class="arrival-timer" aria-live="polite"></span>
     </div>
   </div>
   <div class="header-actions" role="toolbar">
     <div class="patient-menu-container">
     <details id="patientMenu" class="patient-menu">
-      <summary class="btn" aria-label="Pacientai" hidden><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg><span id="patientMenuLabel" class="btn-label">Pacientas</span></summary>
+      <summary class="btn" aria-label="Pacientas"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg><span id="patientMenuLabel" class="btn-label">Pacientas</span></summary>
       <div class="menu">
-        <button type="button" id="patientSearchToggle" class="btn icon-btn" title="Search patients" aria-label="Search patients"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
-        <input id="patientSearch" class="btn hidden" type="search" placeholder="Search…">
+        <button type="button" id="patientSearchToggle" class="btn icon-btn" title="Paieška" aria-label="Paieška"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
+        <input id="patientSearch" class="btn hidden" type="search" placeholder="Paieška…">
         <select id="sessionSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
-        <button type="button" id="btnNewSession" title="Naujas pacientas" aria-label="Naujas pacientas" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg> <span class="btn-label">Naujas</span></button>
-        <button type="button" id="renamePatientBtn" title="Pervardyti pacientą" aria-label="Pervardyti pacientą" class="btn icon-btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></button>
+        <button type="button" id="btnNewSession" title="Naujas pacientas" aria-label="Naujas pacientas" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg><span class="btn-label">Naujas</span></button>
         <button type="button" id="deletePatientBtn" title="Ištrinti pacientą" aria-label="Ištrinti pacientą" class="btn icon-btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></button>
         <button type="button" id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" aria-label="Išsaugoti vietoje (naršyklėje)" class="btn icon-btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg></button>
       </div>
@@ -34,10 +33,5 @@
     <div class="toolbar" id="desktopActions">
       <button type="button" class="btn icon-btn" id="btnTheme" aria-label="Tamsus režimas" title="Tamsus režimas"></button>
     </div>
-    <div class="status-wrap">
-      <div id="userList" class="user-list"></div>
-      <div id="saveStatus" aria-live="polite"></div>
-    </div>
   </div>
 </div>
-<div class="nav-overlay" hidden></div>

--- a/public/index.html
+++ b/public/index.html
@@ -19,19 +19,42 @@
 <body>
 <a href="#views" class="skip-link">Skip to content</a>
 <header id="appHeader" role="banner">
-  <div class="patient-menu-container">
-  <details id="patientMenu" class="patient-menu">
-    <summary class="btn" aria-label="Pacientai" hidden><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg><span id="patientMenuLabel" class="btn-label">Pacientas</span></summary>
-    <div class="menu">
-      <button type="button" id="patientSearchToggle" class="btn" title="Search patients" aria-label="Search patients"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
-      <input id="patientSearch" class="btn hidden" type="search" placeholder="Search…">
-      <select id="sessionSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
-      <button id="btnNewSession" title="Naujas pacientas" aria-label="Naujas pacientas" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg> <span class="btn-label">Naujas</span></button>
-      <button id="renamePatientBtn" title="Pervardyti pacientą" aria-label="Pervardyti pacientą" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></button>
-      <button id="deletePatientBtn" title="Ištrinti pacientą" aria-label="Ištrinti pacientą" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></button>
-      <button id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" aria-label="Išsaugoti vietoje (naršyklėje)" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg></button>
+  <div class="wrap">
+    <div class="header-left">
+      <button type="button" class="btn icon-btn" id="navToggle" aria-controls="tabs" aria-expanded="false" aria-label="Navigacijos meniu" title="Navigacijos meniu">
+        <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
+      <div>
+        <h1>Sunkios traumos forma</h1>
+        <div class="sub">Aktyvacija · ABCE · Santrauka <span id="activationIndicator" class="activation-dot"></span><span id="activationStatusText" class="sr-only" aria-live="polite"></span></div>
+      </div>
     </div>
-  </details>
+    <div class="header-center">
+      <div class="toolbar" id="arrivalBar">
+        <button type="button" class="btn" id="btnAtvyko" aria-label="Atvyko" title="Atvyko"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg><span class="btn-label">Atvyko</span></button>
+        <span id="arrivalTimer" class="arrival-timer" aria-live="polite"></span>
+      </div>
+    </div>
+    <div class="header-actions" role="toolbar">
+      <div class="patient-menu-container">
+      <details id="patientMenu" class="patient-menu">
+        <summary class="btn" aria-label="Pacientas"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg><span id="patientMenuLabel" class="btn-label">Pacientas</span></summary>
+        <div class="menu">
+          <button type="button" id="patientSearchToggle" class="btn icon-btn" title="Paieška" aria-label="Paieška"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
+          <input id="patientSearch" class="btn hidden" type="search" placeholder="Paieška…">
+          <select id="sessionSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
+          <button type="button" id="btnNewSession" title="Naujas pacientas" aria-label="Naujas pacientas" class="btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg><span class="btn-label">Naujas</span></button>
+          <button type="button" id="deletePatientBtn" title="Ištrinti pacientą" aria-label="Ištrinti pacientą" class="btn icon-btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></button>
+          <button type="button" id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" aria-label="Išsaugoti vietoje (naršyklėje)" class="btn icon-btn"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg></button>
+        </div>
+      </details>
+      </div>
+      <div class="toolbar" id="desktopActions">
+        <button type="button" class="btn icon-btn" id="btnTheme" aria-label="Tamsus režimas" title="Tamsus režimas"></button>
+      </div>
+    </div>
   </div>
 </header>
 <template id="chip-template">

--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -177,9 +177,10 @@ export async function initTopbar(){
     const ro=new ResizeObserver(updateHeight);
     ro.observe(header);
   }
-  const toggle=document.getElementById('navToggle');
   const nav=document.querySelector('nav');
-  initNavToggle(toggle, nav);
+  nav?.removeAttribute('hidden');
+  const toggle=document.getElementById('navToggle');
+  if(toggle && nav) initNavToggle(toggle, nav);
   const patientMenu=document.getElementById('patientMenu');
   initPatientMenuToggle(patientMenu);
 }

--- a/public/js/sessionUI.js
+++ b/public/js/sessionUI.js
@@ -28,7 +28,6 @@ export async function initSessions(){
   let sessions=await getSessions();
   let currentSessionId=getCurrentSessionId();
   const patientLabel=$('#patientMenuLabel');
-  const renameBtn=$('#renamePatientBtn');
   const deleteBtn=$('#deletePatientBtn');
   const saveBtn=$('#saveBtn');
   const render=()=>{
@@ -58,26 +57,6 @@ export async function initSessions(){
     setCurrentSessionId(currentSessionId);
   }
   render();
-
-  renameBtn?.addEventListener('click', async () => {
-    const id=getCurrentSessionId();
-    const session=sessions.find(s=>s.id===id);
-    if(!session) return;
-    const newName=await notify({type:'prompt', message:'Paciento ID', defaultValue: session.name});
-    if(!newName) return;
-    const trimmed=newName.trim();
-    if(!trimmed){
-      notify({ type:'error', message:'Pavadinimas negali būti tuščias.' });
-      return;
-    }
-    if(sessions.some(s=>s.id!==id && s.name.trim().toLowerCase()===trimmed.toLowerCase())){
-      notify({ type:'error', message:'Pacientas su tokiu pavadinimu jau egzistuoja.' });
-      return;
-    }
-    session.name=trimmed;
-    await saveSessions(sessions);
-    render();
-  });
 
   deleteBtn?.addEventListener('click', async () => {
     const id=getCurrentSessionId();


### PR DESCRIPTION
## Summary
- Streamlined top bar to keep arrival, patient, and theme controls
- Standardized button styling across the top bar for a consistent look
- Removed unused patient rename logic
- Restored navigation toggle so side navigation remains accessible

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8015cbb348320ad3726f0100acf9d