### PR TITLE
fix: show navigation when toggle absent

### DIFF
--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -179,6 +179,10 @@ export async function initTopbar(){
   }
   const toggle=document.getElementById('navToggle');
   const nav=document.querySelector('nav');
+  if(!toggle && nav){
+    nav.removeAttribute('hidden');
+    nav.removeAttribute('aria-hidden');
+  }
   initNavToggle(toggle, nav);
   const patientMenu=document.getElementById('patientMenu');
   initPatientMenuToggle(patientMenu);

--- a/public/js/tabs.js
+++ b/public/js/tabs.js
@@ -66,6 +66,8 @@ export function initTabs(){
     b.onclick=()=>showTab(t.name);
     nav.appendChild(b);
   });
+  nav.removeAttribute('hidden');
+  nav.removeAttribute('aria-hidden');
   document.querySelectorAll('.view').forEach((v, i) => {
     const active = i === 0;
     v.classList.toggle('visible', active);


### PR DESCRIPTION
## Summary
- handle missing nav toggle by unhiding nav before initializing
- ensure tabs nav is unhidden after building tab list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c80b1c6fc48320b0138be73a8a2a37