### PR TITLE
Expose nav when topbar fails

### DIFF
--- a/public/js/components/topbar.js
+++ b/public/js/components/topbar.js
@@ -163,9 +163,12 @@ export async function initTopbar(){
     if(!res.ok) throw new Error(`HTTP ${res.status}`);
     header.innerHTML=await res.text();
   }catch(e){
-    console.error('Failed to load topbar', e);
-    notify({type:'error', message:'Failed to load topbar'});
+    console.warn('Nepavyko įkelti viršutinės juostos', e);
+    notify({type:'error', message:'Nepavyko įkelti viršutinės juostos'});
     header.innerHTML='<div class="wrap"><button type="button" class="btn" id="retryTopbar">Retry</button></div>';
+    const nav=document.querySelector('nav');
+    nav?.removeAttribute('hidden');
+    nav?.removeAttribute('aria-hidden');
     header.querySelector('#retryTopbar')?.addEventListener('click', initTopbar);
   }
   if(typeof ResizeObserver==='function'){


### PR DESCRIPTION
## Summary
- warn and notify in Lithuanian when topbar load fails
- unhide nav on topbar load failure so navigation stays accessible

## Testing
- `npm run lint`
- `npm run test:client`
- `npm run test:server`


------
https://chatgpt.com/codex/tasks/task_e_68c8156293b08320b4ac5cb86ecbd620