### PR TITLE
Add ES5 legacy bundle for non-module browsers

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules/
 docs/
 public/js/lib
+public/js/app.legacy.js

--- a/public/index.html
+++ b/public/index.html
@@ -542,5 +542,6 @@
 
 <script src="https://cdn.socket.io/4.7.5/socket.io.min.js" integrity="sha384-2huaZvOR9iDzHqslqwpR87isEmrfxqyWOF7hr7BY6KG0+hVKLoEXMPUJw3ynWuhO" crossorigin="anonymous"></script>
 <script src="js/app.js" defer type="module"></script>
+<script nomodule src="js/app.legacy.js"></script>
 </body>
 </html>

--- a/public/js/app.legacy.js
+++ b/public/js/app.legacy.js
@@ -1,0 +1,16469 @@
+var TraumaTeamApp = (function (exports) {
+  'use strict';
+
+  function _arrayLikeToArray(r, a) {
+    (null == a || a > r.length) && (a = r.length);
+    for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e];
+    return n;
+  }
+  function _arrayWithHoles(r) {
+    if (Array.isArray(r)) return r;
+  }
+  function _arrayWithoutHoles(r) {
+    if (Array.isArray(r)) return _arrayLikeToArray(r);
+  }
+  function asyncGeneratorStep(n, t, e, r, o, a, c) {
+    try {
+      var i = n[a](c),
+        u = i.value;
+    } catch (n) {
+      return void e(n);
+    }
+    i.done ? t(u) : Promise.resolve(u).then(r, o);
+  }
+  function _asyncToGenerator(n) {
+    return function () {
+      var t = this,
+        e = arguments;
+      return new Promise(function (r, o) {
+        var a = n.apply(t, e);
+        function _next(n) {
+          asyncGeneratorStep(a, r, o, _next, _throw, "next", n);
+        }
+        function _throw(n) {
+          asyncGeneratorStep(a, r, o, _next, _throw, "throw", n);
+        }
+        _next(void 0);
+      });
+    };
+  }
+  function _classCallCheck(a, n) {
+    if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
+  }
+  function _defineProperties(e, r) {
+    for (var t = 0; t < r.length; t++) {
+      var o = r[t];
+      o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, _toPropertyKey(o.key), o);
+    }
+  }
+  function _createClass(e, r, t) {
+    return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
+      writable: !1
+    }), e;
+  }
+  function _createForOfIteratorHelper(r, e) {
+    var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"];
+    if (!t) {
+      if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) {
+        t && (r = t);
+        var n = 0,
+          F = function () {};
+        return {
+          s: F,
+          n: function () {
+            return n >= r.length ? {
+              done: !0
+            } : {
+              done: !1,
+              value: r[n++]
+            };
+          },
+          e: function (r) {
+            throw r;
+          },
+          f: F
+        };
+      }
+      throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+    }
+    var o,
+      a = !0,
+      u = !1;
+    return {
+      s: function () {
+        t = t.call(r);
+      },
+      n: function () {
+        var r = t.next();
+        return a = r.done, r;
+      },
+      e: function (r) {
+        u = !0, o = r;
+      },
+      f: function () {
+        try {
+          a || null == t.return || t.return();
+        } finally {
+          if (u) throw o;
+        }
+      }
+    };
+  }
+  function _defineProperty(e, r, t) {
+    return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+      value: t,
+      enumerable: !0,
+      configurable: !0,
+      writable: !0
+    }) : e[r] = t, e;
+  }
+  function _iterableToArray(r) {
+    if ("undefined" != typeof Symbol && null != r[Symbol.iterator] || null != r["@@iterator"]) return Array.from(r);
+  }
+  function _iterableToArrayLimit(r, l) {
+    var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"];
+    if (null != t) {
+      var e,
+        n,
+        i,
+        u,
+        a = [],
+        f = !0,
+        o = !1;
+      try {
+        if (i = (t = t.call(r)).next, 0 === l) {
+          if (Object(t) !== t) return;
+          f = !1;
+        } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0);
+      } catch (r) {
+        o = !0, n = r;
+      } finally {
+        try {
+          if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return;
+        } finally {
+          if (o) throw n;
+        }
+      }
+      return a;
+    }
+  }
+  function _nonIterableRest() {
+    throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+  }
+  function _nonIterableSpread() {
+    throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+  }
+  function ownKeys(e, r) {
+    var t = Object.keys(e);
+    if (Object.getOwnPropertySymbols) {
+      var o = Object.getOwnPropertySymbols(e);
+      r && (o = o.filter(function (r) {
+        return Object.getOwnPropertyDescriptor(e, r).enumerable;
+      })), t.push.apply(t, o);
+    }
+    return t;
+  }
+  function _objectSpread2(e) {
+    for (var r = 1; r < arguments.length; r++) {
+      var t = null != arguments[r] ? arguments[r] : {};
+      r % 2 ? ownKeys(Object(t), !0).forEach(function (r) {
+        _defineProperty(e, r, t[r]);
+      }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) {
+        Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r));
+      });
+    }
+    return e;
+  }
+  function _regenerator() {
+    /*! regenerator-runtime -- Copyright (c) 2014-present, Facebook, Inc. -- license (MIT): https://github.com/babel/babel/blob/main/packages/babel-helpers/LICENSE */
+    var e,
+      t,
+      r = "function" == typeof Symbol ? Symbol : {},
+      n = r.iterator || "@@iterator",
+      o = r.toStringTag || "@@toStringTag";
+    function i(r, n, o, i) {
+      var c = n && n.prototype instanceof Generator ? n : Generator,
+        u = Object.create(c.prototype);
+      return _regeneratorDefine(u, "_invoke", function (r, n, o) {
+        var i,
+          c,
+          u,
+          f = 0,
+          p = o || [],
+          y = !1,
+          G = {
+            p: 0,
+            n: 0,
+            v: e,
+            a: d,
+            f: d.bind(e, 4),
+            d: function (t, r) {
+              return i = t, c = 0, u = e, G.n = r, a;
+            }
+          };
+        function d(r, n) {
+          for (c = r, u = n, t = 0; !y && f && !o && t < p.length; t++) {
+            var o,
+              i = p[t],
+              d = G.p,
+              l = i[2];
+            r > 3 ? (o = l === n) && (u = i[(c = i[4]) ? 5 : (c = 3, 3)], i[4] = i[5] = e) : i[0] <= d && ((o = r < 2 && d < i[1]) ? (c = 0, G.v = n, G.n = i[1]) : d < l && (o = r < 3 || i[0] > n || n > l) && (i[4] = r, i[5] = n, G.n = l, c = 0));
+          }
+          if (o || r > 1) return a;
+          throw y = !0, n;
+        }
+        return function (o, p, l) {
+          if (f > 1) throw TypeError("Generator is already running");
+          for (y && 1 === p && d(p, l), c = p, u = l; (t = c < 2 ? e : u) || !y;) {
+            i || (c ? c < 3 ? (c > 1 && (G.n = -1), d(c, u)) : G.n = u : G.v = u);
+            try {
+              if (f = 2, i) {
+                if (c || (o = "next"), t = i[o]) {
+                  if (!(t = t.call(i, u))) throw TypeError("iterator result is not an object");
+                  if (!t.done) return t;
+                  u = t.value, c < 2 && (c = 0);
+                } else 1 === c && (t = i.return) && t.call(i), c < 2 && (u = TypeError("The iterator does not provide a '" + o + "' method"), c = 1);
+                i = e;
+              } else if ((t = (y = G.n < 0) ? u : r.call(n, G)) !== a) break;
+            } catch (t) {
+              i = e, c = 1, u = t;
+            } finally {
+              f = 1;
+            }
+          }
+          return {
+            value: t,
+            done: y
+          };
+        };
+      }(r, o, i), !0), u;
+    }
+    var a = {};
+    function Generator() {}
+    function GeneratorFunction() {}
+    function GeneratorFunctionPrototype() {}
+    t = Object.getPrototypeOf;
+    var c = [][n] ? t(t([][n]())) : (_regeneratorDefine(t = {}, n, function () {
+        return this;
+      }), t),
+      u = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(c);
+    function f(e) {
+      return Object.setPrototypeOf ? Object.setPrototypeOf(e, GeneratorFunctionPrototype) : (e.__proto__ = GeneratorFunctionPrototype, _regeneratorDefine(e, o, "GeneratorFunction")), e.prototype = Object.create(u), e;
+    }
+    return GeneratorFunction.prototype = GeneratorFunctionPrototype, _regeneratorDefine(u, "constructor", GeneratorFunctionPrototype), _regeneratorDefine(GeneratorFunctionPrototype, "constructor", GeneratorFunction), GeneratorFunction.displayName = "GeneratorFunction", _regeneratorDefine(GeneratorFunctionPrototype, o, "GeneratorFunction"), _regeneratorDefine(u), _regeneratorDefine(u, o, "Generator"), _regeneratorDefine(u, n, function () {
+      return this;
+    }), _regeneratorDefine(u, "toString", function () {
+      return "[object Generator]";
+    }), (_regenerator = function () {
+      return {
+        w: i,
+        m: f
+      };
+    })();
+  }
+  function _regeneratorDefine(e, r, n, t) {
+    var i = Object.defineProperty;
+    try {
+      i({}, "", {});
+    } catch (e) {
+      i = 0;
+    }
+    _regeneratorDefine = function (e, r, n, t) {
+      function o(r, n) {
+        _regeneratorDefine(e, r, function (e) {
+          return this._invoke(r, n, e);
+        });
+      }
+      r ? i ? i(e, r, {
+        value: n,
+        enumerable: !t,
+        configurable: !t,
+        writable: !t
+      }) : e[r] = n : (o("next", 0), o("throw", 1), o("return", 2));
+    }, _regeneratorDefine(e, r, n, t);
+  }
+  function _slicedToArray(r, e) {
+    return _arrayWithHoles(r) || _iterableToArrayLimit(r, e) || _unsupportedIterableToArray(r, e) || _nonIterableRest();
+  }
+  function _toConsumableArray(r) {
+    return _arrayWithoutHoles(r) || _iterableToArray(r) || _unsupportedIterableToArray(r) || _nonIterableSpread();
+  }
+  function _toPrimitive(t, r) {
+    if ("object" != typeof t || !t) return t;
+    var e = t[Symbol.toPrimitive];
+    if (void 0 !== e) {
+      var i = e.call(t, r || "default");
+      if ("object" != typeof i) return i;
+      throw new TypeError("@@toPrimitive must return a primitive value.");
+    }
+    return ("string" === r ? String : Number)(t);
+  }
+  function _toPropertyKey(t) {
+    var i = _toPrimitive(t, "string");
+    return "symbol" == typeof i ? i : i + "";
+  }
+  function _typeof(o) {
+    "@babel/helpers - typeof";
+
+    return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+      return typeof o;
+    } : function (o) {
+      return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
+    }, _typeof(o);
+  }
+  function _unsupportedIterableToArray(r, a) {
+    if (r) {
+      if ("string" == typeof r) return _arrayLikeToArray(r, a);
+      var t = {}.toString.call(r).slice(8, -1);
+      return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0;
+    }
+  }
+
+  var $ = function $(selector) {
+    var scope = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : typeof document !== 'undefined' ? document : null;
+    return scope ? scope.querySelector(selector) : null;
+  };
+  var $$ = function $$(selector) {
+    var scope = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : typeof document !== 'undefined' ? document : null;
+    return scope ? Array.from(scope.querySelectorAll(selector)) : [];
+  };
+  var nowHM = function nowHM() {
+    var d = new Date();
+    var p = function p(n) {
+      return String(n).padStart(2, '0');
+    };
+    return "".concat(p(d.getHours()), ":").concat(p(d.getMinutes()));
+  };
+
+  var TABS = [{
+    name: 'Aktyvacija',
+    icon: 'alarm'
+  }, {
+    name: 'A – Kvėpavimo takai'
+  }, {
+    name: 'B – Kvėpavimas'
+  }, {
+    name: 'C – Kraujotaka'
+  }, {
+    name: 'D – Sąmonė'
+  }, {
+    name: 'E – Kita'
+  }, {
+    name: 'Intervencijos',
+    icon: 'syringe'
+  }, {
+    name: 'Vaizdiniai tyrimai',
+    icon: 'radiation'
+  }, {
+    name: 'Laboratorija',
+    icon: 'lab'
+  }, {
+    name: 'Komanda',
+    icon: 'team'
+  }, {
+    name: 'Sprendimas',
+    icon: 'scale'
+  }, {
+    name: 'Santrauka',
+    icon: 'note'
+  }];
+  var TAB_NAMES = TABS.map(function (t) {
+    return t.name;
+  });
+  function showTab(name) {
+    document.querySelectorAll('nav .tab').forEach(function (b) {
+      var active = b.dataset.tab === name;
+      b.classList.toggle('active', active);
+      b.setAttribute('aria-selected', active ? 'true' : 'false');
+    });
+    document.querySelectorAll('.view').forEach(function (v) {
+      var visible = v.dataset.tab === name;
+      v.classList.toggle('visible', visible);
+      v.classList.toggle('hidden', !visible);
+      v.toggleAttribute('hidden', !visible);
+    });
+    localStorage.setItem('v10_activeTab', name);
+    document.dispatchEvent(new CustomEvent('tabShown', {
+      detail: name
+    }));
+  }
+  function initTabs() {
+    var nav = document.getElementById('tabs');
+    nav.setAttribute('role', 'tablist');
+    var iconCache = {};
+    TABS.forEach(function (t, i) {
+      var b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'tab' + (i === 0 ? ' active' : '');
+      b.dataset.tab = t.name;
+      var label = t.name;
+      b.innerHTML = '<span class="tab-icon"></span><span class="tab-label">' + label + '</span>';
+      if (t.icon && typeof fetch === 'function') {
+        if (!iconCache[t.icon]) {
+          iconCache[t.icon] = fetch("assets/icons/".concat(t.icon, ".svg")).then(function (r) {
+            return r.text();
+          }).catch(function () {
+            return '';
+          });
+        }
+        iconCache[t.icon].then(function (svg) {
+          var span = b.querySelector('.tab-icon');
+          if (span && svg) span.innerHTML = svg;
+        });
+      }
+      b.setAttribute('role', 'tab');
+      b.setAttribute('tabindex', '0');
+      b.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
+      var view = document.querySelector(".view[data-tab=\"".concat(t.name, "\"]"));
+      var viewId = (view === null || view === void 0 ? void 0 : view.id) || "view-".concat(i);
+      b.id = "tab-".concat(viewId.replace(/^view-/, ''));
+      b.setAttribute('aria-controls', viewId);
+      if (view) {
+        if (!view.id) view.id = viewId;
+        view.setAttribute('aria-labelledby', b.id);
+        view.setAttribute('role', 'tabpanel');
+      }
+      b.onclick = function () {
+        return showTab(t.name);
+      };
+      nav.appendChild(b);
+    });
+    nav.classList.add('tabs-ready');
+    nav.removeAttribute('aria-hidden');
+    document.querySelectorAll('.view').forEach(function (v, i) {
+      var active = i === 0;
+      v.classList.toggle('visible', active);
+      v.classList.toggle('hidden', !active);
+      v.toggleAttribute('hidden', !active);
+    });
+    nav.addEventListener('keydown', function (e) {
+      var tabs = Array.from(nav.querySelectorAll('.tab'));
+      var currentIndex = tabs.indexOf(document.activeElement);
+      if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+        e.preventDefault();
+        var newIndex = currentIndex + (e.key === 'ArrowRight' ? 1 : -1);
+        if (newIndex < 0) newIndex = tabs.length - 1;
+        if (newIndex >= tabs.length) newIndex = 0;
+        tabs[newIndex].focus();
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        document.activeElement.click();
+      }
+    });
+    var savedTab = localStorage.getItem('v10_activeTab');
+    if (savedTab && TAB_NAMES.includes(savedTab)) showTab(savedTab);
+  }
+
+  var listenersAdded = false;
+  function addChipIndicators(chip) {
+    if (!chip || chip.querySelector('.chip-status-icon')) return;
+    var tpl = document.getElementById('chip-template');
+    if (tpl) {
+      var fragment = tpl.content.cloneNode(true);
+      var icon = fragment.querySelector('.chip-status-icon');
+      var sr = fragment.querySelector('.chip-status-text');
+      chip.prepend(icon);
+      chip.appendChild(sr);
+    } else {
+      var _icon = document.createElement('span');
+      _icon.className = 'chip-status-icon';
+      _icon.setAttribute('aria-hidden', 'true');
+      chip.prepend(_icon);
+      var _sr = document.createElement('span');
+      _sr.className = 'chip-status-text sr-only';
+      _sr.setAttribute('aria-live', 'polite');
+      _sr.textContent = 'not selected';
+      chip.appendChild(_sr);
+    }
+  }
+  function isChipActive(chip) {
+    if (chip.tagName === 'BUTTON') return chip.getAttribute('aria-pressed') === 'true';
+    var input = chip.querySelector('input');
+    if (input) return input.checked;
+    return chip.classList.contains('active');
+  }
+  function setChipActive(chip, active) {
+    addChipIndicators(chip);
+    chip.setAttribute('aria-pressed', active ? 'true' : 'false');
+    if (chip.tagName !== 'BUTTON') {
+      var input = chip.querySelector('input');
+      if (input) input.checked = active;
+    }
+    chip.classList.toggle('active', active);
+    if (chip.getAttribute('role') === 'radio') {
+      chip.setAttribute('aria-checked', active ? 'true' : 'false');
+    }
+    var icon = chip.querySelector('.chip-status-icon');
+    var sr = chip.querySelector('.chip-status-text');
+    if (icon) icon.textContent = active ? '✓' : '✗';
+    if (sr) sr.textContent = active ? 'selected' : 'not selected';
+  }
+  function togglePupilNote(side) {
+    var group = $("#d_pupil_".concat(side, "_group"));
+    var note = $("#d_pupil_".concat(side, "_note"));
+    if (!group || !note) return;
+    var show = $$('.chip.active', group).some(function (c) {
+      return c.dataset.value === 'kita';
+    });
+    note.hidden = !show;
+    note.classList.toggle('hidden', !show);
+    var label = $("#d_pupil_".concat(side, "_wrapper label[for=\"d_pupil_").concat(side, "_note\"]"));
+    if (label) {
+      label.hidden = !show;
+      label.classList.toggle('hidden', !show);
+    }
+    if (!show) note.value = '';
+    var wrapper = $("#d_pupil_".concat(side, "_wrapper"));
+    if (wrapper) wrapper.setAttribute('aria-expanded', show ? 'true' : 'false');
+  }
+  function toggleBackNote(chip) {
+    var _chip$parentElement;
+    if (((_chip$parentElement = chip.parentElement) === null || _chip$parentElement === void 0 ? void 0 : _chip$parentElement.id) !== 'e_back_group') return;
+    var note = $('#e_back_notes');
+    var show = chip.dataset.value === 'Pakitimai' && isChipActive(chip);
+    note.style.display = show ? 'block' : 'none';
+    note.classList.toggle('hidden', !show);
+    if (!show) note.value = '';
+  }
+  function toggleAbdomenNote(chip) {
+    var _chip$parentElement2;
+    if (((_chip$parentElement2 = chip.parentElement) === null || _chip$parentElement2 === void 0 ? void 0 : _chip$parentElement2.id) !== 'e_abdomen_group') return;
+    var note = $('#e_abdomen_notes');
+    var show = chip.dataset.value === 'Pakitimai' && isChipActive(chip);
+    note.style.display = show ? 'block' : 'none';
+    note.classList.toggle('hidden', !show);
+    if (!show) note.value = '';
+  }
+  function toggleSkinColorNote(chip) {
+    var _chip$parentElement3;
+    if (((_chip$parentElement3 = chip.parentElement) === null || _chip$parentElement3 === void 0 ? void 0 : _chip$parentElement3.id) !== 'c_skin_color_group') return;
+    var note = $('#c_skin_color_other');
+    var show = chip.dataset.value === 'Kita' && isChipActive(chip);
+    note.hidden = !show;
+    note.classList.toggle('hidden', !show);
+    if (!show) note.value = '';
+  }
+  function updateBreathGroups() {
+    ['b_breath_left_group', 'b_breath_right_group'].forEach(function (id) {
+      var group = $('#' + id);
+      if (!group) return;
+      var toggle = group.querySelector('.breath-toggle');
+      var options = $$('.breath-option', group);
+      var show = toggle && isChipActive(toggle) || options.some(isChipActive);
+      options.forEach(function (opt) {
+        opt.classList.toggle('hidden', !show);
+        if (!show) setChipActive(opt, false);
+      });
+    });
+  }
+  function initChips(saveAll) {
+    $$('.chip').forEach(function (chip) {
+      var _group$dataset;
+      addChipIndicators(chip);
+      var group = chip.parentElement;
+      var single = (group === null || group === void 0 || (_group$dataset = group.dataset) === null || _group$dataset === void 0 ? void 0 : _group$dataset.single) === 'true';
+      if (group) {
+        group.setAttribute('role', single ? 'radiogroup' : 'group');
+      }
+      if (chip.tagName !== 'BUTTON') {
+        chip.setAttribute('tabindex', '0');
+        chip.setAttribute('role', single ? 'radio' : 'button');
+      } else if (single) {
+        chip.setAttribute('role', 'radio');
+      }
+      setChipActive(chip, isChipActive(chip));
+    });
+    togglePupilNote('left');
+    togglePupilNote('right');
+    updateBreathGroups();
+    if (listenersAdded) return;
+    listenersAdded = true;
+    function handleChip(chip) {
+      var _group$dataset2;
+      var group = chip.parentElement;
+      var single = (group === null || group === void 0 || (_group$dataset2 = group.dataset) === null || _group$dataset2 === void 0 ? void 0 : _group$dataset2.single) === 'true';
+      if (single) {
+        $$('.chip', group).forEach(function (c) {
+          return setChipActive(c, false);
+        });
+        setChipActive(chip, true);
+      } else {
+        setChipActive(chip, !isChipActive(chip));
+      }
+      togglePupilNote('left');
+      togglePupilNote('right');
+      toggleBackNote(chip);
+      toggleAbdomenNote(chip);
+      toggleSkinColorNote(chip);
+      if (group.id.startsWith('imaging_')) {
+        var box = $('#imaging_other');
+        var show = !!document.querySelector('[id^="imaging_"] .chip.active[data-value="Kita"]');
+        box.style.display = show ? 'block' : 'none';
+        box.classList.toggle('hidden', !show);
+        if (!show) box.value = '';
+      }
+      if (group.id === 'spr_decision_group') {
+        var showSky = chip.dataset.value === 'Stacionarizavimas' && isChipActive(chip);
+        var boxSky = $('#spr_skyrius_container');
+        boxSky.style.display = showSky ? 'block' : 'none';
+        boxSky.classList.toggle('hidden', !showSky);
+        if (!showSky) {
+          $('#spr_skyrius').value = '';
+          $('#spr_skyrius_kita').style.display = 'none';
+          $('#spr_skyrius_kita').classList.add('hidden');
+          $('#spr_skyrius_kita').value = '';
+        }
+        var showHosp = chip.dataset.value === 'Pervežimas į kitą ligoninę' && isChipActive(chip);
+        var boxHosp = $('#spr_ligonine_container');
+        boxHosp.style.display = showHosp ? 'block' : 'none';
+        boxHosp.classList.toggle('hidden', !showHosp);
+        if (!showHosp) {
+          $('#spr_ligonine').value = '';
+        }
+      }
+      updateBreathGroups();
+      delete chip.dataset.auto;
+      if (typeof saveAll === 'function') saveAll();
+    }
+    document.addEventListener('click', function (e) {
+      var _e$target, _e$target$closest;
+      var chip = (_e$target = e.target) === null || _e$target === void 0 || (_e$target$closest = _e$target.closest) === null || _e$target$closest === void 0 ? void 0 : _e$target$closest.call(_e$target, '.chip');
+      if (!chip) return;
+      handleChip(chip);
+    }, true);
+
+    // Support keyboard interaction:
+    // * Enter/Space toggles the active state of a chip
+    // * Arrow keys move focus within a chip group. For radiogroups the
+    //   newly focused chip is activated automatically to mirror native
+    //   radio behaviour.
+    document.addEventListener('keydown', function (e) {
+      var _e$target2, _e$target2$closest;
+      var chip = (_e$target2 = e.target) === null || _e$target2 === void 0 || (_e$target2$closest = _e$target2.closest) === null || _e$target2$closest === void 0 ? void 0 : _e$target2$closest.call(_e$target2, '.chip');
+      if (!chip) return;
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleChip(chip);
+        return;
+      }
+      if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+        var _group$dataset3;
+        var group = chip.parentElement;
+        if (!group) return;
+        var chips = $$('.chip', group);
+        var activeIndex = chips.findIndex(isChipActive);
+        var index = activeIndex !== -1 ? activeIndex : chips.indexOf(chip);
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+          index = (index - 1 + chips.length) % chips.length;
+        } else {
+          index = (index + 1) % chips.length;
+        }
+        var nextChip = chips[index];
+        e.preventDefault();
+        nextChip.focus();
+        if (((_group$dataset3 = group.dataset) === null || _group$dataset3 === void 0 ? void 0 : _group$dataset3.single) === 'true') {
+          handleChip(nextChip);
+        }
+      }
+    }, true);
+  }
+  function listChips(sel) {
+    return $$('.chip', $(sel)).filter(isChipActive).map(function (c) {
+      return c.dataset.value;
+    });
+  }
+
+  function gmpGKS() {
+    var _$, _$2, _$3;
+    var a = +(((_$ = $('#gmp_gksa')) === null || _$ === void 0 ? void 0 : _$.value) || 0);
+    var k = +(((_$2 = $('#gmp_gksk')) === null || _$2 === void 0 ? void 0 : _$2.value) || 0);
+    var m = +(((_$3 = $('#gmp_gksm')) === null || _$3 === void 0 ? void 0 : _$3.value) || 0);
+    return a && k && m ? a + k + m : 0;
+  }
+  var autoMap = {
+    red: {
+      'AKS < 90 mmHg': function AKS__90_mmHg() {
+        var _$4;
+        var s = +(((_$4 = $('#gmp_sbp')) === null || _$4 === void 0 ? void 0 : _$4.value) || 0);
+        return s > 0 && s < 90;
+      },
+      'SpO₂ < 90%': function SpO__90() {
+        var _$5;
+        var s = +(((_$5 = $('#gmp_spo2')) === null || _$5 === void 0 ? void 0 : _$5.value) || 0);
+        return s > 0 && s < 90;
+      },
+      'KD < 8 ar > 30/min': function KD__8_ar__30_min() {
+        var _$6;
+        var r = +(((_$6 = $('#gmp_rr')) === null || _$6 === void 0 ? void 0 : _$6.value) || 0);
+        return r > 0 && (r < 8 || r > 30);
+      },
+      'ŠSD > 120/min': function ŠSD__120_min() {
+        var _$7;
+        var h = +(((_$7 = $('#gmp_hr')) === null || _$7 === void 0 ? void 0 : _$7.value) || 0);
+        return h > 120;
+      },
+      'GKS < 9': function GKS__9() {
+        var g = gmpGKS();
+        return g > 0 && g < 9;
+      }
+    }
+  };
+  function autoActivateFromGMP() {
+    var red = $('#chips_red');
+    Object.entries(autoMap.red).forEach(function (_ref) {
+      var _ref2 = _slicedToArray(_ref, 2),
+        label = _ref2[0],
+        fn = _ref2[1];
+      var chip = $$('.chip', red).find(function (c) {
+        return c.dataset.value === label;
+      });
+      if (!chip) return;
+      if (fn()) {
+        setChipActive(chip, true);
+        chip.dataset.auto = 'true';
+        chip.classList.add('auto');
+        var sr = chip.querySelector('.chip-status-text');
+        if (sr) sr.textContent = 'auto-selected';
+      } else if (chip.dataset.auto === 'true') {
+        setChipActive(chip, false);
+        delete chip.dataset.auto;
+        chip.classList.remove('auto');
+      }
+    });
+    if ($$('.chip.active', red).length) {
+      var yellow = $('#chips_yellow');
+      if (yellow) $$('.chip', yellow).forEach(function (c) {
+        return setChipActive(c, false);
+      });
+    }
+    window.ensureSingleTeam && window.ensureSingleTeam();
+    window.updateActivationIndicator && window.updateActivationIndicator();
+  }
+  function initAutoActivate(saveAll) {
+    ['#gmp_hr', '#gmp_rr', '#gmp_spo2', '#gmp_sbp', '#gmp_dbp', '#gmp_gksa', '#gmp_gksk', '#gmp_gksm'].forEach(function (sel) {
+      var el = $(sel);
+      if (el) el.addEventListener('input', function () {
+        if (typeof window !== 'undefined' && typeof window.validateVitals === 'function') window.validateVitals();
+        autoActivateFromGMP();
+        if (typeof saveAll === 'function') saveAll();
+      });
+    });
+    if (typeof window !== 'undefined' && typeof window.validateVitals === 'function') window.validateVitals();
+  }
+
+  var PAIN_MEDS = ['Fentanilis', 'Paracetamolis', 'Ketoprofenas'];
+  var BLEEDING_MEDS = ['TXA', 'O- kraujas', 'Fibryga', 'Ca gliukonatas'];
+  var OTHER_MEDS = ['Ringerio tirpalas', 'Noradrenalinas', 'Metoklopramidas', 'Ondansetronas'];
+  var PROCS_IT = ['Intubacija', 'Krikotirotomija', 'Pleuros drenažas', 'Adatinė dekompresija'];
+  var PROCS_OTHER = ['Kūno šildymas', 'Turniketas', 'Dubens diržas', 'Gipsavimas', 'Siuvimas', 'Repocizija'];
+
+  // Default doses for medications
+  var DEFAULT_DOSES = {
+    'Fentanilis': '100 mcg',
+    'Paracetamolis': '1 g',
+    'Ketoprofenas': '100 mg',
+    'TXA': '1 g',
+    'O- kraujas': '2 V',
+    'Fibryga': '1 g',
+    'Ca gliukonatas': '1 g',
+    'Ringerio tirpalas': '500 ml',
+    'Noradrenalinas': '0.1 µg/kg/min',
+    'Metoklopramidas': '10 mg',
+    'Ondansetronas': '8 mg'
+  };
+  function buildActionCard(group, name, saveAll) {
+    var opts = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+    var custom = opts.custom;
+    var includeDose = group !== 'proc';
+    var card = document.createElement('div');
+    card.className = 'card';
+    card.style.padding = '6px';
+    card.style.borderRadius = '10px';
+    var slug = name.toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '');
+    var gridClass = includeDose || custom ? 'cols-3 cols-auto' : 'cols-2 cols-auto';
+
+    // Build label section
+    var label = document.createElement('label');
+    label.className = 'pill';
+    var chk = document.createElement('input');
+    chk.type = 'checkbox';
+    chk.className = 'act_chk';
+    chk.dataset.field = "".concat(group, "_").concat(slug, "_chk");
+    var nameSpan = document.createElement('span');
+    nameSpan.className = 'act_name';
+    nameSpan.textContent = name;
+    nameSpan.title = DEFAULT_DOSES[name] || '';
+    label.appendChild(chk);
+    label.appendChild(nameSpan);
+
+    // Detail section
+    var detail = document.createElement('div');
+    detail.className = 'detail collapsed';
+    var grid = document.createElement('div');
+    grid.className = "grid ".concat(gridClass);
+    grid.style.marginTop = '4px';
+    if (custom) {
+      var customDiv = document.createElement('div');
+      var customLabel = document.createElement('label');
+      customLabel.textContent = 'Pavadinimas';
+      var customInput = document.createElement('input');
+      customInput.type = 'text';
+      customInput.className = 'act_custom_name';
+      customInput.dataset.field = "".concat(group, "_").concat(slug, "_custom");
+      customDiv.appendChild(customLabel);
+      customDiv.appendChild(customInput);
+      grid.appendChild(customDiv);
+    }
+    var timeDiv = document.createElement('div');
+    var timeLabel = document.createElement('label');
+    timeLabel.textContent = 'Laikas';
+    var timeInput = document.createElement('input');
+    timeInput.type = 'time';
+    timeInput.className = 'act_time';
+    timeInput.dataset.field = "".concat(group, "_").concat(slug, "_time");
+    timeDiv.appendChild(timeLabel);
+    timeDiv.appendChild(timeInput);
+    grid.appendChild(timeDiv);
+    if (includeDose) {
+      var doseDiv = document.createElement('div');
+      var doseLabel = document.createElement('label');
+      doseLabel.textContent = 'Dozė/kiekis';
+      var doseInput = document.createElement('input');
+      doseInput.type = 'text';
+      doseInput.className = 'act_dose';
+      doseInput.dataset.field = "".concat(group, "_").concat(slug, "_dose");
+      doseDiv.appendChild(doseLabel);
+      doseDiv.appendChild(doseInput);
+      grid.appendChild(doseDiv);
+    }
+    var noteDiv = document.createElement('div');
+    var noteLabel = document.createElement('label');
+    noteLabel.textContent = 'Pastabos';
+    var noteInput = document.createElement('input');
+    noteInput.type = 'text';
+    noteInput.className = 'act_note';
+    noteInput.dataset.field = "".concat(group, "_").concat(slug, "_note");
+    noteDiv.appendChild(noteLabel);
+    noteDiv.appendChild(noteInput);
+    grid.appendChild(noteDiv);
+    detail.appendChild(grid);
+    card.appendChild(label);
+    card.appendChild(detail);
+    function update() {
+      if (chk.checked || card.classList.contains('expanded')) detail.classList.remove('collapsed');else detail.classList.add('collapsed');
+    }
+    update();
+    return card;
+  }
+  function initActions(saveAll) {
+    var painWrap = $('#pain_meds');
+    var bleedingWrap = $('#bleeding_meds');
+    var otherWrap = $('#other_meds');
+    var procsItWrap = $('#procedures_it');
+    var procsOtherWrap = $('#procedures_other');
+    var sortedPainMeds = PAIN_MEDS.slice().sort(function (a, b) {
+      return a.localeCompare(b);
+    });
+    var sortedBleedingMeds = BLEEDING_MEDS.slice().sort(function (a, b) {
+      return a.localeCompare(b);
+    });
+    var sortedOtherMeds = OTHER_MEDS.slice().sort(function (a, b) {
+      return a.localeCompare(b);
+    });
+    var painFrag = document.createDocumentFragment();
+    sortedPainMeds.forEach(function (n) {
+      return painFrag.appendChild(buildActionCard('med', n, saveAll));
+    });
+    painWrap.appendChild(painFrag);
+    var bleedingFrag = document.createDocumentFragment();
+    sortedBleedingMeds.forEach(function (n) {
+      return bleedingFrag.appendChild(buildActionCard('med', n, saveAll));
+    });
+    bleedingWrap.appendChild(bleedingFrag);
+    var otherFrag = document.createDocumentFragment();
+    sortedOtherMeds.forEach(function (n) {
+      return otherFrag.appendChild(buildActionCard('med', n, saveAll));
+    });
+    otherFrag.appendChild(buildActionCard('med', 'Kita', saveAll, {
+      custom: true
+    }));
+    otherWrap.appendChild(otherFrag);
+    var procsItFrag = document.createDocumentFragment();
+    PROCS_IT.forEach(function (n) {
+      return procsItFrag.appendChild(buildActionCard('proc', n, saveAll));
+    });
+    procsItWrap.appendChild(procsItFrag);
+    var procsOtherFrag = document.createDocumentFragment();
+    PROCS_OTHER.forEach(function (n) {
+      return procsOtherFrag.appendChild(buildActionCard('proc', n, saveAll));
+    });
+    procsOtherWrap.appendChild(procsOtherFrag);
+    var wraps = [painWrap, bleedingWrap, otherWrap, procsItWrap, procsOtherWrap];
+    function handleAction(e) {
+      var card = e.target.closest('.card');
+      if (!card) return;
+      var chk = card.querySelector('.act_chk');
+      var detail = card.querySelector('.detail');
+      var time = card.querySelector('.act_time');
+      var dose = card.querySelector('.act_dose');
+      var name = card.querySelector('.act_name').textContent;
+      var includeDose = !!dose;
+      var update = function update() {
+        if (chk.checked || card.classList.contains('expanded')) detail.classList.remove('collapsed');else detail.classList.add('collapsed');
+      };
+      if (e.type === 'change' && e.target.matches('.act_chk')) {
+        if (chk.checked) {
+          if (!time.value) time.value = nowHM();
+          if (includeDose && !dose.value && DEFAULT_DOSES[name]) dose.value = DEFAULT_DOSES[name];
+        }
+        update();
+        if (typeof saveAll === 'function') saveAll();
+      } else if (e.type === 'click') {
+        if (e.target.closest('label.pill') || e.target.closest('.detail')) return;
+        card.classList.toggle('expanded');
+        update();
+      }
+    }
+    wraps.forEach(function (wrap) {
+      wrap.addEventListener('click', handleAction);
+      wrap.addEventListener('change', handleAction);
+    });
+    var medSearch = $('#medSearch');
+    if (medSearch) {
+      var medWraps = [painWrap, bleedingWrap, otherWrap, procsItWrap, procsOtherWrap];
+      medSearch.addEventListener('input', function () {
+        var q = medSearch.value.trim().toLowerCase();
+        medWraps.forEach(function (wrap) {
+          wrap.querySelectorAll('.card').forEach(function (card) {
+            var name = card.querySelector('.act_name').textContent.toLowerCase();
+            card.style.display = name.includes(q) ? '' : 'none';
+          });
+        });
+      });
+    }
+    $$('.interv-toggle').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var group = btn.closest('.interv-group');
+        var collapsed = group.classList.toggle('collapsed');
+        btn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      });
+    });
+  }
+
+  var handlers = {};
+  var queue = [];
+  var processing = false;
+  function register(type, handler) {
+    handlers[type] = handler;
+  }
+  function notify(options) {
+    return new Promise(function (resolve) {
+      queue.push(_objectSpread2(_objectSpread2({}, options), {}, {
+        resolve: resolve
+      }));
+      processQueue();
+    });
+  }
+  function processQueue() {
+    return _processQueue.apply(this, arguments);
+  }
+  function _processQueue() {
+    _processQueue = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee() {
+      var item, handler, result, _t, _t2;
+      return _regenerator().w(function (_context) {
+        while (1) switch (_context.p = _context.n) {
+          case 0:
+            if (!processing) {
+              _context.n = 1;
+              break;
+            }
+            return _context.a(2);
+          case 1:
+            processing = true;
+          case 2:
+            if (!queue.length) {
+              _context.n = 11;
+              break;
+            }
+            item = queue.shift();
+            handler = handlers[item.type] || handlers.toast;
+            if (!(typeof handler === 'function')) {
+              _context.n = 9;
+              break;
+            }
+            _context.p = 3;
+            result = handler(item);
+            if (!(result && typeof result.then === 'function')) {
+              _context.n = 5;
+              break;
+            }
+            _t = item;
+            _context.n = 4;
+            return result;
+          case 4:
+            _t.resolve.call(_t, _context.v);
+            _context.n = 6;
+            break;
+          case 5:
+            item.resolve(result);
+          case 6:
+            _context.n = 8;
+            break;
+          case 7:
+            _context.p = 7;
+            _t2 = _context.v;
+            console.error(_t2);
+            item.resolve();
+          case 8:
+            _context.n = 10;
+            break;
+          case 9:
+            item.resolve();
+          case 10:
+            _context.n = 2;
+            break;
+          case 11:
+            processing = false;
+          case 12:
+            return _context.a(2);
+        }
+      }, _callee, null, [[3, 7]]);
+    }));
+    return _processQueue.apply(this, arguments);
+  }
+
+  var container;
+  function toastHandler(_ref) {
+    var message = _ref.message,
+      _ref$type = _ref.type,
+      type = _ref$type === void 0 ? 'info' : _ref$type,
+      _ref$duration = _ref.duration,
+      duration = _ref$duration === void 0 ? 3000 : _ref$duration;
+    if (!container) {
+      container = document.createElement('div');
+      container.className = 'toast-container';
+      document.body.appendChild(container);
+    }
+    var toast = document.createElement('div');
+    toast.className = 'toast ' + type;
+    toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
+    toast.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
+    toast.textContent = message;
+    container.appendChild(toast);
+    setTimeout(function () {
+      toast.classList.add('hide');
+      setTimeout(function () {
+        return toast.remove();
+      }, 300);
+    }, duration);
+  }
+  register('toast', toastHandler);
+
+  function promptHandler(_ref) {
+    var message = _ref.message,
+      _ref$defaultValue = _ref.defaultValue,
+      defaultValue = _ref$defaultValue === void 0 ? '' : _ref$defaultValue;
+    return new Promise(function (resolve) {
+      var prev = document.activeElement;
+      var overlay = document.createElement('div');
+      overlay.className = 'modal-overlay';
+      var box = document.createElement('div');
+      box.className = 'modal';
+      box.setAttribute('role', 'dialog');
+      box.setAttribute('aria-modal', 'true');
+      var p = document.createElement('p');
+      p.id = 'modalMsg';
+      p.textContent = message;
+      box.setAttribute('aria-labelledby', p.id);
+      box.appendChild(p);
+      var input = document.createElement('input');
+      input.type = 'text';
+      input.value = defaultValue;
+      box.appendChild(input);
+      var actions = document.createElement('div');
+      actions.className = 'actions';
+      var btnOk = document.createElement('button');
+      btnOk.textContent = 'OK';
+      btnOk.className = 'btn primary';
+      var btnCancel = document.createElement('button');
+      btnCancel.textContent = 'Cancel';
+      btnCancel.className = 'btn';
+      actions.appendChild(btnCancel);
+      actions.appendChild(btnOk);
+      box.appendChild(actions);
+      overlay.appendChild(box);
+      document.body.appendChild(overlay);
+      var focusable = box.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+      function trap(e) {
+        if (e.key === 'Tab') {
+          if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          close(null);
+        }
+      }
+      function close(val) {
+        overlay.remove();
+        document.removeEventListener('keydown', trap, true);
+        prev === null || prev === void 0 || prev.focus();
+        resolve(val);
+      }
+      btnOk.addEventListener('click', function () {
+        return close(input.value.trim() || null);
+      });
+      btnCancel.addEventListener('click', function () {
+        return close(null);
+      });
+      overlay.addEventListener('click', function (e) {
+        if (e.target === overlay) close(null);
+      });
+      document.addEventListener('keydown', trap, true);
+      input.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter') btnOk.click();
+      });
+      first.focus();
+    });
+  }
+  function confirmHandler(_ref2) {
+    var message = _ref2.message;
+    return new Promise(function (resolve) {
+      var prev = document.activeElement;
+      var overlay = document.createElement('div');
+      overlay.className = 'modal-overlay';
+      var box = document.createElement('div');
+      box.className = 'modal';
+      box.setAttribute('role', 'dialog');
+      box.setAttribute('aria-modal', 'true');
+      var p = document.createElement('p');
+      p.id = 'modalMsg';
+      p.textContent = message;
+      box.setAttribute('aria-labelledby', p.id);
+      box.appendChild(p);
+      var actions = document.createElement('div');
+      actions.className = 'actions';
+      var btnOk = document.createElement('button');
+      btnOk.textContent = 'OK';
+      btnOk.className = 'btn primary';
+      var btnCancel = document.createElement('button');
+      btnCancel.textContent = 'Cancel';
+      btnCancel.className = 'btn';
+      actions.appendChild(btnCancel);
+      actions.appendChild(btnOk);
+      box.appendChild(actions);
+      overlay.appendChild(box);
+      document.body.appendChild(overlay);
+      var focusable = box.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+      function trap(e) {
+        if (e.key === 'Tab') {
+          if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          close(false);
+        }
+      }
+      function close(val) {
+        overlay.remove();
+        document.removeEventListener('keydown', trap, true);
+        prev === null || prev === void 0 || prev.focus();
+        resolve(val);
+      }
+      btnOk.addEventListener('click', function () {
+        return close(true);
+      });
+      btnCancel.addEventListener('click', function () {
+        return close(false);
+      });
+      overlay.addEventListener('click', function (e) {
+        if (e.target === overlay) close(false);
+      });
+      document.addEventListener('keydown', trap, true);
+      first.focus();
+    });
+  }
+  register('prompt', promptHandler);
+  register('confirm', confirmHandler);
+
+  function showInlineError(el, msg) {
+    var err = el.nextElementSibling;
+    if (!err || !err.classList.contains('input-error')) {
+      err = document.createElement('span');
+      err.className = 'input-error';
+      err.style.color = 'var(--danger)';
+      err.style.fontSize = '12px';
+      err.style.marginLeft = '4px';
+      el.insertAdjacentElement('afterend', err);
+    }
+    err.textContent = msg;
+    err.style.display = msg ? 'inline' : 'none';
+    if (msg) {
+      el.classList.add('invalid');
+    } else {
+      el.classList.remove('invalid');
+    }
+  }
+  function validateField(el) {
+    var val = el.value.trim();
+    var msg = '';
+    if (el.hasAttribute('required') && val === '') {
+      msg = 'Privalomas laukas';
+    } else if (val !== '') {
+      var min = el.getAttribute('min');
+      var max = el.getAttribute('max');
+      if (min !== null || max !== null) {
+        var num = parseFloat(val);
+        if (Number.isNaN(num)) {
+          msg = 'Netinkama reikšmė';
+        } else if (min !== null && num < parseFloat(min) || max !== null && num > parseFloat(max)) {
+          msg = "Leistina ".concat(min, "\u2013").concat(max);
+        }
+      }
+    }
+    showInlineError(el, msg);
+  }
+  function validateVitals() {
+    var fields = ['#gmp_hr', '#gmp_rr', '#gmp_spo2', '#gmp_sbp', '#gmp_dbp', '#gmp_gksa', '#gmp_gksk', '#gmp_gksm', '#d_gksa', '#d_gksk', '#d_gksm', '#patient_age', '#patient_sex'];
+    var ok = true;
+    fields.forEach(function (sel) {
+      var el = $(sel);
+      if (el) {
+        validateField(el);
+        if (el.classList.contains('invalid')) ok = false;
+      }
+    });
+    return ok;
+  }
+  function initValidation() {
+    var selectors = ['#patient_age', '#patient_sex', '#gmp_hr', '#gmp_rr', '#gmp_spo2', '#gmp_sbp', '#gmp_dbp', '#gmp_gksa', '#gmp_gksk', '#gmp_gksm', '#d_gksa', '#d_gksk', '#d_gksm'];
+    selectors.forEach(function (sel) {
+      var el = $(sel);
+      if (!el) return;
+      ['input', 'change'].forEach(function (evt) {
+        return el.addEventListener(evt, function () {
+          return validateField(el);
+        });
+      });
+      validateField(el);
+    });
+  }
+  if (typeof window !== 'undefined') {
+    window.validateVitals = validateVitals;
+  }
+
+  var NAV_BREAKPOINT = 768;
+  var navMq;
+  var navMqListener;
+  function initNavToggle(toggle, nav) {
+    if (navMq && navMqListener) {
+      navMq.removeEventListener('change', navMqListener);
+    }
+    if (!nav) return;
+    if (toggle) {
+      toggle.setAttribute('aria-controls', nav.id);
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+    var overlay = document.querySelector('.nav-overlay');
+    var focusableSel = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+    var navOpen = false;
+    var trapActive = false;
+    function close() {
+      document.body.classList.remove('nav-open');
+      if (toggle) {
+        toggle.setAttribute('aria-expanded', 'false');
+      }
+      nav.setAttribute('aria-hidden', 'true');
+      nav.setAttribute('hidden', '');
+      if (overlay) overlay.hidden = true;
+      document.body.style.overflow = '';
+      if (trapActive) {
+        document.removeEventListener('keydown', trap);
+        trapActive = false;
+      }
+      navOpen = false;
+      if (toggle) {
+        toggle.focus();
+      }
+    }
+    function trap(e) {
+      if (e.key === 'Tab') {
+        var items = nav.querySelectorAll(focusableSel);
+        if (!items.length) return;
+        var first = items[0];
+        var last = items[items.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      } else if (e.key === 'Escape') {
+        close();
+      }
+    }
+    function open() {
+      var mobile = !navMq || !navMq.matches;
+      var wasClosed = !navOpen;
+      navOpen = true;
+      document.body.classList.toggle('nav-open', mobile);
+      if (toggle) {
+        toggle.setAttribute('aria-expanded', 'true');
+      }
+      nav.removeAttribute('aria-hidden');
+      nav.removeAttribute('hidden');
+      if (mobile) {
+        if (overlay) overlay.hidden = false;
+        document.body.style.overflow = 'hidden';
+        var items = nav.querySelectorAll(focusableSel);
+        if (wasClosed && items.length) items[0].focus();
+        if (!trapActive) {
+          document.addEventListener('keydown', trap);
+          trapActive = true;
+        }
+      } else {
+        if (overlay) overlay.hidden = true;
+        document.body.style.overflow = '';
+        if (trapActive) {
+          document.removeEventListener('keydown', trap);
+          trapActive = false;
+        }
+      }
+    }
+    if (toggle) {
+      toggle.addEventListener('click', function () {
+        navOpen ? close() : open();
+      });
+      if (overlay) {
+        overlay.addEventListener('click', close);
+      }
+      nav.addEventListener('click', function () {
+        var mobile = !navMq || !navMq.matches;
+        if (mobile) {
+          close();
+        } else {
+          setTimeout(function () {
+            if (nav.hasAttribute('hidden')) open();
+          });
+        }
+      });
+    }
+    navMq = typeof matchMedia === 'function' ? matchMedia("(min-width: ".concat(NAV_BREAKPOINT, "px)")) : null;
+    if (navMq) {
+      navMqListener = function navMqListener(e) {
+        e.matches ? open() : close();
+      };
+      navMq.addEventListener('change', navMqListener);
+      if (toggle) {
+        navMq.matches ? open() : close();
+      } else {
+        open();
+      }
+    } else {
+      open();
+    }
+  }
+  var patientMenuMq;
+  var patientMenuMqListener;
+  var patientMenuDocListener;
+  var patientMenuSearchListener;
+  var patientMenuSearchToggle;
+  function initPatientMenuToggle(menu) {
+    if (patientMenuMq && patientMenuMqListener) {
+      if (typeof patientMenuMq.removeEventListener === 'function') {
+        patientMenuMq.removeEventListener('change', patientMenuMqListener);
+      }
+      patientMenuMqListener = null;
+    }
+    if (patientMenuDocListener) {
+      document.removeEventListener('click', patientMenuDocListener);
+      patientMenuDocListener = null;
+    }
+    if (patientMenuSearchToggle && patientMenuSearchListener) {
+      patientMenuSearchToggle.removeEventListener('click', patientMenuSearchListener);
+      patientMenuSearchToggle = null;
+      patientMenuSearchListener = null;
+    }
+    if (!menu) return;
+    var search = menu.querySelector('#patientSearch');
+    var searchToggle = menu.querySelector('#patientSearchToggle');
+    patientMenuMq = typeof matchMedia === 'function' ? matchMedia('(min-width: 769px)') : null;
+    var update = function update() {
+      if (patientMenuMq && patientMenuMq.matches) menu.setAttribute('open', '');else menu.removeAttribute('open');
+    };
+    update();
+    if (patientMenuMq) {
+      patientMenuMqListener = update;
+      patientMenuMq.addEventListener('change', patientMenuMqListener);
+    }
+    patientMenuDocListener = function patientMenuDocListener(e) {
+      if (menu.hasAttribute('open') && (!patientMenuMq || !patientMenuMq.matches) && !menu.contains(e.target)) {
+        menu.removeAttribute('open');
+        search === null || search === void 0 || search.classList.add('hidden');
+      }
+    };
+    document.addEventListener('click', patientMenuDocListener);
+    patientMenuSearchListener = function patientMenuSearchListener(e) {
+      e.stopPropagation();
+      e.preventDefault();
+      search === null || search === void 0 || search.classList.toggle('hidden');
+      menu.setAttribute('open', '');
+      if (!(search !== null && search !== void 0 && search.classList.contains('hidden'))) {
+        requestAnimationFrame(function () {
+          search.focus();
+          menu.setAttribute('open', '');
+        });
+      } else if (search) {
+        search.value = '';
+      }
+    };
+    if (searchToggle) {
+      searchToggle.addEventListener('click', patientMenuSearchListener);
+      patientMenuSearchToggle = searchToggle;
+    }
+  }
+  function initTopbar() {
+    return _initTopbar.apply(this, arguments);
+  }
+  function _initTopbar() {
+    _initTopbar = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee() {
+      var header, res, _header$querySelector, _nav, updateHeight, ro, toggle, nav, patientMenu, _t;
+      return _regenerator().w(function (_context) {
+        while (1) switch (_context.p = _context.n) {
+          case 0:
+            header = document.getElementById('appHeader');
+            if (!(!header || typeof fetch !== 'function')) {
+              _context.n = 1;
+              break;
+            }
+            return _context.a(2);
+          case 1:
+            _context.p = 1;
+            _context.n = 2;
+            return fetch(new URL('assets/partials/topbar.html', document.baseURI).href);
+          case 2:
+            res = _context.v;
+            if (res.ok) {
+              _context.n = 3;
+              break;
+            }
+            throw new Error("HTTP ".concat(res.status));
+          case 3:
+            _context.n = 4;
+            return res.text();
+          case 4:
+            header.innerHTML = _context.v;
+            _context.n = 6;
+            break;
+          case 5:
+            _context.p = 5;
+            _t = _context.v;
+            console.warn('Nepavyko įkelti viršutinės juostos', _t);
+            notify({
+              type: 'error',
+              message: 'Nepavyko įkelti viršutinės juostos'
+            });
+            header.innerHTML = '<div class="wrap"><button type="button" class="btn" id="retryTopbar">Retry</button></div>';
+            _nav = document.querySelector('nav');
+            _nav === null || _nav === void 0 || _nav.removeAttribute('hidden');
+            _nav === null || _nav === void 0 || _nav.removeAttribute('aria-hidden');
+            (_header$querySelector = header.querySelector('#retryTopbar')) === null || _header$querySelector === void 0 || _header$querySelector.addEventListener('click', initTopbar);
+          case 6:
+            if (typeof ResizeObserver === 'function') {
+              updateHeight = function updateHeight(entries) {
+                var _iterator = _createForOfIteratorHelper(entries),
+                  _step;
+                try {
+                  for (_iterator.s(); !(_step = _iterator.n()).done;) {
+                    var entry = _step.value;
+                    document.documentElement.style.setProperty('--header-height', entry.contentRect.height + 'px');
+                  }
+                } catch (err) {
+                  _iterator.e(err);
+                } finally {
+                  _iterator.f();
+                }
+              };
+              ro = new ResizeObserver(updateHeight);
+              ro.observe(header);
+            }
+            toggle = document.getElementById('navToggle');
+            nav = document.querySelector('nav');
+            if (!toggle && nav) {
+              nav.removeAttribute('hidden');
+              nav.removeAttribute('aria-hidden');
+            }
+            initNavToggle(toggle, nav);
+            patientMenu = document.getElementById('patientMenu');
+            initPatientMenuToggle(patientMenu);
+          case 7:
+            return _context.a(2);
+        }
+      }, _callee, null, [[1, 5]]);
+    }));
+    return _initTopbar.apply(this, arguments);
+  }
+
+  function initCollapsibles() {
+    $$('.view').forEach(function (view) {
+      $$('fieldset.collapsible', view).forEach(function (fs, i) {
+        var legend = fs.querySelector('legend');
+        if (!legend) return;
+        var legendIcon = document.createElement('span');
+        legendIcon.className = 'legend-icon';
+        legend.appendChild(legendIcon);
+        var content = document.createElement('div');
+        content.className = 'fieldset-content';
+        while (legend.nextSibling) {
+          content.appendChild(legend.nextSibling);
+        }
+        fs.appendChild(content);
+        legend.style.cursor = 'pointer';
+        legend.setAttribute('role', 'button');
+        legend.setAttribute('tabindex', '0');
+        var collapsed = fs.dataset.open !== 'true' && view.id !== 'view-aktivacija' && i > 0;
+        if (collapsed) {
+          fs.classList.add('collapsed');
+          legendIcon.classList.add('collapsed');
+          legend.setAttribute('aria-expanded', 'false');
+        } else {
+          legend.setAttribute('aria-expanded', 'true');
+        }
+        var toggle = function toggle() {
+          var isCollapsed = fs.classList.toggle('collapsed');
+          legendIcon.classList.toggle('collapsed', isCollapsed);
+          legend.setAttribute('aria-expanded', (!isCollapsed).toString());
+        };
+        legend.addEventListener('click', toggle);
+        legend.addEventListener('keydown', function (e) {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggle();
+          }
+        });
+      });
+    });
+  }
+
+  var CANVAS = {
+    WIDTH: 480,
+    HEIGHT: 500
+  };
+  var WIDTH = CANVAS.WIDTH;
+
+  /**
+   * Mirror an SVG path across the vertical axis of the viewBox.
+   * Supports basic commands used in this project (M, L, H, C and relative c).
+   *
+   * @param {string} d Path definition for the left side of the body
+   * @returns {string} Mirrored path suitable for the right side
+   */
+  function mirrorPath(d) {
+    var segments = d.match(/[a-zA-Z][^a-zA-Z]*/g) || [];
+    return segments.map(function (seg) {
+      var cmd = seg[0];
+      var nums = seg.slice(1).trim();
+      if (!nums) return cmd;
+      var parts = nums.split(/[ ,]+/).filter(Boolean).map(Number);
+      if (cmd === 'M' || cmd === 'L' || cmd === 'C') {
+        for (var i = 0; i < parts.length; i += 2) {
+          parts[i] = WIDTH - parts[i];
+        }
+      } else if (cmd === 'H') {
+        for (var _i = 0; _i < parts.length; _i++) {
+          parts[_i] = WIDTH - parts[_i];
+        }
+      } else if (cmd === 'c') {
+        for (var _i2 = 0; _i2 < parts.length; _i2 += 2) {
+          parts[_i2] = -parts[_i2];
+        }
+      }
+      return cmd + parts.join(' ');
+    }).join(' ');
+  }
+  function mirrorBbox(_ref) {
+    var _ref2 = _slicedToArray(_ref, 4),
+      x1 = _ref2[0],
+      y1 = _ref2[1],
+      x2 = _ref2[2],
+      y2 = _ref2[3];
+    return [WIDTH - x2, y1, WIDTH - x1, y2];
+  }
+  function makeSymmetric(side, defs) {
+    var sideLabel = side === 'front' ? 'priekis' : 'nugara';
+    return defs.flatMap(function (def) {
+      var left = {
+        id: "".concat(side, "-left-").concat(def.id),
+        side: side,
+        path: def.path,
+        area: def.area,
+        label: "Kair\u0117 ".concat(def.label, " (").concat(sideLabel, ")"),
+        bbox: def.bbox
+      };
+      var right = {
+        id: "".concat(side, "-right-").concat(def.id),
+        side: side,
+        path: mirrorPath(def.path),
+        area: def.area,
+        label: "De\u0161in\u0117 ".concat(def.label, " (").concat(sideLabel, ")"),
+        bbox: mirrorBbox(def.bbox)
+      };
+      return [left, right];
+    });
+  }
+
+  // Symmetric limb definitions used for both front and back views
+  var limbDefs = [{
+    id: 'upper-arm',
+    path: 'M10 200 L60 200 L60 320 L10 320 Z',
+    area: 60,
+    label: 'žastas',
+    bbox: [10, 200, 60, 320]
+  }, {
+    id: 'lower-arm',
+    path: 'M15 320 L55 320 L55 440 L15 440 Z',
+    area: 48,
+    label: 'dilbis',
+    bbox: [15, 320, 55, 440]
+  }, {
+    id: 'hand',
+    path: 'M15 440 L60 440 L60 480 L15 480 Z',
+    area: 18,
+    label: 'plaštaka',
+    bbox: [15, 440, 60, 480]
+  }, {
+    id: 'thigh',
+    path: 'M150 300 L230 300 L230 410 L150 410 Z',
+    area: 88,
+    label: 'šlaunis',
+    bbox: [150, 300, 230, 410]
+  }, {
+    id: 'leg',
+    path: 'M160 410 L220 410 L220 460 L160 460 Z',
+    area: 30,
+    label: 'blauzda',
+    bbox: [160, 410, 220, 460]
+  }, {
+    id: 'foot',
+    path: 'M150 460 L230 460 L230 500 L150 500 Z',
+    area: 32,
+    label: 'pėda',
+    bbox: [150, 460, 230, 500]
+  }];
+  var zones = [
+  // Front zones
+  {
+    id: 'front-head',
+    side: 'front',
+    path: 'M240 30c40 0 70 30 70 70s-30 70-70 70-70-30-70-70 30-70 70-70z',
+    area: 153.94,
+    label: 'Galva (priekis)',
+    bbox: [170, 30, 310, 170]
+  }, {
+    id: 'front-neck',
+    side: 'front',
+    path: 'M210 170 L270 170 L270 200 L210 200 Z',
+    area: 18,
+    label: 'Kaklas (priekis)',
+    bbox: [210, 170, 270, 200]
+  }, {
+    id: 'front-chest',
+    side: 'front',
+    path: 'M140 200 L340 200 L340 300 L140 300 Z',
+    area: 200,
+    label: 'Krūtinė (priekis)',
+    bbox: [140, 200, 340, 300]
+  }, {
+    id: 'front-abdomen',
+    side: 'front',
+    path: 'M140 300 L340 300 L340 400 L140 400 Z',
+    area: 200,
+    label: 'Pilvas (priekis)',
+    bbox: [140, 300, 340, 400]
+  }, {
+    id: 'front-pelvis',
+    side: 'front',
+    path: 'M170 400 L310 400 L310 460 L170 460 Z',
+    area: 84,
+    label: 'Dubuo (priekis)',
+    bbox: [170, 400, 310, 460]
+  }, {
+    id: 'front-groin',
+    side: 'front',
+    path: 'M200 460 L280 460 L280 480 L200 480 Z',
+    area: 16,
+    label: 'Tarpvietė',
+    bbox: [200, 460, 280, 480]
+  }].concat(_toConsumableArray(makeSymmetric('front', limbDefs)), [
+  // Back zones
+  {
+    id: 'back-head',
+    side: 'back',
+    path: 'M240 30c40 0 70 30 70 70s-30 70-70 70-70-30-70-70 30-70 70-70z',
+    area: 153.94,
+    label: 'Galva (nugara)',
+    bbox: [170, 30, 310, 170]
+  }, {
+    id: 'back-neck',
+    side: 'back',
+    path: 'M210 170 L270 170 L270 200 L210 200 Z',
+    area: 18,
+    label: 'Kaklas (nugara)',
+    bbox: [210, 170, 270, 200]
+  }, {
+    id: 'back-upper-back',
+    side: 'back',
+    path: 'M140 200 L340 200 L340 300 L140 300 Z',
+    area: 200,
+    label: 'Viršutinė nugara',
+    bbox: [140, 200, 340, 300]
+  }, {
+    id: 'back-lower-back',
+    side: 'back',
+    path: 'M140 300 L340 300 L340 400 L140 400 Z',
+    area: 200,
+    label: 'Juosmuo',
+    bbox: [140, 300, 340, 400]
+  }, {
+    id: 'back-buttocks',
+    side: 'back',
+    path: 'M170 400 L310 400 L310 460 L170 460 Z',
+    area: 84,
+    label: 'Sėdmenys',
+    bbox: [170, 400, 310, 460]
+  }], _toConsumableArray(makeSymmetric('back', limbDefs)));
+
+  var TOOLS = {
+    WOUND: {
+      char: 'Ž',
+      symbol: '#sym-wound',
+      size: 14
+    },
+    BRUISE: {
+      char: 'S',
+      symbol: '#sym-bruise',
+      size: 10
+    },
+    BURN: {
+      char: 'B',
+      symbol: ''
+    },
+    BURN_ERASE: {
+      char: 'E',
+      symbol: ''
+    }
+  };
+
+  var TOOL_SYMBOL = Object.values(TOOLS).reduce(function (acc, t) {
+    if (t.symbol) acc[t.char] = t.symbol;
+    return acc;
+  }, {});
+  var ZONE_LABELS = zones.reduce(function (acc, z) {
+    acc[z.id] = z.label;
+    return acc;
+  }, {});
+  var TOTAL_AREA = zones.reduce(function (sum, z) {
+    return sum + z.area;
+  }, 0);
+
+  /** Minimalus kūno žemėlapis: žymi žaizdas ir nudegimus. */
+  var BodyMap = /*#__PURE__*/function () {
+    function BodyMap() {
+      _classCallCheck(this, BodyMap);
+      this.initialized = false;
+      this.svg = null;
+      this.marksLayer = null;
+      this.brushLayer = null;
+      this.activeTool = TOOLS.WOUND.char;
+      this.markScale = 1;
+      this.brushSize = 20;
+      this.saveCb = function () {};
+      this.idSeq = 1;
+      this.undoStack = [];
+      this.redoStack = [];
+    }
+    return _createClass(BodyMap, [{
+      key: "init",
+      value: function init(saveCb) {
+        var _this = this;
+        if (this.initialized) return;
+        this.svg = $('#bodySvg');
+        this.marksLayer = $('#marks');
+        if (!this.svg || !this.marksLayer) return;
+        this.saveCb = typeof saveCb === 'function' ? saveCb : function () {};
+        this.brushLayer = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        this.svg.insertBefore(this.brushLayer, this.marksLayer);
+        var layers = {
+          front: $('#layer-front'),
+          back: $('#layer-back')
+        };
+        var _this$getScale = this.getScale(),
+          sx = _this$getScale.sx,
+          sy = _this$getScale.sy;
+        zones.forEach(function (z) {
+          var layer = layers[z.side];
+          if (!layer) return;
+          var group = layer.querySelector('.zones');
+          if (!group) {
+            group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+            group.classList.add('zones');
+            group.setAttribute('transform', "scale(".concat(sx, " ").concat(sy, ")"));
+            layer.appendChild(group);
+          }
+          var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+          path.setAttribute('d', z.path);
+          path.classList.add('zone');
+          path.dataset.zone = z.id;
+          path.dataset.side = z.side;
+          group.appendChild(path);
+        });
+        this.svg.addEventListener('click', function (evt) {
+          var zone = evt.target.closest('.zone');
+          if (!zone) return;
+          var pt = _this.svgPoint(evt);
+          if (_this.activeTool === TOOLS.BURN.char) {
+            _this.addBrush(pt.x, pt.y, _this.brushSize);
+          } else if (_this.activeTool === TOOLS.BURN_ERASE.char) {
+            _this.eraseBrush(pt.x, pt.y, _this.brushSize);
+          } else {
+            _this.addMark(pt.x, pt.y, _this.activeTool, zone.dataset.side, zone.dataset.zone);
+          }
+          _this.saveCb();
+        });
+        this.initialized = true;
+      }
+    }, {
+      key: "getScale",
+      value: function getScale() {
+        var _this$svg$viewBox;
+        var vb = (_this$svg$viewBox = this.svg.viewBox) === null || _this$svg$viewBox === void 0 ? void 0 : _this$svg$viewBox.baseVal;
+        return {
+          // viewBox width includes both front and back halves
+          sx: vb ? vb.width / 2 / CANVAS.WIDTH : 1,
+          sy: vb ? vb.height / CANVAS.HEIGHT : 1
+        };
+      }
+    }, {
+      key: "svgPoint",
+      value: function svgPoint(evt) {
+        var pt = this.svg.createSVGPoint();
+        pt.x = evt.clientX;
+        pt.y = evt.clientY;
+        var _pt$matrixTransform = pt.matrixTransform(this.svg.getScreenCTM().inverse()),
+          x = _pt$matrixTransform.x,
+          y = _pt$matrixTransform.y;
+        return {
+          x: x,
+          y: y
+        };
+      }
+    }, {
+      key: "setTool",
+      value: function setTool(tool) {
+        this.activeTool = tool;
+      }
+    }, {
+      key: "setMarkScale",
+      value: function setMarkScale(scale) {
+        var s = parseFloat(scale);
+        if (!isNaN(s) && s > 0) this.markScale = s;
+      }
+    }, {
+      key: "setBrushSize",
+      value: function setBrushSize(size) {
+        var s = parseFloat(size);
+        if (!isNaN(s) && s > 0) this.brushSize = s;
+      }
+    }, {
+      key: "addMark",
+      value: function addMark(x, y, type, side, zone) {
+        var details = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : {};
+        var use = document.createElementNS('http://www.w3.org/2000/svg', 'use');
+        use.setAttribute('href', TOOL_SYMBOL[type] || '');
+        use.setAttribute('transform', "translate(".concat(x, ",").concat(y, ") scale(").concat(this.markScale, ")"));
+        use.dataset.id = this.idSeq++;
+        use.dataset.type = type;
+        use.dataset.side = side;
+        use.dataset.zone = zone;
+        use.dataset.x = x;
+        use.dataset.y = y;
+        use.dataset.details = JSON.stringify(details);
+        this.marksLayer.appendChild(use);
+        this.undoStack.push({
+          type: 'addMark',
+          el: use
+        });
+        this.redoStack = [];
+        return use;
+      }
+    }, {
+      key: "addBrush",
+      value: function addBrush(x, y, r) {
+        var c = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        c.setAttribute('cx', x);
+        c.setAttribute('cy', y);
+        c.setAttribute('r', r);
+        c.dataset.id = this.idSeq++;
+        c.dataset.x = x;
+        c.dataset.y = y;
+        c.dataset.r = r;
+        this.brushLayer.appendChild(c);
+        this.undoStack.push({
+          type: 'addBrush',
+          el: c
+        });
+        this.redoStack = [];
+        this.updateBurnTotal();
+        return c;
+      }
+
+      /** Remove burn marks within the eraser radius. */
+    }, {
+      key: "eraseBrush",
+      value: function eraseBrush(x, y, r) {
+        var circles = _toConsumableArray(this.brushLayer.querySelectorAll('circle'));
+        var removed = [];
+        circles.forEach(function (c) {
+          var cx = Number(c.dataset.x);
+          var cy = Number(c.dataset.y);
+          var cr = Number(c.dataset.r);
+          var dx = cx - x;
+          var dy = cy - y;
+          if (Math.hypot(dx, dy) <= r + cr) {
+            removed.push(c);
+            c.remove();
+          }
+        });
+        if (removed.length) {
+          this.undoStack.push({
+            type: 'eraseBrush',
+            els: removed
+          });
+          this.redoStack = [];
+        }
+        this.updateBurnTotal();
+      }
+    }, {
+      key: "clear",
+      value: function clear() {
+        this.marksLayer.innerHTML = '';
+        this.brushLayer.innerHTML = '';
+        this.undoStack = [];
+        this.redoStack = [];
+      }
+    }, {
+      key: "serialize",
+      value: function serialize() {
+        var marks = _toConsumableArray(this.marksLayer.querySelectorAll('use')).map(function (el) {
+          return {
+            id: Number(el.dataset.id),
+            x: Number(el.dataset.x),
+            y: Number(el.dataset.y),
+            type: el.dataset.type,
+            side: el.dataset.side,
+            zone: el.dataset.zone,
+            details: JSON.parse(el.dataset.details || '{}')
+          };
+        });
+        var brushes = _toConsumableArray(this.brushLayer.querySelectorAll('circle')).map(function (el) {
+          return {
+            id: Number(el.dataset.id),
+            x: Number(el.dataset.x),
+            y: Number(el.dataset.y),
+            r: Number(el.dataset.r)
+          };
+        });
+        return JSON.stringify({
+          tool: this.activeTool,
+          marks: marks,
+          brushes: brushes
+        });
+      }
+    }, {
+      key: "load",
+      value: function load(data) {
+        var _this2 = this;
+        var obj = typeof data === 'string' ? JSON.parse(data) : data;
+        this.clear();
+        this.activeTool = obj.tool || this.activeTool;
+        (obj.marks || []).forEach(function (m) {
+          return _this2.addMark(m.x, m.y, m.type, m.side, m.zone, m.details);
+        });
+        (obj.brushes || []).forEach(function (b) {
+          return _this2.addBrush(b.x, b.y, b.r);
+        });
+      }
+    }, {
+      key: "burnArea",
+      value: function burnArea() {
+        var total = _toConsumableArray(this.brushLayer.querySelectorAll('circle')).reduce(function (sum, c) {
+          var r = Number(c.dataset.r);
+          return sum + Math.PI * r * r;
+        }, 0);
+        return total * 100 / TOTAL_AREA;
+      }
+    }, {
+      key: "updateBurnTotal",
+      value: function updateBurnTotal() {
+        var el = document.querySelector('#burnTotal');
+        if (!el) return;
+        var pct = this.burnArea().toFixed(1);
+        el.textContent = "".concat(pct, "%");
+      }
+    }, {
+      key: "zoneCounts",
+      value: function zoneCounts() {
+        var counts = {};
+        zones.forEach(function (z) {
+          counts[z.id] = {
+            label: z.label,
+            burned: 0
+          };
+        });
+        this.marksLayer.querySelectorAll('use').forEach(function (el) {
+          var zone = el.dataset.zone;
+          var type = el.dataset.type;
+          if (!counts[zone]) counts[zone] = {
+            label: ZONE_LABELS[zone] || '',
+            burned: 0
+          };
+          counts[zone][type] = (counts[zone][type] || 0) + 1;
+        });
+        var _this$getScale2 = this.getScale(),
+          sx = _this$getScale2.sx,
+          sy = _this$getScale2.sy;
+        this.brushLayer.querySelectorAll('circle').forEach(function (c) {
+          var x = Number(c.dataset.x);
+          var y = Number(c.dataset.y);
+          var r = Number(c.dataset.r);
+          var area = Math.PI * r * r;
+          var zone = zones.find(function (z) {
+            return x >= z.bbox[0] * sx && x <= z.bbox[2] * sx && y >= z.bbox[1] * sy && y <= z.bbox[3] * sy;
+          });
+          if (zone) counts[zone.id].burned += area * 100 / zone.area;
+        });
+        return counts;
+      }
+    }, {
+      key: "undo",
+      value: function undo() {
+        var _this3 = this;
+        var action = this.undoStack.pop();
+        if (!action) return;
+        switch (action.type) {
+          case 'addMark':
+          case 'addBrush':
+            action.el.remove();
+            break;
+          case 'eraseBrush':
+            action.els.forEach(function (el) {
+              return _this3.brushLayer.appendChild(el);
+            });
+            break;
+          case 'deleteMark':
+            this.marksLayer.appendChild(action.el);
+            break;
+        }
+        this.redoStack.push(action);
+      }
+    }, {
+      key: "redo",
+      value: function redo() {
+        var action = this.redoStack.pop();
+        if (!action) return;
+        switch (action.type) {
+          case 'addMark':
+            this.marksLayer.appendChild(action.el);
+            break;
+          case 'addBrush':
+            this.brushLayer.appendChild(action.el);
+            break;
+          case 'eraseBrush':
+            action.els.forEach(function (el) {
+              return el.remove();
+            });
+            break;
+          case 'deleteMark':
+            action.el.remove();
+            break;
+        }
+        this.undoStack.push(action);
+      }
+
+      /**
+       * Replace <use> elements with the referenced shapes so the SVG renders
+       * correctly when exported or printed.
+       * @param {SVGElement} [svg=this.svg] - SVG root to process.
+       * @returns {SVGElement} The processed SVG element.
+       */
+    }, {
+      key: "embedSilhouettes",
+      value: (function () {
+        var _embedSilhouettes = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee(svg) {
+          var root;
+          return _regenerator().w(function (_context) {
+            while (1) switch (_context.n) {
+              case 0:
+                root = svg || this.svg;
+                if (root) {
+                  _context.n = 1;
+                  break;
+                }
+                return _context.a(2, svg);
+              case 1:
+                root.querySelectorAll('use').forEach(function (use) {
+                  var href = use.getAttribute('href') || use.getAttribute('xlink:href');
+                  if (!href || !href.startsWith('#')) return;
+                  var ref = root.querySelector(href);
+                  if (!ref) return;
+                  var g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+                  // Copy all attributes except the href to preserve transforms and data attrs
+                  _toConsumableArray(use.attributes).forEach(function (attr) {
+                    if (attr.name === 'href' || attr.name === 'xlink:href') return;
+                    g.setAttribute(attr.name, attr.value);
+                  });
+                  var refClone = ref.cloneNode(true);
+                  if (refClone.tagName.toLowerCase() === 'symbol') {
+                    while (refClone.firstChild) {
+                      g.appendChild(refClone.firstChild);
+                    }
+                  } else {
+                    g.appendChild(refClone);
+                  }
+                  use.replaceWith(g);
+                });
+                return _context.a(2, root);
+            }
+          }, _callee, this);
+        }));
+        function embedSilhouettes(_x) {
+          return _embedSilhouettes.apply(this, arguments);
+        }
+        return embedSilhouettes;
+      }())
+    }]);
+  }();
+
+  var bodyMap = new BodyMap();
+
+  var FIELD_SELECTORS = 'input[type="text"],input[type="number"],input[type="time"],input[type="date"],input[type="radio"],input[type="checkbox"],textarea,select';
+  var MAX_FIELD_LENGTH = 500;
+  var limit = function limit(val) {
+    var max = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : MAX_FIELD_LENGTH;
+    return (val || '').toString().slice(0, max);
+  };
+  function serializeFields() {
+    var data = {};
+    $$(FIELD_SELECTORS).forEach(function (el) {
+      var key = el.dataset.field || el.id || el.name;
+      if (!key) return;
+      if (el.type === 'radio') {
+        if (el.checked) data[key + '__' + el.value] = true;
+      } else if (el.type === 'checkbox') {
+        data[key] = el.checked ? '__checked__' : limit(el.value);
+      } else {
+        data[key] = limit(el.value);
+      }
+    });
+    return data;
+  }
+  function loadFields() {
+    var data = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    $$(FIELD_SELECTORS).forEach(function (el) {
+      var key = el.dataset.field || el.id || el.name;
+      if (!key) return;
+      if (el.type === 'radio') {
+        el.checked = !!data[key + '__' + el.value];
+      } else if (el.type === 'checkbox') {
+        el.checked = data[key] === '__checked__';
+      } else {
+        var _data$key;
+        el.value = (_data$key = data[key]) !== null && _data$key !== void 0 ? _data$key : '';
+      }
+    });
+  }
+
+  var IMAGING_GROUPS = ['#imaging_ct', '#imaging_xray', '#imaging_other_group'];
+  var CHIP_GROUPS = ['#chips_red', '#chips_yellow'].concat(IMAGING_GROUPS, ['#labs_basic', '#a_airway_group', '#b_breath_left_group', '#b_breath_right_group', '#c_pulse_radial_group', '#c_pulse_femoral_group', '#c_skin_temp_group', '#c_skin_color_group', '#d_pupil_left_group', '#d_pupil_right_group', '#spr_decision_group']);
+  function serializeChips() {
+    var groups = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : CHIP_GROUPS;
+    var data = {};
+    groups.forEach(function (sel) {
+      data['chips:' + sel] = $$('.chip.active', $(sel)).map(function (c) {
+        return c.dataset.value;
+      });
+    });
+    return data;
+  }
+  function loadChips(data) {
+    var groups = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : CHIP_GROUPS;
+    groups.forEach(function (sel) {
+      var arr = data['chips:' + sel] || [];
+      $$('.chip', $(sel)).forEach(function (c) {
+        return c.classList.toggle('active', arr.includes(c.dataset.value));
+      });
+    });
+    var labsArr = data['chips:#labs_basic'] || [];
+    var labsContainer = $('#labs_basic');
+    labsArr.forEach(function (val) {
+      if (!$$('.chip', labsContainer).some(function (c) {
+        return c.dataset.value === val;
+      })) {
+        var chip = document.createElement('span');
+        chip.className = 'chip';
+        chip.dataset.value = val;
+        chip.textContent = val;
+        labsContainer.appendChild(chip);
+      }
+    });
+    $$('.chip', labsContainer).forEach(function (c) {
+      return c.classList.toggle('active', labsArr.includes(c.dataset.value));
+    });
+  }
+
+  function updateDomToggles() {
+    var showBack = $$('.chip.active', $('#e_back_group')).some(function (c) {
+      return c.dataset.value === 'Pakitimai';
+    });
+    var backNote = $('#e_back_notes');
+    backNote.style.display = showBack ? 'block' : 'none';
+    backNote.classList.toggle('hidden', !showBack);
+    var showAbdomen = $$('.chip.active', $('#e_abdomen_group')).some(function (c) {
+      return c.dataset.value === 'Pakitimai';
+    });
+    var abdomenNote = $('#e_abdomen_notes');
+    abdomenNote.style.display = showAbdomen ? 'block' : 'none';
+    abdomenNote.classList.toggle('hidden', !showAbdomen);
+    var showSkinColorOther = $$('.chip.active', $('#c_skin_color_group')).some(function (c) {
+      return c.dataset.value === 'Kita';
+    });
+    var skinColorOther = $('#c_skin_color_other');
+    skinColorOther.hidden = !showSkinColorOther;
+    skinColorOther.classList.toggle('hidden', !showSkinColorOther);
+    $('#oxygenFields').classList.toggle('hidden', !($('#b_oxygen_liters').value || $('#b_oxygen_type').value));
+    $('#dpvFields').classList.toggle('hidden', !$('#b_dpv_fio2').value);
+    var showSky = $$('.chip.active', $('#spr_decision_group')).some(function (c) {
+      return c.dataset.value === 'Stacionarizavimas';
+    });
+    var skyBox = $('#spr_skyrius_container');
+    skyBox.style.display = showSky ? 'block' : 'none';
+    skyBox.classList.toggle('hidden', !showSky);
+    var showHosp = $$('.chip.active', $('#spr_decision_group')).some(function (c) {
+      return c.dataset.value === 'Pervežimas į kitą ligoninę';
+    });
+    var hospBox = $('#spr_ligonine_container');
+    hospBox.style.display = showHosp ? 'block' : 'none';
+    hospBox.classList.toggle('hidden', !showHosp);
+    var showSkyOther = $('#spr_skyrius').value === 'Kita';
+    var skyOther = $('#spr_skyrius_kita');
+    skyOther.style.display = showSkyOther ? 'block' : 'none';
+    skyOther.classList.toggle('hidden', !showSkyOther);
+    var showImgOther = IMAGING_GROUPS.some(function (sel) {
+      return $$('.chip.active', $(sel)).some(function (c) {
+        return c.dataset.value === 'Kita';
+      });
+    });
+    var imgOther = $('#imaging_other');
+    imgOther.style.display = showImgOther ? 'block' : 'none';
+    imgOther.classList.toggle('hidden', !showImgOther);
+  }
+
+  var authToken = localStorage.getItem('trauma_token') || null;
+  var currentSessionId = localStorage.getItem('trauma_current_session') || null;
+  var theme = localStorage.getItem('trauma_theme') || 'light';
+  function setTheme(t) {
+    theme = t === 'light' ? 'light' : 'dark';
+    localStorage.setItem('trauma_theme', theme);
+    var root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    root.style.colorScheme = theme;
+    var meta = document.querySelector('meta[name="color-scheme"]');
+    if (meta) meta.content = theme === 'dark' ? 'dark light' : 'light dark';
+  }
+  function initTheme() {
+    setTheme(theme);
+  }
+  function sessionKey() {
+    return 'trauma_v10_' + currentSessionId;
+  }
+  function setCurrentSessionId(id) {
+    currentSessionId = id;
+    if (id) localStorage.setItem('trauma_current_session', id);else localStorage.removeItem('trauma_current_session');
+  }
+  function getCurrentSessionId() {
+    return currentSessionId;
+  }
+  function saveAll() {
+    return _saveAll.apply(this, arguments);
+  }
+  function _saveAll() {
+    _saveAll = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee() {
+      var data, pack, statusEl, res, msg;
+      return _regenerator().w(function (_context) {
+        while (1) switch (_context.p = _context.n) {
+          case 0:
+            pack = function _pack(container) {
+              return Array.from(container.children).map(function (card) {
+                return {
+                  name: limit(card.querySelector('.act_custom_name') ? card.querySelector('.act_custom_name').value : card.querySelector('.act_name').textContent.trim()),
+                  on: card.querySelector('.act_chk').checked,
+                  time: limit(card.querySelector('.act_time').value),
+                  dose: limit(card.querySelector('.act_dose') ? card.querySelector('.act_dose').value : ''),
+                  note: limit(card.querySelector('.act_note').value)
+                };
+              });
+            };
+            if (currentSessionId) {
+              _context.n = 1;
+              break;
+            }
+            return _context.a(2);
+          case 1:
+            data = _objectSpread2(_objectSpread2({}, serializeFields()), serializeChips(CHIP_GROUPS));
+            data['pain_meds'] = pack($('#pain_meds'));
+            data['bleeding_meds'] = pack($('#bleeding_meds'));
+            data['other_meds'] = pack($('#other_meds'));
+            data['procs'] = pack($('#procedures_it')).concat(pack($('#procedures_other')));
+            data['bodymap_svg'] = limit(bodyMap.serialize(), 200000);
+            localStorage.setItem(sessionKey(), JSON.stringify(data));
+            statusEl = $('#saveStatus');
+            if (statusEl) {
+              statusEl.textContent = 'Saving...';
+              statusEl.classList.remove('offline');
+            }
+            if (!(authToken && typeof fetch === 'function')) {
+              _context.n = 7;
+              break;
+            }
+            _context.p = 2;
+            _context.n = 3;
+            return fetch("/api/sessions/".concat(currentSessionId, "/data"), {
+              method: 'PUT',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer ' + authToken
+              },
+              body: JSON.stringify(data)
+            });
+          case 3:
+            res = _context.v;
+            if (res.ok) {
+              _context.n = 4;
+              break;
+            }
+            throw new Error(res.status);
+          case 4:
+            if (statusEl) {
+              statusEl.textContent = 'Saved';
+              statusEl.classList.remove('offline');
+            }
+            _context.n = 6;
+            break;
+          case 5:
+            _context.p = 5;
+            _context.v;
+            if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+              msg = {
+                type: 'queue-session',
+                id: currentSessionId,
+                data: data,
+                token: authToken
+              };
+              navigator.serviceWorker.ready.then(function (reg) {
+                var _reg$active;
+                (_reg$active = reg.active) === null || _reg$active === void 0 || _reg$active.postMessage(msg);
+                reg.sync.register('sync-sessions');
+              });
+            }
+            if (statusEl) {
+              statusEl.textContent = 'Save failed';
+              statusEl.classList.add('offline');
+            }
+          case 6:
+            _context.n = 8;
+            break;
+          case 7:
+            if (statusEl) {
+              statusEl.textContent = 'Saved';
+            }
+          case 8:
+            return _context.a(2);
+        }
+      }, _callee, null, [[2, 5]]);
+    }));
+    return _saveAll.apply(this, arguments);
+  }
+  function loadAll() {
+    if (!currentSessionId) return;
+    var apply = function apply(data) {
+      loadFields(data);
+      loadChips(data, CHIP_GROUPS);
+      loadRecords(data);
+      loadBodyMap(data);
+      updateDomToggles();
+    };
+    var fallback = function fallback() {
+      var raw = localStorage.getItem(sessionKey());
+      if (!raw) {
+        apply({});
+        return;
+      }
+      try {
+        apply(JSON.parse(raw));
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    if (authToken && typeof fetch === 'function') {
+      fetch("/api/sessions/".concat(currentSessionId, "/data"), {
+        headers: {
+          'Authorization': 'Bearer ' + authToken
+        }
+      }).then(function (r) {
+        return r.json();
+      }).then(function (d) {
+        localStorage.setItem(sessionKey(), JSON.stringify(d));
+        apply(d);
+      }).catch(fallback);
+    } else {
+      fallback();
+    }
+  }
+  function loadRecords(data) {
+    function unpack(container, records) {
+      var arr = Array.isArray(records) ? records : [];
+      Array.from(container.children).forEach(function (card, i) {
+        var r = arr[i] || {};
+        card.querySelector('.act_chk').checked = !!r.on;
+        card.querySelector('.act_time').value = r.time || '';
+        var d = card.querySelector('.act_dose');
+        if (d) d.value = r.dose || '';
+        card.querySelector('.act_note').value = r.note || '';
+        var cn = card.querySelector('.act_custom_name');
+        if (cn) cn.value = r.name || '';
+      });
+    }
+    unpack($('#pain_meds'), data['pain_meds']);
+    unpack($('#bleeding_meds'), data['bleeding_meds']);
+    unpack($('#other_meds'), data['other_meds']);
+    var procsArr = Array.isArray(data['procs']) ? data['procs'] : [];
+    var itCount = $('#procedures_it').children.length;
+    unpack($('#procedures_it'), procsArr.slice(0, itCount));
+    unpack($('#procedures_other'), procsArr.slice(itCount));
+  }
+  function loadBodyMap(data) {
+    bodyMap.load(data['bodymap_svg'] || '{}');
+  }
+  function getAuthToken() {
+    return authToken;
+  }
+  function logout() {
+    return _logout.apply(this, arguments);
+  }
+  function _logout() {
+    _logout = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee2() {
+      var _t2;
+      return _regenerator().w(function (_context2) {
+        while (1) switch (_context2.p = _context2.n) {
+          case 0:
+            if (!(authToken && typeof fetch === 'function')) {
+              _context2.n = 4;
+              break;
+            }
+            _context2.p = 1;
+            _context2.n = 2;
+            return fetch('/api/logout', {
+              method: 'POST',
+              headers: {
+                'Authorization': 'Bearer ' + authToken
+              }
+            });
+          case 2:
+            _context2.n = 4;
+            break;
+          case 3:
+            _context2.p = 3;
+            _t2 = _context2.v;
+            console.error(_t2);
+          case 4:
+            authToken = null;
+            localStorage.removeItem('trauma_token');
+            location.reload();
+          case 5:
+            return _context2.a(2);
+        }
+      }, _callee2, null, [[1, 3]]);
+    }));
+    return _logout.apply(this, arguments);
+  }
+
+  /* global io */
+
+  var socket = null;
+  var socketEndpoint = window.socketEndpoint || window.SOCKET_URL;
+  var INITIAL_DELAY = 1000;
+  var MAX_DELAY = 16000;
+  var reconnectDelay = INITIAL_DELAY;
+  function resetDelay() {
+    reconnectDelay = INITIAL_DELAY;
+  }
+  function fetchUsers() {
+    return _fetchUsers.apply(this, arguments);
+  }
+  function _fetchUsers() {
+    _fetchUsers = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee() {
+      var token, res, _t;
+      return _regenerator().w(function (_context) {
+        while (1) switch (_context.p = _context.n) {
+          case 0:
+            token = getAuthToken();
+            if (!(token && typeof fetch === 'function')) {
+              _context.n = 6;
+              break;
+            }
+            _context.p = 1;
+            _context.n = 2;
+            return fetch('/api/users', {
+              headers: {
+                'Authorization': 'Bearer ' + token
+              }
+            });
+          case 2:
+            res = _context.v;
+            if (!res.ok) {
+              _context.n = 4;
+              break;
+            }
+            _context.n = 3;
+            return res.json();
+          case 3:
+            return _context.a(2, _context.v);
+          case 4:
+            _context.n = 6;
+            break;
+          case 5:
+            _context.p = 5;
+            _t = _context.v;
+            console.error(_t);
+          case 6:
+            return _context.a(2, []);
+        }
+      }, _callee, null, [[1, 5]]);
+    }));
+    return _fetchUsers.apply(this, arguments);
+  }
+  function getSessions() {
+    return _getSessions.apply(this, arguments);
+  }
+  function _getSessions() {
+    _getSessions = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee2() {
+      var token, res, data, normalized, _t2;
+      return _regenerator().w(function (_context2) {
+        while (1) switch (_context2.p = _context2.n) {
+          case 0:
+            token = getAuthToken();
+            if (!(token && typeof fetch === 'function')) {
+              _context2.n = 6;
+              break;
+            }
+            _context2.p = 1;
+            _context2.n = 2;
+            return fetch('/api/sessions', {
+              headers: {
+                'Authorization': 'Bearer ' + token
+              }
+            });
+          case 2:
+            res = _context2.v;
+            if (!res.ok) {
+              _context2.n = 4;
+              break;
+            }
+            _context2.n = 3;
+            return res.json();
+          case 3:
+            data = _context2.v;
+            normalized = data.map(function (s) {
+              return _objectSpread2(_objectSpread2({}, s), {}, {
+                archived: !!s.archived
+              });
+            });
+            localStorage.setItem('trauma_sessions', JSON.stringify(normalized));
+            return _context2.a(2, normalized);
+          case 4:
+            _context2.n = 6;
+            break;
+          case 5:
+            _context2.p = 5;
+            _t2 = _context2.v;
+            console.error(_t2);
+          case 6:
+            _context2.p = 6;
+            return _context2.a(2, JSON.parse(localStorage.getItem('trauma_sessions') || '[]').map(function (s) {
+              return _objectSpread2(_objectSpread2({}, s), {}, {
+                archived: !!s.archived
+              });
+            }));
+          case 7:
+            _context2.p = 7;
+            _context2.v;
+            return _context2.a(2, []);
+        }
+      }, _callee2, null, [[6, 7], [1, 5]]);
+    }));
+    return _getSessions.apply(this, arguments);
+  }
+  function saveSessions(_x) {
+    return _saveSessions.apply(this, arguments);
+  }
+  function _saveSessions() {
+    _saveSessions = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee3(list) {
+      var token, res, _t4;
+      return _regenerator().w(function (_context3) {
+        while (1) switch (_context3.p = _context3.n) {
+          case 0:
+            localStorage.setItem('trauma_sessions', JSON.stringify(list));
+            token = getAuthToken();
+            if (!(token && typeof fetch === 'function')) {
+              _context3.n = 5;
+              break;
+            }
+            _context3.p = 1;
+            _context3.n = 2;
+            return fetch('/api/sessions', {
+              method: 'PUT',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer ' + token
+              },
+              body: JSON.stringify(list)
+            });
+          case 2:
+            res = _context3.v;
+            if (res.ok) {
+              _context3.n = 3;
+              break;
+            }
+            throw new Error(res.status);
+          case 3:
+            _context3.n = 5;
+            break;
+          case 4:
+            _context3.p = 4;
+            _t4 = _context3.v;
+            console.error(_t4);
+            notify({
+              type: 'error',
+              message: 'Failed to save sessions'
+            });
+          case 5:
+            return _context3.a(2);
+        }
+      }, _callee3, null, [[1, 4]]);
+    }));
+    return _saveSessions.apply(this, arguments);
+  }
+  function connectSocket() {
+    var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      onSessions = _ref.onSessions,
+      onSessionData = _ref.onSessionData,
+      onUsers = _ref.onUsers;
+    var token = getAuthToken();
+    if (typeof io === 'undefined' || socket || !token) return;
+    socket = io(socketEndpoint || undefined, {
+      auth: {
+        token: 'Bearer ' + token
+      }
+    });
+    socket.on('connect', resetDelay);
+    socket.on('connect_error', function (err) {
+      console.error('Socket connection error:', err);
+      notify({
+        type: 'error',
+        message: 'Connection error. Retrying...'
+      });
+      setTimeout(function () {
+        return socket.connect();
+      }, reconnectDelay);
+      reconnectDelay = Math.min(reconnectDelay * 2, MAX_DELAY);
+    });
+    socket.on('disconnect', function (reason) {
+      console.warn('Socket disconnected:', reason);
+      notify({
+        type: 'error',
+        message: 'Disconnected from server'
+      });
+    });
+    socket.on('reconnect', function (attempt) {
+      console.log('Socket reconnected after', attempt, 'attempts');
+      notify({
+        type: 'success',
+        message: 'Reconnected to server'
+      });
+      resetDelay();
+    });
+    if (onSessions) socket.on('sessions', onSessions);
+    if (onSessionData) socket.on('sessionData', onSessionData);
+    if (onUsers) socket.on('users', onUsers);
+  }
+
+  function updateUserList(users) {
+    var el = document.getElementById('userList');
+    if (el) el.textContent = users.length ? "Prisijung\u0119: ".concat(users.join(', ')) : '';
+  }
+  function populateSessionSelect(sel, sessions) {
+    var _ref = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {},
+      _ref$query = _ref.query,
+      query = _ref$query === void 0 ? '' : _ref$query;
+    sel.innerHTML = '';
+    var q = query.trim().toLowerCase();
+    var list = sessions.filter(function (s) {
+      return (!s.archived) && (!q || s.name.toLowerCase().includes(q));
+    }).slice().sort(function (a, b) {
+      return (a.created || 0) - (b.created || 0);
+    });
+    list.forEach(function (s) {
+      var opt = document.createElement('option');
+      opt.value = s.id;
+      opt.textContent = s.name;
+      sel.appendChild(opt);
+    });
+    return list;
+  }
+  function initSessions() {
+    return _initSessions.apply(this, arguments);
+  }
+  function _initSessions() {
+    _initSessions = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee4() {
+      var select, searchInput, sessions, currentSessionId, patientLabel, renameBtn, deleteBtn, saveBtn, render, id, _sessions$find;
+      return _regenerator().w(function (_context4) {
+        while (1) switch (_context4.n) {
+          case 0:
+            select = $('#sessionSelect');
+            if (select) {
+              _context4.n = 1;
+              break;
+            }
+            return _context4.a(2);
+          case 1:
+            searchInput = $('#patientSearch');
+            _context4.n = 2;
+            return getSessions();
+          case 2:
+            sessions = _context4.v;
+            currentSessionId = getCurrentSessionId();
+            patientLabel = $('#patientMenuLabel');
+            renameBtn = $('#renamePatientBtn');
+            deleteBtn = $('#deletePatientBtn');
+            saveBtn = $('#saveBtn');
+            render = function render() {
+              var filtered = populateSessionSelect(select, sessions, {
+                query: (searchInput === null || searchInput === void 0 ? void 0 : searchInput.value) || ''
+              });
+              if (currentSessionId && filtered.some(function (s) {
+                return s.id === currentSessionId;
+              })) {
+                select.value = currentSessionId;
+              } else {
+                var _filtered$;
+                currentSessionId = ((_filtered$ = filtered[0]) === null || _filtered$ === void 0 ? void 0 : _filtered$.id) || null;
+                setCurrentSessionId(currentSessionId);
+                if (currentSessionId) select.value = currentSessionId;else select.value = '';
+              }
+              if (patientLabel) {
+                var current = filtered.find(function (s) {
+                  return s.id === currentSessionId;
+                });
+                patientLabel.textContent = current ? current.name : 'Pacientas';
+              }
+            };
+            searchInput === null || searchInput === void 0 || searchInput.addEventListener('input', function () {
+              return render();
+            });
+            if (sessions.length) {
+              _context4.n = 4;
+              break;
+            }
+            id = Date.now().toString(36);
+            sessions = [{
+              id: id,
+              name: 'Pacientas Nr.1',
+              archived: false,
+              created: Date.now()
+            }];
+            _context4.n = 3;
+            return saveSessions(sessions);
+          case 3:
+            currentSessionId = id;
+            setCurrentSessionId(id);
+          case 4:
+            if (!currentSessionId || !sessions.some(function (s) {
+              return s.id === currentSessionId;
+            })) {
+              currentSessionId = ((_sessions$find = sessions.find(function (s) {
+                return !s.archived;
+              })) === null || _sessions$find === void 0 ? void 0 : _sessions$find.id) || sessions[0].id;
+              setCurrentSessionId(currentSessionId);
+            }
+            render();
+            renameBtn === null || renameBtn === void 0 || renameBtn.addEventListener('click', /*#__PURE__*/_asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee() {
+              var id, session, newName, trimmed;
+              return _regenerator().w(function (_context) {
+                while (1) switch (_context.n) {
+                  case 0:
+                    id = getCurrentSessionId();
+                    session = sessions.find(function (s) {
+                      return s.id === id;
+                    });
+                    if (session) {
+                      _context.n = 1;
+                      break;
+                    }
+                    return _context.a(2);
+                  case 1:
+                    _context.n = 2;
+                    return notify({
+                      type: 'prompt',
+                      message: 'Paciento ID',
+                      defaultValue: session.name
+                    });
+                  case 2:
+                    newName = _context.v;
+                    if (newName) {
+                      _context.n = 3;
+                      break;
+                    }
+                    return _context.a(2);
+                  case 3:
+                    trimmed = newName.trim();
+                    if (trimmed) {
+                      _context.n = 4;
+                      break;
+                    }
+                    notify({
+                      type: 'error',
+                      message: 'Pavadinimas negali būti tuščias.'
+                    });
+                    return _context.a(2);
+                  case 4:
+                    if (!sessions.some(function (s) {
+                      return s.id !== id && s.name.trim().toLowerCase() === trimmed.toLowerCase();
+                    })) {
+                      _context.n = 5;
+                      break;
+                    }
+                    notify({
+                      type: 'error',
+                      message: 'Pacientas su tokiu pavadinimu jau egzistuoja.'
+                    });
+                    return _context.a(2);
+                  case 5:
+                    session.name = trimmed;
+                    _context.n = 6;
+                    return saveSessions(sessions);
+                  case 6:
+                    render();
+                  case 7:
+                    return _context.a(2);
+                }
+              }, _callee);
+            })));
+            deleteBtn === null || deleteBtn === void 0 || deleteBtn.addEventListener('click', /*#__PURE__*/_asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee2() {
+              var id, session, token, _t;
+              return _regenerator().w(function (_context2) {
+                while (1) switch (_context2.p = _context2.n) {
+                  case 0:
+                    id = getCurrentSessionId();
+                    if (id) {
+                      _context2.n = 1;
+                      break;
+                    }
+                    return _context2.a(2);
+                  case 1:
+                    session = sessions.find(function (s) {
+                      return s.id === id;
+                    });
+                    if (session) {
+                      _context2.n = 2;
+                      break;
+                    }
+                    return _context2.a(2);
+                  case 2:
+                    _context2.n = 3;
+                    return notify({
+                      type: 'confirm',
+                      message: 'Ar tikrai norite ištrinti pacientą?'
+                    });
+                  case 3:
+                    if (_context2.v) {
+                      _context2.n = 4;
+                      break;
+                    }
+                    return _context2.a(2);
+                  case 4:
+                    token = getAuthToken();
+                    if (!(token && typeof fetch === 'function')) {
+                      _context2.n = 8;
+                      break;
+                    }
+                    _context2.p = 5;
+                    _context2.n = 6;
+                    return fetch("/api/sessions/".concat(id), {
+                      method: 'DELETE',
+                      headers: {
+                        'Authorization': 'Bearer ' + token
+                      }
+                    });
+                  case 6:
+                    _context2.n = 8;
+                    break;
+                  case 7:
+                    _context2.p = 7;
+                    _t = _context2.v;
+                    console.error(_t);
+                  case 8:
+                    sessions = sessions.filter(function (s) {
+                      return s.id !== id;
+                    });
+                    _context2.n = 9;
+                    return saveSessions(sessions);
+                  case 9:
+                    localStorage.removeItem('trauma_v10_' + id);
+                    render();
+                    localStorage.setItem('v10_activeTab', 'Aktyvacija');
+                    location.reload();
+                  case 10:
+                    return _context2.a(2);
+                }
+              }, _callee2, null, [[5, 7]]);
+            })));
+            saveBtn === null || saveBtn === void 0 || saveBtn.addEventListener('click', function () {
+              try {
+                saveAll();
+                notify({
+                  type: 'success',
+                  message: 'Išsaugota.'
+                });
+              } catch (e) {
+                console.error(e);
+                notify({
+                  type: 'error',
+                  message: 'Nepavyko išsaugoti.'
+                });
+              }
+            });
+            $('#btnNewSession').addEventListener('click', /*#__PURE__*/_asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee3() {
+              var name, id;
+              return _regenerator().w(function (_context3) {
+                while (1) switch (_context3.n) {
+                  case 0:
+                    _context3.n = 1;
+                    return notify({
+                      type: 'prompt',
+                      message: 'Paciento ID'
+                    });
+                  case 1:
+                    name = _context3.v;
+                    if (name) {
+                      _context3.n = 2;
+                      break;
+                    }
+                    return _context3.a(2);
+                  case 2:
+                    id = Date.now().toString(36);
+                    sessions.push({
+                      id: id,
+                      name: name,
+                      archived: false,
+                      created: Date.now()
+                    });
+                    _context3.n = 3;
+                    return saveSessions(sessions);
+                  case 3:
+                    currentSessionId = id;
+                    setCurrentSessionId(id);
+                    render();
+                    localStorage.setItem('v10_activeTab', 'Aktyvacija');
+                    location.reload();
+                  case 4:
+                    return _context3.a(2);
+                }
+              }, _callee3);
+            })));
+            select.addEventListener('change', function () {
+              var id = select.value;
+              saveAll();
+              currentSessionId = id;
+              setCurrentSessionId(id);
+              localStorage.setItem('v10_activeTab', 'Aktyvacija');
+              location.reload();
+            });
+          case 5:
+            return _context4.a(2);
+        }
+      }, _callee4);
+    }));
+    return _initSessions.apply(this, arguments);
+  }
+
+  var TEAM_ROLES = ['Komandos vadovas', 'Raštininkas', 'ED gydytojas 1', 'ED gydytojas 2', 'Slaugytoja 1', 'Slaugytoja 2', 'Anesteziologas', 'Chirurgas', 'Ortopedas'];
+
+  var fastAreas = [{
+    name: 'Perikardas',
+    marker: 'skystis'
+  }, {
+    name: 'Dešinė pleura',
+    marker: 'skystis ar oras'
+  }, {
+    name: 'Kairė pleura',
+    marker: 'skystis ar oras'
+  }, {
+    name: 'RUQ',
+    marker: 'skystis'
+  }, {
+    name: 'LUQ',
+    marker: 'skystis'
+  }, {
+    name: 'Dubuo',
+    marker: 'skystis'
+  }];
+  function gksSum(a, k, m) {
+    a = +a || 0;
+    k = +k || 0;
+    m = +m || 0;
+    return a && k && m ? a + k + m : '';
+  }
+  var getSingleValue = function getSingleValue(sel) {
+    return listChips(sel)[0] || '';
+  };
+  function bodymapSummary() {
+    var zones = bodyMap.zoneCounts();
+    var parts = Object.values(zones).map(function (z) {
+      var seg = [];
+      if (z[TOOLS.WOUND.char]) seg.push("".concat(z[TOOLS.WOUND.char], " ").concat(TOOLS.WOUND.char));
+      if (z[TOOLS.BRUISE.char]) seg.push("".concat(z[TOOLS.BRUISE.char], " ").concat(TOOLS.BRUISE.char));
+      if (z.burned) seg.push("nudegimai ".concat(z.burned.toFixed(1), "%"));
+      return seg.length ? "".concat(z.label, ": ").concat(seg.join(', ')) : null;
+    }).filter(Boolean);
+    return parts.length ? "\u017Dem\u0117lapis: ".concat(parts.join('; ')) : '';
+  }
+  function generateReport() {
+    var out = [];
+    var patient = {
+      age: $('#patient_age').value,
+      sex: $('#patient_sex').value
+    };
+    var patientLine = [patient.age ? "Am\u017Eius ".concat(patient.age) : null, patient.sex ? "Lytis ".concat(patient.sex) : null].filter(Boolean).join('; ');
+    if (patientLine) {
+      out.push('--- Pacientas ---');
+      out.push(patientLine);
+    }
+    var red = listChips('#chips_red'),
+      yellow = listChips('#chips_yellow');
+    var gmp = {
+      hr: $('#gmp_hr').value,
+      rr: $('#gmp_rr').value,
+      spo2: $('#gmp_spo2').value,
+      sbp: $('#gmp_sbp').value,
+      dbp: $('#gmp_dbp').value,
+      gksa: $('#gmp_gksa').value,
+      gksk: $('#gmp_gksk').value,
+      gksm: $('#gmp_gksm').value,
+      time: $('#gmp_time').value,
+      mechanism: $('#gmp_mechanism').value,
+      notes: $('#gmp_notes').value
+    };
+    var gksGMP = gksSum(gmp.gksa, gmp.gksk, gmp.gksm);
+    var gmpMeta = [gmp.time ? "GMP ".concat(gmp.time) : null, gmp.mechanism ? "Mechanizmas: ".concat(gmp.mechanism) : null].filter(Boolean).join('; ');
+    var gmpLine = [gmp.hr ? "\u0160SD ".concat(gmp.hr, "/min") : null, gmp.rr ? "KD ".concat(gmp.rr, "/min") : null, gmp.spo2 ? "SpO\u2082 ".concat(gmp.spo2, "%") : null, gmp.sbp || gmp.dbp ? "AKS ".concat(gmp.sbp, "/").concat(gmp.dbp) : null, gksGMP ? "GKS ".concat(gksGMP, " (A").concat(gmp.gksa, "-K").concat(gmp.gksk, "-M").concat(gmp.gksm, ")") : null].filter(Boolean).join('; ');
+    out.push('--- Aktyvacija ---');
+    if (gmpMeta) out.push(gmpMeta);
+    if (gmpLine) out.push(gmpLine);
+    if (gmp.notes) out.push('Pastabos: ' + gmp.notes);
+    if (red.length) out.push('RAUDONA: ' + red.join(', '));
+    if (yellow.length) out.push('GELTONA: ' + yellow.join(', '));
+    out.push('\n--- A Kvėpavimo takai ---');
+    out.push(['Takai: ' + (getSingleValue('#a_airway_group') || '-'), $('#a_notes').value ? 'Pastabos: ' + $('#a_notes').value : null].filter(Boolean).join(' | '));
+    out.push('\n--- B Kvėpavimas ---');
+    out.push([$('#b_rr').value ? 'KD ' + $('#b_rr').value + '/min' : null, $('#b_spo2').value ? 'SpO₂ ' + $('#b_spo2').value + '%' : null, 'Alsavimas kairė ' + (getSingleValue('#b_breath_left_group') || '–') + ', dešinė ' + (getSingleValue('#b_breath_right_group') || '–'), $('#b_oxygen_liters').value || $('#b_oxygen_type').value ? 'O2 ' + ($('#b_oxygen_liters').value ? $('#b_oxygen_liters').value + ' L/min ' : '') + ($('#b_oxygen_type').value ? $('#b_oxygen_type').value : '') : null, $('#b_dpv_fio2').value ? 'DPV FiO₂ ' + $('#b_dpv_fio2').value : null].filter(Boolean).join('; '));
+    var chr = $('#c_hr').value,
+      csbp = $('#c_sbp').value,
+      cdbp = $('#c_dbp').value;
+    var cmap = csbp && cdbp ? Math.round((+csbp + 2 * +cdbp) / 3) : '';
+    var csi = chr && csbp ? (+chr / +csbp).toFixed(2) : '';
+    var radial = getSingleValue('#c_pulse_radial_group');
+    var femoral = getSingleValue('#c_pulse_femoral_group');
+    var skinTemp = getSingleValue('#c_skin_temp_group');
+    var skinColorChip = getSingleValue('#c_skin_color_group');
+    var skinColor = skinColorChip === 'Kita' ? $('#c_skin_color_other').value : skinColorChip;
+    var skinParts = [skinTemp, skinColor].filter(Boolean);
+    var skin = skinParts.length ? 'Oda: ' + skinParts.join(', ') : null;
+    out.push('\n--- C Kraujotaka ---');
+    out.push([chr ? 'ŠSD ' + chr + '/min' : null, csbp || cdbp ? 'AKS ' + csbp + '/' + cdbp : null, cmap ? 'VAS ' + cmap : null, csi ? 'ŠI ' + csi : null, $('#c_caprefill').value ? 'KPL ' + $('#c_caprefill').value + 's' : null, radial ? 'Radialinis pulsas ' + radial : null, femoral ? 'Femoralis pulsas ' + femoral : null, skin].filter(Boolean).join('; '));
+    var dgks = gksSum($('#d_gksa').value, $('#d_gksk').value, $('#d_gksm').value);
+    var left = getSingleValue('#d_pupil_left_group');
+    var right = getSingleValue('#d_pupil_right_group');
+    out.push('\n--- D Sąmonė ---');
+    out.push([dgks ? 'GKS ' + dgks + ' (A' + $('#d_gksa').value + '-K' + $('#d_gksk').value + '-M' + $('#d_gksm').value + ')' : null, left ? 'Vyzdžiai kairė: ' + left + (left === 'kita' && $('#d_pupil_left_note').value ? ' (' + $('#d_pupil_left_note').value + ')' : '') : null, right ? 'Vyzdžiai dešinė: ' + right + (right === 'kita' && $('#d_pupil_right_note').value ? ' (' + $('#d_pupil_right_note').value + ')' : '') : null, $('#d_notes').value ? 'Pastabos: ' + $('#d_notes').value : null].filter(Boolean).join(' | '));
+    var back = getSingleValue('#e_back_group');
+    var abdomen = getSingleValue('#e_abdomen_group');
+    out.push('\n--- E Kita ---');
+    out.push([$('#e_temp').value ? 'T ' + $('#e_temp').value + '°C' : null, back === 'Be pakitimų' ? 'Nugara: be pakitimų' : back === 'Pakitimai' && $('#e_back_notes').value ? 'Nugara: ' + $('#e_back_notes').value : null, abdomen === 'Be pakitimų' ? 'Pilvas: be pakitimų' : abdomen === 'Pakitimai' && $('#e_abdomen_notes').value ? 'Pilvas: ' + $('#e_abdomen_notes').value : null, $('#e_other').value ? 'Kita: ' + $('#e_other').value : null, bodymapSummary()].filter(Boolean).join(' | '));
+    function collect(container) {
+      return Array.from(container.children).map(function (card) {
+        var on = card.querySelector('.act_chk').checked;
+        if (!on) return null;
+        var nameInput = card.querySelector('.act_custom_name');
+        var base = card.querySelector('.act_name').textContent.trim();
+        var customName = nameInput ? nameInput.value.trim() : '';
+        var name = nameInput ? customName : base;
+        if (nameInput && !customName) return null;
+        var time = card.querySelector('.act_time').value;
+        var doseInput = card.querySelector('.act_dose');
+        var dose = doseInput ? doseInput.value : '';
+        var note = card.querySelector('.act_note').value;
+        return [name, time ? 'laikas ' + time : null, dose ? 'dozė ' + dose : null, note ? 'pastabos ' + note : null].filter(Boolean).join(' | ');
+      }).filter(Boolean);
+    }
+    var pain = collect($('#pain_meds')),
+      bleeding = collect($('#bleeding_meds')),
+      other = collect($('#other_meds')),
+      procsIt = collect($('#procedures_it')),
+      procsOther = collect($('#procedures_other'));
+    if (pain.length || bleeding.length || other.length || procsIt.length || procsOther.length) {
+      out.push('\n--- Intervencijos ---');
+      if (pain.length) out.push('Medikamentai (skausmo kontrolė):\n' + pain.join('\n'));
+      if (bleeding.length) out.push('Medikamentai (kraujavimo kontrolė):\n' + bleeding.join('\n'));
+      if (other.length) out.push('Medikamentai (kita):\n' + other.join('\n'));
+      if (procsIt.length) out.push('Procedūros (IT):\n' + procsIt.join('\n'));
+      if (procsOther.length) out.push('Procedūros (kitos):\n' + procsOther.join('\n'));
+    }
+    var imgs = [].concat(_toConsumableArray(listChips('#imaging_ct')), _toConsumableArray(listChips('#imaging_xray')));
+    if (listChips('#imaging_other_group').includes('Kita')) {
+      var _other = $('#imaging_other').value.trim();
+      if (_other) imgs.push(_other);
+    }
+    var fr = fastAreas.map(function (_ref) {
+      var _document$querySelect, _document$querySelect2;
+      var name = _ref.name,
+        marker = _ref.marker;
+      var y = (_document$querySelect = document.querySelector('input[name="fast_' + name + '"][value="Yra"]')) === null || _document$querySelect === void 0 ? void 0 : _document$querySelect.checked;
+      var n = (_document$querySelect2 = document.querySelector('input[name="fast_' + name + '"][value="Nėra"]')) === null || _document$querySelect2 === void 0 ? void 0 : _document$querySelect2.checked;
+      return y ? "".concat(name, ": ").concat(marker, " Yra") : n ? "".concat(name, ": ").concat(marker, " N\u0117ra") : null;
+    }).filter(Boolean);
+    if (imgs.length || fr.length) {
+      out.push('\n--- Vaizdiniai tyrimai ---');
+      if (imgs.length) out.push('Užsakyta: ' + imgs.join(', '));
+      if (fr.length) out.push('FAST: ' + fr.join(' | '));
+    }
+    var labs = listChips('#labs_basic');
+    if (labs.length) {
+      out.push('\n--- Laboratorija ---');
+      out.push(labs.join(', '));
+    }
+    var team = TEAM_ROLES.map(function (r) {
+      var _el$value;
+      var el = document.querySelector('input[data-team="' + r + '"]');
+      var v = el === null || el === void 0 || (_el$value = el.value) === null || _el$value === void 0 ? void 0 : _el$value.trim();
+      return v ? r + ': ' + v : null;
+    }).filter(Boolean);
+    if (team.length) {
+      out.push('\n--- Komanda ---');
+      out.push(team.join(' | '));
+    }
+    var sprDecision = getSingleValue('#spr_decision_group');
+    var sprSkyrius = sprDecision === 'Stacionarizavimas' ? $('#spr_skyrius').value === 'Kita' ? $('#spr_skyrius_kita').value : $('#spr_skyrius').value : '';
+    var sprLigonine = sprDecision === 'Pervežimas į kitą ligoninę' ? $('#spr_ligonine').value : '';
+    var sprGks = gksSum($('#spr_gksa').value, $('#spr_gksk').value, $('#spr_gksm').value);
+    var sprVitals = [$('#spr_hr').value ? 'ŠSD ' + $('#spr_hr').value + '/min' : null, $('#spr_rr').value ? 'KD ' + $('#spr_rr').value + '/min' : null, $('#spr_spo2').value ? 'SpO₂ ' + $('#spr_spo2').value + '%' : null, $('#spr_sbp').value || $('#spr_dbp').value ? 'AKS ' + $('#spr_sbp').value + '/' + $('#spr_dbp').value : null, sprGks ? "GKS ".concat(sprGks, " (A").concat($('#spr_gksa').value, "-K").concat($('#spr_gksk').value, "-M").concat($('#spr_gksm').value, ")") : null].filter(Boolean).join('; ');
+    if (sprDecision || $('#spr_time').value || sprVitals) {
+      out.push('\n--- Sprendimas ---');
+      var meta = [$('#spr_time').value ? 'Laikas ' + $('#spr_time').value : null, sprDecision ? 'Sprendimas: ' + sprDecision : null, sprDecision === 'Stacionarizavimas' && sprSkyrius ? 'Skyrius: ' + sprSkyrius : null, sprDecision === 'Pervežimas į kitą ligoninę' && sprLigonine ? 'Ligoninė: ' + sprLigonine : null].filter(Boolean).join(' | ');
+      if (meta) out.push(meta);
+      if (sprVitals) out.push(sprVitals);
+    }
+    $('#output').value = out.filter(Boolean).join('\n');
+  }
+
+  var arrivalTime = null;
+  var timerId = null;
+  function recordArrivalTime() {
+    var force = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+    var stored = localStorage.getItem('arrival_time');
+    if (stored && !force) {
+      arrivalTime = new Date(stored);
+    } else {
+      arrivalTime = new Date();
+      localStorage.setItem('arrival_time', arrivalTime.toISOString());
+    }
+    return arrivalTime;
+  }
+  function formatElapsed(ms) {
+    var pad = function pad(n) {
+      return String(n).padStart(2, '0');
+    };
+    var h = Math.floor(ms / 3600000);
+    var m = Math.floor(ms / 60000) % 60;
+    var s = Math.floor(ms / 1000) % 60;
+    return "".concat(pad(h), ":").concat(pad(m), ":").concat(pad(s));
+  }
+  function startArrivalTimer() {
+    var force = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+    var el = $('#arrivalTimer');
+    if (!el) return;
+    recordArrivalTime(force);
+    var update = function update() {
+      if (!arrivalTime) return;
+      var diff = Date.now() - arrivalTime.getTime();
+      el.textContent = formatElapsed(diff);
+    };
+    update();
+    clearInterval(timerId);
+    timerId = setInterval(update, 1000);
+  }
+
+  function setupHeaderActions(_ref) {
+    var validateForm = _ref.validateForm;
+    var btnAtvyko = document.getElementById('btnAtvyko');
+    if (btnAtvyko) btnAtvyko.addEventListener('click', function () {
+      return startArrivalTimer(true);
+    });
+    var arrivalTimer = document.getElementById('arrivalTimer');
+    if (arrivalTimer) arrivalTimer.addEventListener('dblclick', function () {
+      return startArrivalTimer(true);
+    });
+    var copyButtons = [$('#btnCopyReport')].filter(Boolean);
+    copyButtons.forEach(function (btn) {
+      return btn.addEventListener('click', /*#__PURE__*/_asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee() {
+        return _regenerator().w(function (_context) {
+          while (1) switch (_context.p = _context.n) {
+            case 0:
+              _context.p = 0;
+              _context.n = 1;
+              return navigator.clipboard.writeText($('#output').value || '');
+            case 1:
+              notify({
+                message: 'Nukopijuota.',
+                type: 'success'
+              });
+              _context.n = 3;
+              break;
+            case 2:
+              _context.p = 2;
+              _context.v;
+              notify({
+                message: 'Nepavyko nukopijuoti.',
+                type: 'error'
+              });
+            case 3:
+              return _context.a(2);
+          }
+        }, _callee, null, [[0, 2]]);
+      })));
+    });
+    var pdfButtons = [$('#btnPdfReport')].filter(Boolean);
+    pdfButtons.forEach(function (btn) {
+      return btn.addEventListener('click', /*#__PURE__*/_asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee2() {
+        var text, module, _ref4, jsPDF, doc, lines, _t2;
+        return _regenerator().w(function (_context2) {
+          while (1) switch (_context2.p = _context2.n) {
+            case 0:
+              if (validateForm()) {
+                _context2.n = 1;
+                break;
+              }
+              return _context2.a(2);
+            case 1:
+              showTab('Santrauka');
+              text = $('#output').value || '';
+              _context2.p = 2;
+              _context2.n = 3;
+              return Promise.resolve().then(function () { return jspdf_umd_min; });
+            case 3:
+              module = _context2.v;
+              _ref4 = module.default || module, jsPDF = _ref4.jsPDF;
+              doc = new jsPDF();
+              lines = doc.splitTextToSize(text, 180);
+              doc.text(lines, 10, 10);
+              doc.save('report.pdf');
+              _context2.n = 5;
+              break;
+            case 4:
+              _context2.p = 4;
+              _t2 = _context2.v;
+              notify({
+                message: 'Nepavyko sugeneruoti PDF.',
+                type: 'error'
+              });
+              console.error('PDF generation failed', _t2);
+            case 5:
+              return _context2.a(2);
+          }
+        }, _callee2, null, [[2, 4]]);
+      })));
+    });
+    var printButtons = [$('#btnPrintReport')].filter(Boolean);
+    printButtons.forEach(function (btn) {
+      return btn.addEventListener('click', /*#__PURE__*/_asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee3() {
+        var prevTab, text, printWin, doc, svg, front, back, pre;
+        return _regenerator().w(function (_context3) {
+          while (1) switch (_context3.n) {
+            case 0:
+              if (validateForm()) {
+                _context3.n = 1;
+                break;
+              }
+              return _context3.a(2);
+            case 1:
+              prevTab = localStorage.getItem('v10_activeTab');
+              showTab('Santrauka');
+              text = $('#output').value || '';
+              printWin = window.open('', '_blank');
+              if (!printWin) {
+                _context3.n = 3;
+                break;
+              }
+              doc = printWin.document;
+              doc.open();
+              doc.write('<!DOCTYPE html><html><head><meta charset="utf-8"><title>Santrauka</title><link rel="stylesheet" href="/css/main.css"><style>body{font-family:sans-serif;padding:20px;} pre{white-space:pre-wrap;}</style></head><body></body></html>');
+              doc.close();
+              svg = doc.importNode(document.getElementById('bodySvg'), true);
+              _context3.n = 2;
+              return bodyMap.embedSilhouettes(svg);
+            case 2:
+              svg = _context3.v;
+              front = svg.querySelector('#layer-front');
+              back = svg.querySelector('#layer-back');
+              if (front) front.classList.remove('hidden');
+              if (back) back.classList.remove('hidden');
+              pre = doc.createElement('pre');
+              pre.textContent = text;
+              doc.body.appendChild(pre);
+              doc.body.appendChild(svg);
+              printWin.focus();
+              printWin.print();
+              printWin.close();
+              _context3.n = 4;
+              break;
+            case 3:
+              window.print();
+            case 4:
+              if (prevTab) showTab(prevTab);
+            case 5:
+              return _context3.a(2);
+          }
+        }, _callee3);
+      })));
+    });
+    var actionsBar = document.getElementById('desktopActions');
+    if (actionsBar) {
+      var themeBtn = document.getElementById('btnTheme');
+      if (!themeBtn) {
+        themeBtn = document.createElement('button');
+        themeBtn.type = 'button';
+        themeBtn.className = 'btn icon-btn';
+        themeBtn.id = 'btnTheme';
+        actionsBar.appendChild(themeBtn);
+      } else {
+        themeBtn.classList.add('icon-btn');
+      }
+      var sunSvg = '<svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>';
+      var moonSvg = '<svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401"/></svg>';
+      var updateThemeBtn = function updateThemeBtn() {
+        var dark = document.documentElement.classList.contains('dark');
+        themeBtn.innerHTML = dark ? sunSvg : moonSvg;
+        var label = dark ? 'Šviesus režimas' : 'Tamsus režimas';
+        themeBtn.setAttribute('title', label);
+        themeBtn.setAttribute('aria-label', label);
+      };
+      themeBtn.addEventListener('click', function () {
+        var next = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
+        setTheme(next);
+        updateThemeBtn();
+      });
+      updateThemeBtn();
+      if (getAuthToken() && !document.getElementById('btnLogout')) {
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn icon-btn';
+        btn.id = 'btnLogout';
+        btn.innerHTML = '<svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m16 17 5-5-5-5"/><path d="M21 12H9"/><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/></svg>';
+        btn.setAttribute('title', 'Atsijungti');
+        btn.setAttribute('aria-label', 'Atsijungti');
+        btn.addEventListener('click', function () {
+          return logout();
+        });
+        actionsBar.appendChild(btn);
+      }
+    }
+  }
+
+  var CIRC_THRESHOLDS = {
+    '#c_hr': {
+      min: 60,
+      max: 100,
+      label: 'ŠSD'
+    },
+    '#c_sbp': {
+      min: 90,
+      max: 180,
+      label: 'AKS s'
+    },
+    '#c_dbp': {
+      min: 60,
+      max: 110,
+      label: 'AKS d'
+    }
+  };
+  function checkField(sel) {
+    var cfg = CIRC_THRESHOLDS[sel];
+    var el = $(sel);
+    if (!cfg || !el) return false;
+    var val = parseFloat(el.value);
+    if (isNaN(val)) return false;
+    if (cfg.min !== undefined && val < cfg.min || cfg.max !== undefined && val > cfg.max) {
+      notify({
+        type: 'warning',
+        message: "".concat(cfg.label, " u\u017E rib\u0173")
+      });
+      return true;
+    }
+    return false;
+  }
+  function initCirculationChecks(updateMetrics) {
+    Object.keys(CIRC_THRESHOLDS).forEach(function (sel) {
+      var el = $(sel);
+      if (!el) return;
+      el.addEventListener('input', function () {
+        if (typeof updateMetrics === 'function') updateMetrics();
+        checkField(sel);
+      });
+    });
+  }
+  function updateCirculationMetrics() {
+    var _$, _$2, _$3;
+    var hr = parseFloat((_$ = $('#c_hr')) === null || _$ === void 0 ? void 0 : _$.value);
+    var sbp = parseFloat((_$2 = $('#c_sbp')) === null || _$2 === void 0 ? void 0 : _$2.value);
+    var dbp = parseFloat((_$3 = $('#c_dbp')) === null || _$3 === void 0 ? void 0 : _$3.value);
+    var mapEl = $('#c_map');
+    var siEl = $('#c_si');
+    var map = !isNaN(sbp) && !isNaN(dbp) ? Math.round((sbp + 2 * dbp) / 3) : '';
+    var si = !isNaN(hr) && !isNaN(sbp) && sbp > 0 ? (hr / sbp).toFixed(2) : '';
+    if (mapEl) mapEl.textContent = map;
+    if (siEl) siEl.textContent = si;
+  }
+  function initCirculation() {
+    initCirculationChecks(updateCirculationMetrics);
+    updateCirculationMetrics();
+  }
+
+  function ensureSingleTeam() {
+    var red = $('#chips_red');
+    var yellow = $('#chips_yellow');
+    var redActive = $$('.chip.active', red).length > 0;
+    var yellowActive = $$('.chip.active', yellow).length > 0;
+    if (redActive && yellowActive) {
+      $$('.chip', yellow).forEach(function (c) {
+        return setChipActive(c, false);
+      });
+    }
+  }
+  function updateActivationIndicator() {
+    var dot = $('#activationIndicator');
+    var status = $('#activationStatusText');
+    var redActive = $$('.chip.active', $('#chips_red')).length > 0;
+    var yellowActive = $$('.chip.active', $('#chips_yellow')).length > 0;
+    if (!dot) return;
+    dot.classList.remove('red', 'yellow');
+    dot.style.display = 'none';
+    var text = 'No team activated';
+    if (redActive) {
+      dot.classList.add('red');
+      dot.style.display = 'inline-block';
+      text = 'Red team activated';
+    } else if (yellowActive) {
+      dot.classList.add('yellow');
+      dot.style.display = 'inline-block';
+      text = 'Yellow team activated';
+    }
+    if (status) status.textContent = text;
+  }
+  function setupActivationControls() {
+    var redGroup = $('#chips_red');
+    var yellowGroup = $('#chips_yellow');
+    redGroup.addEventListener('click', function (e) {
+      var chip = e.target.closest('.chip');
+      if (!chip) return;
+      if (isChipActive(chip)) {
+        $$('.chip', yellowGroup).forEach(function (c) {
+          return setChipActive(c, false);
+        });
+      }
+      ensureSingleTeam();
+      updateActivationIndicator();
+      saveAll();
+    });
+    yellowGroup.addEventListener('click', function (e) {
+      var chip = e.target.closest('.chip');
+      if (!chip) return;
+      if (isChipActive(chip)) {
+        $$('.chip', redGroup).forEach(function (c) {
+          return setChipActive(c, false);
+        });
+      }
+      ensureSingleTeam();
+      updateActivationIndicator();
+      saveAll();
+    });
+  }
+  window.updateActivationIndicator = updateActivationIndicator;
+  window.ensureSingleTeam = ensureSingleTeam;
+
+  function setupGcsCalc(prefix) {
+    var panel = $("#".concat(prefix, "_gcs_calc"));
+    var selA = $("#".concat(prefix, "_gcs_calc_a"));
+    var selK = $("#".concat(prefix, "_gcs_calc_k"));
+    var selM = $("#".concat(prefix, "_gcs_calc_m"));
+    var apply = $("#".concat(prefix, "_gcs_apply"));
+    var total = $("#".concat(prefix, "_gcs_calc_total"));
+    var btnClose = $("#".concat(prefix, "_gcs_close"));
+    var btn = prefix === 'spr' ? $('#btnSprGCSCalc') : $('#btnGCSCalc');
+    if (!panel || !selA || !selK || !selM || !apply || !total) return function () {};
+    var update = function update() {
+      total.textContent = gksSum(selA.value, selK.value, selM.value);
+    };
+    [selA, selK, selM].forEach(function (sel) {
+      return sel.addEventListener('change', update);
+    });
+    var firstFocusable, lastFocusable;
+    var close = function close() {
+      panel.classList.add('hidden');
+      panel.style.display = 'none';
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('click', onDocClick);
+      if (btn) btn.focus();
+    };
+    var onKey = function onKey(e) {
+      if (e.key === 'Escape') return close();
+      if (e.key === 'Tab') {
+        if (e.shiftKey && document.activeElement === firstFocusable) {
+          e.preventDefault();
+          lastFocusable.focus();
+        } else if (!e.shiftKey && document.activeElement === lastFocusable) {
+          e.preventDefault();
+          firstFocusable.focus();
+        }
+      }
+    };
+    var onDocClick = function onDocClick(e) {
+      if (!panel.contains(e.target) && e.target !== btn) close();
+    };
+    apply.addEventListener('click', function () {
+      if (selA.value) $("#".concat(prefix, "_gksa")).value = selA.value;
+      if (selK.value) $("#".concat(prefix, "_gksk")).value = selK.value;
+      if (selM.value) $("#".concat(prefix, "_gksm")).value = selM.value;
+      ['#' + prefix + '_gksa', '#' + prefix + '_gksk', '#' + prefix + '_gksm'].forEach(function (sel) {
+        return $(sel).dispatchEvent(new Event('input'));
+      });
+      close();
+      saveAll();
+    });
+    if (btnClose) btnClose.addEventListener('click', close);
+    return function () {
+      var hidden = getComputedStyle(panel).display === 'none';
+      if (hidden) {
+        panel.classList.remove('hidden');
+        panel.style.display = 'block';
+        var focusables = panel.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        firstFocusable = focusables[0];
+        lastFocusable = focusables[focusables.length - 1];
+        document.addEventListener('keydown', onKey);
+        document.addEventListener('click', onDocClick);
+        selA.focus();
+      } else {
+        close();
+      }
+    };
+  }
+  function initGcs() {
+    var btnGcs15 = $('#btnGCS15');
+    if (btnGcs15) btnGcs15.addEventListener('click', function () {
+      $('#d_gksa').value = 4;
+      $('#d_gksk').value = 5;
+      $('#d_gksm').value = 6;
+      ['#d_gksa', '#d_gksk', '#d_gksm'].forEach(function (sel) {
+        return $(sel).dispatchEvent(new Event('input'));
+      });
+      saveAll();
+    });
+    if ($('#d_gcs_calc') && $('#btnGCSCalc')) {
+      var toggleDGcs = setupGcsCalc('d');
+      $('#btnGCSCalc').addEventListener('click', toggleDGcs);
+    }
+    if ($('#spr_gcs_calc') && $('#btnSprGCSCalc')) {
+      var toggleSprGcs = setupGcsCalc('spr');
+      $('#btnSprGCSCalc').addEventListener('click', toggleSprGcs);
+    }
+    var updateDGksTotal = function updateDGksTotal() {
+      var el = $('#d_gks_total');
+      if (el) el.textContent = gksSum($('#d_gksa').value, $('#d_gksk').value, $('#d_gksm').value);
+    };
+    ['#d_gksa', '#d_gksk', '#d_gksm'].forEach(function (sel) {
+      return $(sel).addEventListener('input', updateDGksTotal);
+    });
+    var updateGmpGksTotal = function updateGmpGksTotal() {
+      var el = $('#gmp_gks_total');
+      if (el) el.textContent = gksSum($('#gmp_gksa').value, $('#gmp_gksk').value, $('#gmp_gksm').value);
+    };
+    ['#gmp_gksa', '#gmp_gksk', '#gmp_gksm'].forEach(function (sel) {
+      return $(sel).addEventListener('input', updateGmpGksTotal);
+    });
+    var updateSprGksTotal;
+    if ($('#spr_gks_total')) {
+      updateSprGksTotal = function updateSprGksTotal() {
+        var el = $('#spr_gks_total');
+        if (el) el.textContent = gksSum($('#spr_gksa').value, $('#spr_gksk').value, $('#spr_gksm').value);
+      };
+      ['#spr_gksa', '#spr_gksk', '#spr_gksm'].forEach(function (sel) {
+        return $(sel).addEventListener('input', updateSprGksTotal);
+      });
+    }
+    var btnGmpNow = $('#btnGmpNow');
+    if (btnGmpNow) btnGmpNow.addEventListener('click', function () {
+      $('#gmp_time').value = nowHM();
+      saveAll();
+    });
+    var btnSprNow = $('#btnSprNow');
+    if (btnSprNow) btnSprNow.addEventListener('click', function () {
+      $('#spr_time').value = nowHM();
+      saveAll();
+    });
+    updateDGksTotal();
+    updateGmpGksTotal();
+    if (updateSprGksTotal) updateSprGksTotal();
+  }
+
+  var IMG_CT = ['Galvos KT', 'Kaklo KT', 'Viso kūno KT'];
+  var IMG_XRAY = ['Krūtinės Ro', 'Dubens Ro'];
+  var LABS = ['BKT', 'Biocheminis tyrimas', 'Krešumai', 'Fibrinogenas', 'ROTEM', 'Kraujo grupė', 'Kraujo dujos'];
+  var BLOOD_GROUPS = ['0-', '0+', 'A-', 'A+', 'B-', 'B+', 'AB-', 'AB+'];
+  var FAST_AREAS = [{
+    name: 'Perikardas',
+    marker: 'skystis'
+  }, {
+    name: 'Dešinė pleura',
+    marker: 'skystis ar oras'
+  }, {
+    name: 'Kairė pleura',
+    marker: 'skystis ar oras'
+  }, {
+    name: 'RUQ',
+    marker: 'skystis'
+  }, {
+    name: 'LUQ',
+    marker: 'skystis'
+  }, {
+    name: 'Dubuo',
+    marker: 'skystis'
+  }];
+
+  function init$4() {
+    var fastWrap = $('#fastGrid');
+    if (!fastWrap) return;
+    FAST_AREAS.forEach(function (_ref) {
+      var name = _ref.name,
+        marker = _ref.marker;
+      var box = document.createElement('div');
+      box.innerHTML = "<label>".concat(name, " (").concat(marker, ")</label><div class=\"row\"><label class=\"pill red\"><input type=\"radio\" name=\"fast_").concat(name, "\" value=\"Yra\"> Yra</label><label class=\"pill\"><input type=\"radio\" name=\"fast_").concat(name, "\" value=\"N\u0117ra\"> N\u0117ra</label></div>");
+      fastWrap.appendChild(box);
+    });
+  }
+
+  function init$3() {
+    var teamWrap = $('#teamGrid');
+    if (!teamWrap) return;
+    TEAM_ROLES.forEach(function (r) {
+      var slug = r.replace(/\s+/g, '_');
+      var box = document.createElement('div');
+      box.innerHTML = "<label>".concat(r, "</label><input type=\"text\" data-team=\"").concat(r, "\" data-field=\"team_").concat(slug, "\" placeholder=\"Vardas Pavard\u0117\">");
+      teamWrap.appendChild(box);
+    });
+  }
+
+  var LS_MECHANISM_KEY = 'traumos_mechanizmai';
+  function init$2() {
+    var list = $('#gmp_mechanism_list');
+    var input = $('#gmp_mechanism');
+    if (!list || !input) return;
+    var existing = new Set(Array.from(list.options).map(function (o) {
+      return o.value;
+    }));
+    var stored = JSON.parse(localStorage.getItem(LS_MECHANISM_KEY) || '[]');
+    stored.forEach(function (v) {
+      if (!existing.has(v)) {
+        var opt = document.createElement('option');
+        opt.value = v;
+        list.appendChild(opt);
+        existing.add(v);
+      }
+    });
+    input.addEventListener('change', function () {
+      var val = input.value.trim();
+      if (!val || existing.has(val)) return;
+      var opt = document.createElement('option');
+      opt.value = val;
+      list.appendChild(opt);
+      existing.add(val);
+      stored.push(val);
+      localStorage.setItem(LS_MECHANISM_KEY, JSON.stringify(stored));
+    });
+  }
+
+  var CHIP_DATA = {
+    chips_red: [{
+      label: 'GKS < 9',
+      color: 'red'
+    }, {
+      label: 'KD < 8 ar > 30/min',
+      color: 'red'
+    }, {
+      label: 'AKS < 90 mmHg',
+      color: 'red'
+    }, {
+      label: 'SpO₂ < 90%',
+      color: 'red'
+    }, {
+      label: 'ŠSD > 120/min',
+      color: 'red'
+    }, {
+      label: 'Stridoras',
+      color: 'red'
+    }, {
+      label: 'Lūžę 2 ilgieji kaulai/dubuo',
+      color: 'red'
+    }, {
+      label: 'Kiauriniai suž. kakle/krūtinėje/juosmenyje',
+      color: 'red'
+    }, {
+      label: 'Įtariamas vidinis kraujavimas',
+      color: 'red'
+    }, {
+      label: 'Nestabili krūtinės ląsta',
+      color: 'red'
+    }, {
+      label: 'Nudegimas >18% ar KT nudegimas',
+      color: 'red'
+    }, {
+      label: 'Amputacijos aukščiau plašt./pėdų',
+      color: 'red'
+    }],
+    chips_yellow: [{
+      label: 'Pėst./dvir./motociklo trauma',
+      color: 'yellow'
+    }, {
+      label: 'Sprogimas/susišaudymas',
+      color: 'yellow'
+    }, {
+      label: 'Kritimas >3 m ar nardymas',
+      color: 'yellow'
+    }, {
+      label: 'Reikėjo gelbėtojų pagalbos',
+      color: 'yellow'
+    }],
+    a_airway_group: [{
+      label: 'Atviri'
+    }, {
+      label: 'Obstrukcija',
+      color: 'red'
+    }, {
+      label: 'Įvesta laringinė kaukė',
+      color: 'red'
+    }, {
+      label: 'Intubuotas',
+      color: 'red'
+    }, {
+      label: 'Kita',
+      color: 'red'
+    }],
+    b_breath_left_group: [{
+      label: 'Normalus',
+      class: 'breath-chip'
+    }, {
+      label: 'Kita',
+      value: '_kita',
+      color: 'red',
+      class: 'breath-chip breath-toggle'
+    }, {
+      label: 'Neišklausomas',
+      color: 'red',
+      class: 'breath-chip breath-option hidden'
+    }, {
+      label: 'Susilpnėjęs',
+      color: 'red',
+      class: 'breath-chip breath-option hidden'
+    }, {
+      label: 'Kita',
+      color: 'red',
+      class: 'breath-chip breath-option hidden'
+    }],
+    b_breath_right_group: [{
+      label: 'Normalus',
+      class: 'breath-chip'
+    }, {
+      label: 'Kita',
+      value: '_kita',
+      color: 'red',
+      class: 'breath-chip breath-toggle'
+    }, {
+      label: 'Neišklausomas',
+      color: 'red',
+      class: 'breath-chip breath-option hidden'
+    }, {
+      label: 'Susilpnėjęs',
+      color: 'red',
+      class: 'breath-chip breath-option hidden'
+    }, {
+      label: 'Kita',
+      color: 'red',
+      class: 'breath-chip breath-option hidden'
+    }],
+    c_pulse_radial_group: [{
+      label: 'Stiprus'
+    }, {
+      label: 'Silpnas',
+      color: 'red'
+    }],
+    c_pulse_femoral_group: [{
+      label: 'Stiprus'
+    }, {
+      label: 'Silpnas',
+      color: 'red'
+    }],
+    c_skin_temp_group: [{
+      label: 'Šilta'
+    }, {
+      label: 'Šalta',
+      color: 'red'
+    }],
+    c_skin_color_group: [{
+      label: 'Rausva'
+    }, {
+      label: 'Blyški',
+      color: 'red'
+    }, {
+      label: 'Kita',
+      color: 'red'
+    }],
+    d_pupil_left_group: [{
+      label: 'n.y.',
+      value: 'n.y.'
+    }, {
+      label: 'kita',
+      value: 'kita',
+      color: 'red'
+    }],
+    d_pupil_right_group: [{
+      label: 'n.y.',
+      value: 'n.y.'
+    }, {
+      label: 'kita',
+      value: 'kita',
+      color: 'red'
+    }],
+    e_back_group: [{
+      label: 'Be pakitimų'
+    }, {
+      label: 'Pakitimai',
+      color: 'red'
+    }],
+    e_abdomen_group: [{
+      label: 'Be pakitimų'
+    }, {
+      label: 'Pakitimai',
+      color: 'red'
+    }],
+    spr_decision_group: [{
+      label: 'Stacionarizavimas'
+    }, {
+      label: 'Namo'
+    }, {
+      label: 'Stebėjimas SMPS'
+    }, {
+      label: 'Mirtis'
+    }, {
+      label: 'Pervežimas į kitą ligoninę'
+    }]
+  };
+  function buildChipGroup(containerId, chips) {
+    var container = createChipGroup("#".concat(containerId), chips.map(function (c) {
+      return c.label;
+    }));
+    if (!container) return;
+    var chipEls = container.querySelectorAll('.chip');
+    chips.forEach(function (chip, idx) {
+      var el = chipEls[idx];
+      if (!el) return;
+      if (chip.value && chip.value !== chip.label) {
+        el.dataset.value = chip.value;
+      }
+      if (chip.color) {
+        el.classList.add(chip.color);
+      }
+      if (chip.class) {
+        var _el$classList;
+        (_el$classList = el.classList).add.apply(_el$classList, _toConsumableArray(chip.class.split(' ')));
+      }
+    });
+    return container;
+  }
+  function initChipGroups() {
+    Object.entries(CHIP_DATA).forEach(function (_ref) {
+      var _ref2 = _slicedToArray(_ref, 2),
+        id = _ref2[0],
+        chips = _ref2[1];
+      return buildChipGroup(id, chips);
+    });
+  }
+
+  var STRINGS = {
+    location: 'Lokacija',
+    length: 'Ilgis',
+    contamination: 'Kontaminacija',
+    traumaType: 'Traumos tipas',
+    notes: 'Pastabos',
+    save: 'Išsaugoti',
+    cancel: 'Atšaukti',
+    clear: 'Clear All',
+    delete: 'Delete'
+  };
+  var bodyMapRef;
+  function createInput(id, labelText) {
+    var type = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'text';
+    var label = document.createElement('label');
+    label.htmlFor = id;
+    label.textContent = labelText;
+    var input = document.createElement('input');
+    input.type = type;
+    input.id = id;
+    label.appendChild(input);
+    return {
+      label: label,
+      input: input
+    };
+  }
+  function createTextarea(id, labelText) {
+    var label = document.createElement('label');
+    label.htmlFor = id;
+    label.textContent = labelText;
+    var textarea = document.createElement('textarea');
+    textarea.id = id;
+    label.appendChild(textarea);
+    return {
+      label: label,
+      textarea: textarea
+    };
+  }
+
+  /**
+   * Open wound editor modal populated from mark.dataset
+   * @param {HTMLElement} mark element holding wound data in dataset
+   * @returns {Promise<object|null>} resolves with updated data or null if cancelled
+   */
+  function open$1(mark) {
+    return new Promise(function (resolve) {
+      var prev = document.activeElement;
+      var overlay = document.createElement('div');
+      overlay.className = 'modal-overlay';
+      var box = document.createElement('div');
+      box.className = 'modal';
+      box.setAttribute('role', 'dialog');
+      box.setAttribute('aria-modal', 'true');
+      var form = document.createElement('form');
+      var _createInput = createInput('wound-location', STRINGS.location),
+        locLabel = _createInput.label,
+        locInput = _createInput.input;
+      var _createInput2 = createInput('wound-length', STRINGS.length, 'number'),
+        lenLabel = _createInput2.label,
+        lenInput = _createInput2.input;
+      var _createInput3 = createInput('wound-contamination', STRINGS.contamination),
+        conLabel = _createInput3.label,
+        conInput = _createInput3.input;
+      var _createInput4 = createInput('wound-trauma', STRINGS.traumaType),
+        typeLabel = _createInput4.label,
+        typeInput = _createInput4.input;
+      var _createTextarea = createTextarea('wound-notes', STRINGS.notes),
+        noteLabel = _createTextarea.label,
+        noteInput = _createTextarea.textarea;
+      form.append(locLabel, lenLabel, conLabel, typeLabel, noteLabel);
+      var actions = document.createElement('div');
+      actions.className = 'actions';
+      var btnCancel = document.createElement('button');
+      btnCancel.type = 'button';
+      btnCancel.className = 'btn';
+      btnCancel.textContent = STRINGS.cancel;
+      var btnClear = document.createElement('button');
+      btnClear.type = 'button';
+      btnClear.className = 'btn';
+      btnClear.textContent = STRINGS.clear;
+      var btnDelete = document.createElement('button');
+      btnDelete.type = 'button';
+      btnDelete.className = 'btn';
+      btnDelete.textContent = STRINGS.delete;
+      var btnSave = document.createElement('button');
+      btnSave.type = 'submit';
+      btnSave.className = 'btn primary';
+      btnSave.textContent = STRINGS.save;
+      actions.append(btnCancel, btnClear, btnDelete, btnSave);
+      form.appendChild(actions);
+      box.appendChild(form);
+      overlay.appendChild(box);
+      document.body.appendChild(overlay);
+      var existing = mark.dataset.details ? JSON.parse(mark.dataset.details) : {};
+      locInput.value = existing.location || '';
+      lenInput.value = existing.length || '';
+      conInput.value = existing.contamination || '';
+      typeInput.value = existing.traumaType || '';
+      noteInput.value = existing.notes || '';
+      var focusable = box.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+      function trap(e) {
+        if (e.key === 'Tab') {
+          if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          close(null);
+        }
+      }
+      function close(val) {
+        overlay.remove();
+        document.removeEventListener('keydown', trap, true);
+        prev === null || prev === void 0 || prev.focus();
+        resolve(val);
+      }
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var data = {
+          location: locInput.value.trim(),
+          length: lenInput.value.trim(),
+          contamination: conInput.value.trim(),
+          traumaType: typeInput.value.trim(),
+          notes: noteInput.value.trim()
+        };
+        mark.dataset.details = JSON.stringify(data);
+        close(data);
+      });
+      btnClear.addEventListener('click', function () {
+        locInput.value = '';
+        lenInput.value = '';
+        conInput.value = '';
+        typeInput.value = '';
+        noteInput.value = '';
+      });
+      btnDelete.addEventListener('click', function () {
+        mark.remove();
+        if (bodyMapRef) {
+          bodyMapRef.undoStack.push({
+            type: 'deleteMark',
+            el: mark
+          });
+          bodyMapRef.redoStack = [];
+        }
+        close('deleted');
+      });
+      btnCancel.addEventListener('click', function () {
+        return close(null);
+      });
+      overlay.addEventListener('click', function (e) {
+        if (e.target === overlay) close(null);
+      });
+      document.addEventListener('keydown', trap, true);
+      first.focus();
+    });
+  }
+  function init$1(bodyMap) {
+    var _bodyMap$marksLayer;
+    if (!bodyMap) return;
+    bodyMapRef = bodyMap;
+    var edit = /*#__PURE__*/function () {
+      var _ref = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee(mark) {
+        var data;
+        return _regenerator().w(function (_context) {
+          while (1) switch (_context.n) {
+            case 0:
+              _context.n = 1;
+              return open$1(mark);
+            case 1:
+              data = _context.v;
+              if (data && typeof bodyMap.saveCb === 'function') bodyMap.saveCb();
+            case 2:
+              return _context.a(2);
+          }
+        }, _callee);
+      }));
+      return function edit(_x) {
+        return _ref.apply(this, arguments);
+      };
+    }();
+    var origAddMark = bodyMap.addMark.bind(bodyMap);
+    bodyMap.addMark = function () {
+      var mark = origAddMark.apply(void 0, arguments);
+      edit(mark);
+      return mark;
+    };
+    (_bodyMap$marksLayer = bodyMap.marksLayer) === null || _bodyMap$marksLayer === void 0 || _bodyMap$marksLayer.addEventListener('click', function (e) {
+      var mark = e.target.closest('use');
+      if (mark) edit(mark);
+    });
+  }
+  var woundEditor = {
+    open: open$1,
+    init: init$1
+  };
+
+  initTheme();
+
+  /* ===== Imaging / Labs / Team ===== */
+  function createChipGroup(selector, values) {
+    var wrap = $(selector);
+    if (!wrap) return null;
+    values.forEach(function (val) {
+      var chip = document.createElement('span');
+      chip.className = 'chip';
+      chip.dataset.value = val;
+      chip.textContent = val;
+      addChipIndicators(chip);
+      wrap.appendChild(chip);
+    });
+    return wrap;
+  }
+  initChipGroups();
+  createChipGroup('#imaging_ct', IMG_CT);
+  createChipGroup('#imaging_xray', IMG_XRAY);
+  createChipGroup('#imaging_other_group', ['Kita']);
+  var labsWrap = createChipGroup('#labs_basic', LABS);
+  var bloodGroupWrap = createChipGroup('#bloodGroup', BLOOD_GROUPS);
+  var bloodUnitsInput = $('#bloodUnits');
+  var addBloodOrderBtn = $('#addBloodOrder');
+  if (bloodUnitsInput && bloodGroupWrap && addBloodOrderBtn) {
+    var addOrder = function addOrder(e) {
+      e.preventDefault();
+      var units = bloodUnitsInput.value.trim();
+      var groupEl = $$('.chip', bloodGroupWrap).find(function (c) {
+        return isChipActive(c);
+      });
+      var group = (groupEl === null || groupEl === void 0 ? void 0 : groupEl.dataset.value) || '';
+      if (!units || !group) return;
+      var val = "Kraujo u\u017Esakymas: ".concat(units, " vnt ").concat(group);
+      var chip = document.createElement('span');
+      chip.className = 'chip';
+      chip.dataset.value = val;
+      chip.textContent = val;
+      addChipIndicators(chip);
+      labsWrap.appendChild(chip);
+      setChipActive(chip, true);
+      saveAll();
+      bloodUnitsInput.value = '';
+      $$('.chip', bloodGroupWrap).forEach(function (c) {
+        return setChipActive(c, false);
+      });
+    };
+    addBloodOrderBtn.addEventListener('click', addOrder);
+    bloodUnitsInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') addOrder(e);
+    });
+  }
+
+  /* ===== Save / Load ===== */
+  function expandOutput() {
+    var ta = $('#output');
+    if (!ta) return;
+    ta.style.height = 'auto';
+    ta.style.height = ta.scrollHeight + 'px';
+  }
+  function debounce(fn, delay) {
+    var t;
+    return function () {
+      for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+        args[_key] = arguments[_key];
+      }
+      clearTimeout(t);
+      t = setTimeout(function () {
+        return fn.apply(void 0, args);
+      }, delay);
+    };
+  }
+  var saveAllDebounced = debounce(saveAll, 300);
+  initGcs();
+  /* ===== Other UI ===== */
+
+  function clampNumberInputs() {
+    var clamp = function clamp(el) {
+      if (el.value === '') return;
+      var min = el.getAttribute('min');
+      var max = el.getAttribute('max');
+      var step = parseFloat(el.getAttribute('step')) || 1;
+      var val = parseFloat(el.value);
+      if (isNaN(val)) return;
+      if (min !== null && val < parseFloat(min)) val = parseFloat(min);
+      if (max !== null && val > parseFloat(max)) val = parseFloat(max);
+      val = Math.round(val / step) * step;
+      var decimals = (step.toString().split('.')[1] || '').length;
+      el.value = val.toFixed(decimals);
+    };
+    $$('input[type="number"]').forEach(function (el) {
+      var min = el.getAttribute('min');
+      var max = el.getAttribute('max');
+      if (min !== null || max !== null) {
+        ['input', 'change'].forEach(function (evt) {
+          return el.addEventListener(evt, function () {
+            return clamp(el);
+          });
+        });
+        clamp(el);
+      }
+    });
+  }
+
+  /* ===== Init modules ===== */
+  function init() {
+    return _init.apply(this, arguments);
+  }
+  function _init() {
+    _init = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee2() {
+      var users, brushSlider, toolBtns, btnUndo, btnRedo, btnClearMap, btnExport, btnOxygen, btnDPV, _t2;
+      return _regenerator().w(function (_context2) {
+        while (1) switch (_context2.p = _context2.n) {
+          case 0:
+            if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+              // Use a relative path so the service worker is correctly located when the
+              // site is served from a subdirectory (e.g. GitHub Pages project sites).
+              navigator.serviceWorker.register('./sw.js');
+            }
+            _context2.p = 1;
+            _context2.n = 2;
+            return initTopbar();
+          case 2:
+            setupHeaderActions({
+              validateForm: validateForm
+            });
+            _context2.n = 3;
+            return connectSocket({
+              onSessions: function onSessions(list) {
+                var sel = $('#sessionSelect');
+                if (sel) populateSessionSelect(sel, list);
+              },
+              onSessionData: function onSessionData(_ref2) {
+                var id = _ref2.id;
+                if (id === getCurrentSessionId()) loadAll();
+              },
+              onUsers: updateUserList
+            });
+          case 3:
+            _context2.n = 4;
+            return fetchUsers();
+          case 4:
+            users = _context2.v;
+            updateUserList(users);
+            _context2.n = 5;
+            return initSessions();
+          case 5:
+            _context2.n = 7;
+            break;
+          case 6:
+            _context2.p = 6;
+            _t2 = _context2.v;
+            console.error(_t2);
+            notify({
+              type: 'error',
+              message: 'Nepavyko inicijuoti programos'
+            });
+          case 7:
+            _context2.p = 7;
+            if (document.getElementById('tabs')) {
+              initTabs();
+              initCollapsibles();
+            }
+            return _context2.f(7);
+          case 8:
+            bodyMap.init(saveAllDebounced);
+            bodyMap.setMarkScale(0.35);
+            woundEditor.init(bodyMap);
+            brushSlider = $('#brushSize');
+            if (brushSlider) brushSlider.addEventListener('input', function (e) {
+              return bodyMap.setBrushSize(e.target.value);
+            });
+            initChips(saveAllDebounced);
+            initAutoActivate(saveAllDebounced);
+            initActions(saveAllDebounced);
+            setupActivationControls();
+            init$4();
+            init$3();
+            init$2();
+            document.addEventListener('input', saveAllDebounced);
+            initCirculation();
+            toolBtns = $$('.map-toolbar .tool[data-tool]');
+            toolBtns.forEach(function (btn) {
+              if (btn.dataset.tool === bodyMap.activeTool) btn.classList.add('active');
+              btn.addEventListener('click', function () {
+                bodyMap.setTool(btn.dataset.tool);
+                toolBtns.forEach(function (b) {
+                  return b.classList.toggle('active', b === btn);
+                });
+              });
+            });
+            btnUndo = $('#btnUndo');
+            if (btnUndo) btnUndo.addEventListener('click', function () {
+              bodyMap.undo();
+              saveAllDebounced();
+            });
+            btnRedo = $('#btnRedo');
+            if (btnRedo) btnRedo.addEventListener('click', function () {
+              bodyMap.redo();
+              saveAllDebounced();
+            });
+            btnClearMap = $('#btnClearMap');
+            if (btnClearMap) btnClearMap.addEventListener('click', function () {
+              bodyMap.clear();
+              saveAllDebounced();
+            });
+            btnExport = $('#btnExportSvg');
+            if (btnExport) btnExport.addEventListener('click', /*#__PURE__*/_asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee() {
+              var _$, svg, xml, blob, url, a, _t;
+              return _regenerator().w(function (_context) {
+                while (1) switch (_context.p = _context.n) {
+                  case 0:
+                    _context.p = 0;
+                    svg = (_$ = $('#bodySvg')) === null || _$ === void 0 ? void 0 : _$.cloneNode(true);
+                    if (svg) {
+                      _context.n = 1;
+                      break;
+                    }
+                    return _context.a(2);
+                  case 1:
+                    _context.n = 2;
+                    return bodyMap.embedSilhouettes(svg);
+                  case 2:
+                    xml = new XMLSerializer().serializeToString(svg);
+                    blob = new Blob([xml], {
+                      type: 'image/svg+xml'
+                    });
+                    url = URL.createObjectURL(blob);
+                    a = document.createElement('a');
+                    a.href = url;
+                    a.download = 'bodymap.svg';
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                    URL.revokeObjectURL(url);
+                    _context.n = 4;
+                    break;
+                  case 3:
+                    _context.p = 3;
+                    _t = _context.v;
+                    console.error('SVG export failed', _t);
+                  case 4:
+                    return _context.a(2);
+                }
+              }, _callee, null, [[0, 3]]);
+            })));
+            btnOxygen = $('#btnOxygen');
+            if (btnOxygen) btnOxygen.addEventListener('click', function () {
+              var box = $('#oxygenFields');
+              box.classList.toggle('hidden');
+              saveAll();
+            });
+            btnDPV = $('#btnDPV');
+            if (btnDPV) btnDPV.addEventListener('click', function () {
+              var box = $('#dpvFields');
+              box.classList.toggle('hidden');
+              saveAll();
+            });
+            $('#spr_skyrius').addEventListener('change', function (e) {
+              var show = e.target.value === 'Kita';
+              var field = $('#spr_skyrius_kita');
+              field.style.display = show ? 'block' : 'none';
+              field.classList.toggle('hidden', !show);
+              if (!show) field.value = '';
+              saveAll();
+            });
+            $('#output').addEventListener('input', expandOutput);
+            loadAll();
+            if (document.getElementById('chips_red') && document.getElementById('chips_yellow')) {
+              ensureSingleTeam();
+              updateActivationIndicator();
+            }
+            expandOutput();
+            clampNumberInputs();
+            initValidation();
+            validateVitals();
+          case 9:
+            return _context2.a(2);
+        }
+      }, _callee2, null, [[1, 6, 7, 8]]);
+    }));
+    return _init.apply(this, arguments);
+  }
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+  function validateForm() {
+    var fields = [{
+      el: $('#patient_age'),
+      check: function check(e) {
+        return e.value !== '' && +e.value >= 0 && +e.value <= 120;
+      },
+      msg: 'Amžius 0-120'
+    }, {
+      el: $('#patient_sex'),
+      check: function check(e) {
+        return e.value !== '';
+      },
+      msg: 'Pasirinkite lytį'
+    }];
+    var ok = true;
+    fields.forEach(function (_ref) {
+      var el = _ref.el,
+        check = _ref.check,
+        msg = _ref.msg;
+      if (!el) return;
+      if (!el.dataset.hint && el.getAttribute('aria-describedby')) el.dataset.hint = el.getAttribute('aria-describedby');
+      var err = document.getElementById(el.id + '_error');
+      var hintId = el.dataset.hint || '';
+      if (!check(el)) {
+        ok = false;
+        if (!err) {
+          err = document.createElement('div');
+          err.id = el.id + '_error';
+          err.className = 'error-msg';
+          err.textContent = msg;
+          el.parentElement.appendChild(err);
+        }
+        el.classList.add('invalid');
+        el.setAttribute('aria-invalid', 'true');
+        el.setAttribute('aria-describedby', (hintId + ' ' + err.id).trim());
+      } else {
+        if (err) err.remove();
+        el.classList.remove('invalid');
+        el.removeAttribute('aria-invalid');
+        if (hintId) el.setAttribute('aria-describedby', hintId);else el.removeAttribute('aria-describedby');
+      }
+    });
+    if (!validateVitals()) ok = false;
+    return ok;
+  }
+  document.addEventListener('tabShown', function (e) {
+    if (e.detail === 'Santrauka') {
+      if (validateForm()) {
+        generateReport();
+        expandOutput();
+        saveAll();
+      }
+    }
+  });
+
+  /** @license
+   *
+   * jsPDF - PDF Document creation from JavaScript
+   * Version 2.5.2 Built on 2024-09-17T13:29:57.856Z
+   *                      CommitID 00000000
+   *
+   * Copyright (c) 2010-2021 James Hall <james@parall.ax>, https://github.com/MrRio/jsPDF
+   *               2015-2021 yWorks GmbH, http://www.yworks.com
+   *               2015-2021 Lukas Holländer <lukas.hollaender@yworks.com>, https://github.com/HackbrettXXX
+   *               2016-2018 Aras Abbasi <aras.abbasi@gmail.com>
+   *               2010 Aaron Spike, https://github.com/acspike
+   *               2012 Willow Systems Corporation, https://github.com/willowsystems
+   *               2012 Pablo Hess, https://github.com/pablohess
+   *               2012 Florian Jenett, https://github.com/fjenett
+   *               2013 Warren Weckesser, https://github.com/warrenweckesser
+   *               2013 Youssef Beddad, https://github.com/lifof
+   *               2013 Lee Driscoll, https://github.com/lsdriscoll
+   *               2013 Stefan Slonevskiy, https://github.com/stefslon
+   *               2013 Jeremy Morel, https://github.com/jmorel
+   *               2013 Christoph Hartmann, https://github.com/chris-rock
+   *               2014 Juan Pablo Gaviria, https://github.com/juanpgaviria
+   *               2014 James Makes, https://github.com/dollaruw
+   *               2014 Diego Casorran, https://github.com/diegocr
+   *               2014 Steven Spungin, https://github.com/Flamenco
+   *               2014 Kenneth Glassey, https://github.com/Gavvers
+   *
+   * Permission is hereby granted, free of charge, to any person obtaining
+   * a copy of this software and associated documentation files (the
+   * "Software"), to deal in the Software without restriction, including
+   * without limitation the rights to use, copy, modify, merge, publish,
+   * distribute, sublicense, and/or sell copies of the Software, and to
+   * permit persons to whom the Software is furnished to do so, subject to
+   * the following conditions:
+   *
+   * The above copyright notice and this permission notice shall be
+   * included in all copies or substantial portions of the Software.
+   *
+   * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+   * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+   * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+   * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+   *
+   * Contributor(s):
+   *    siefkenj, ahwolf, rickygu, Midnith, saintclair, eaparango,
+   *    kim3er, mfo, alnorth, Flamenco
+   */
+
+  !function (t, e) {
+    "object" == (typeof exports === "undefined" ? "undefined" : _typeof(exports)) && "undefined" != typeof module ? e(exports) : "function" == typeof define && define.amd ? define(["exports"], e) : e((t = t || self).jspdf = {});
+  }(undefined, function (t) {
+
+    function e(t) {
+      return (e = "function" == typeof Symbol && "symbol" == _typeof(Symbol.iterator) ? function (t) {
+        return _typeof(t);
+      } : function (t) {
+        return t && "function" == typeof Symbol && t.constructor === Symbol && t !== Symbol.prototype ? "symbol" : _typeof(t);
+      })(t);
+    }
+    var r = function () {
+      return "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof self ? self : this;
+    }();
+    function n() {
+      r.console && "function" == typeof r.console.log && r.console.log.apply(r.console, arguments);
+    }
+    var i = {
+      log: n,
+      warn: function warn(t) {
+        r.console && ("function" == typeof r.console.warn ? r.console.warn.apply(r.console, arguments) : n.call(null, arguments));
+      },
+      error: function error(t) {
+        r.console && ("function" == typeof r.console.error ? r.console.error.apply(r.console, arguments) : n(t));
+      }
+    };
+    function a(t, e, r) {
+      var n = new XMLHttpRequest();
+      n.open("GET", t), n.responseType = "blob", n.onload = function () {
+        l(n.response, e, r);
+      }, n.onerror = function () {
+        i.error("could not download file");
+      }, n.send();
+    }
+    function o(t) {
+      var e = new XMLHttpRequest();
+      e.open("HEAD", t, !1);
+      try {
+        e.send();
+      } catch (t) {}
+      return e.status >= 200 && e.status <= 299;
+    }
+    function s(t) {
+      try {
+        t.dispatchEvent(new MouseEvent("click"));
+      } catch (r) {
+        var e = document.createEvent("MouseEvents");
+        e.initMouseEvent("click", !0, !0, window, 0, 0, 0, 80, 20, !1, !1, !1, !1, 0, null), t.dispatchEvent(e);
+      }
+    }
+    var c,
+      u,
+      l = r.saveAs || ("object" !== ("undefined" == typeof window ? "undefined" : e(window)) || window !== r ? function () {} : "undefined" != typeof HTMLAnchorElement && "download" in HTMLAnchorElement.prototype ? function (t, e, n) {
+        var i = r.URL || r.webkitURL,
+          c = document.createElement("a");
+        e = e || t.name || "download", c.download = e, c.rel = "noopener", "string" == typeof t ? (c.href = t, c.origin !== location.origin ? o(c.href) ? a(t, e, n) : s(c, c.target = "_blank") : s(c)) : (c.href = i.createObjectURL(t), setTimeout(function () {
+          i.revokeObjectURL(c.href);
+        }, 4e4), setTimeout(function () {
+          s(c);
+        }, 0));
+      } : "msSaveOrOpenBlob" in navigator ? function (t, r, n) {
+        if (r = r || t.name || "download", "string" == typeof t) {
+          if (o(t)) a(t, r, n);else {
+            var c = document.createElement("a");
+            c.href = t, c.target = "_blank", setTimeout(function () {
+              s(c);
+            });
+          }
+        } else navigator.msSaveOrOpenBlob(function (t, r) {
+          return void 0 === r ? r = {
+            autoBom: !1
+          } : "object" !== e(r) && (i.warn("Deprecated: Expected third argument to be a object"), r = {
+            autoBom: !r
+          }), r.autoBom && /^\s*(?:text\/\S*|application\/xml|\S*\/\S*\+xml)\s*;.*charset\s*=\s*utf-8/i.test(t.type) ? new Blob([String.fromCharCode(65279), t], {
+            type: t.type
+          }) : t;
+        }(t, n), r);
+      } : function (t, n, i, o) {
+        if ((o = o || open("", "_blank")) && (o.document.title = o.document.body.innerText = "downloading..."), "string" == typeof t) return a(t, n, i);
+        var s = "application/octet-stream" === t.type,
+          c = /constructor/i.test(r.HTMLElement) || r.safari,
+          u = /CriOS\/[\d]+/.test(navigator.userAgent);
+        if ((u || s && c) && "object" === ("undefined" == typeof FileReader ? "undefined" : e(FileReader))) {
+          var l = new FileReader();
+          l.onloadend = function () {
+            var t = l.result;
+            t = u ? t : t.replace(/^data:[^;]*;/, "data:attachment/file;"), o ? o.location.href = t : location = t, o = null;
+          }, l.readAsDataURL(t);
+        } else {
+          var h = r.URL || r.webkitURL,
+            f = h.createObjectURL(t);
+          o ? o.location = f : location.href = f, o = null, setTimeout(function () {
+            h.revokeObjectURL(f);
+          }, 4e4);
+        }
+      });
+    /**
+       * A class to parse color values
+       * @author Stoyan Stefanov <sstoo@gmail.com>
+       * {@link   http://www.phpied.com/rgb-color-parser-in-javascript/}
+       * @license Use it if you like it
+       */
+    function h(t) {
+      var e;
+      t = t || "", this.ok = !1, "#" == t.charAt(0) && (t = t.substr(1, 6));
+      t = {
+        aliceblue: "f0f8ff",
+        antiquewhite: "faebd7",
+        aqua: "00ffff",
+        aquamarine: "7fffd4",
+        azure: "f0ffff",
+        beige: "f5f5dc",
+        bisque: "ffe4c4",
+        black: "000000",
+        blanchedalmond: "ffebcd",
+        blue: "0000ff",
+        blueviolet: "8a2be2",
+        brown: "a52a2a",
+        burlywood: "deb887",
+        cadetblue: "5f9ea0",
+        chartreuse: "7fff00",
+        chocolate: "d2691e",
+        coral: "ff7f50",
+        cornflowerblue: "6495ed",
+        cornsilk: "fff8dc",
+        crimson: "dc143c",
+        cyan: "00ffff",
+        darkblue: "00008b",
+        darkcyan: "008b8b",
+        darkgoldenrod: "b8860b",
+        darkgray: "a9a9a9",
+        darkgreen: "006400",
+        darkkhaki: "bdb76b",
+        darkmagenta: "8b008b",
+        darkolivegreen: "556b2f",
+        darkorange: "ff8c00",
+        darkorchid: "9932cc",
+        darkred: "8b0000",
+        darksalmon: "e9967a",
+        darkseagreen: "8fbc8f",
+        darkslateblue: "483d8b",
+        darkslategray: "2f4f4f",
+        darkturquoise: "00ced1",
+        darkviolet: "9400d3",
+        deeppink: "ff1493",
+        deepskyblue: "00bfff",
+        dimgray: "696969",
+        dodgerblue: "1e90ff",
+        feldspar: "d19275",
+        firebrick: "b22222",
+        floralwhite: "fffaf0",
+        forestgreen: "228b22",
+        fuchsia: "ff00ff",
+        gainsboro: "dcdcdc",
+        ghostwhite: "f8f8ff",
+        gold: "ffd700",
+        goldenrod: "daa520",
+        gray: "808080",
+        green: "008000",
+        greenyellow: "adff2f",
+        honeydew: "f0fff0",
+        hotpink: "ff69b4",
+        indianred: "cd5c5c",
+        indigo: "4b0082",
+        ivory: "fffff0",
+        khaki: "f0e68c",
+        lavender: "e6e6fa",
+        lavenderblush: "fff0f5",
+        lawngreen: "7cfc00",
+        lemonchiffon: "fffacd",
+        lightblue: "add8e6",
+        lightcoral: "f08080",
+        lightcyan: "e0ffff",
+        lightgoldenrodyellow: "fafad2",
+        lightgrey: "d3d3d3",
+        lightgreen: "90ee90",
+        lightpink: "ffb6c1",
+        lightsalmon: "ffa07a",
+        lightseagreen: "20b2aa",
+        lightskyblue: "87cefa",
+        lightslateblue: "8470ff",
+        lightslategray: "778899",
+        lightsteelblue: "b0c4de",
+        lightyellow: "ffffe0",
+        lime: "00ff00",
+        limegreen: "32cd32",
+        linen: "faf0e6",
+        magenta: "ff00ff",
+        maroon: "800000",
+        mediumaquamarine: "66cdaa",
+        mediumblue: "0000cd",
+        mediumorchid: "ba55d3",
+        mediumpurple: "9370d8",
+        mediumseagreen: "3cb371",
+        mediumslateblue: "7b68ee",
+        mediumspringgreen: "00fa9a",
+        mediumturquoise: "48d1cc",
+        mediumvioletred: "c71585",
+        midnightblue: "191970",
+        mintcream: "f5fffa",
+        mistyrose: "ffe4e1",
+        moccasin: "ffe4b5",
+        navajowhite: "ffdead",
+        navy: "000080",
+        oldlace: "fdf5e6",
+        olive: "808000",
+        olivedrab: "6b8e23",
+        orange: "ffa500",
+        orangered: "ff4500",
+        orchid: "da70d6",
+        palegoldenrod: "eee8aa",
+        palegreen: "98fb98",
+        paleturquoise: "afeeee",
+        palevioletred: "d87093",
+        papayawhip: "ffefd5",
+        peachpuff: "ffdab9",
+        peru: "cd853f",
+        pink: "ffc0cb",
+        plum: "dda0dd",
+        powderblue: "b0e0e6",
+        purple: "800080",
+        red: "ff0000",
+        rosybrown: "bc8f8f",
+        royalblue: "4169e1",
+        saddlebrown: "8b4513",
+        salmon: "fa8072",
+        sandybrown: "f4a460",
+        seagreen: "2e8b57",
+        seashell: "fff5ee",
+        sienna: "a0522d",
+        silver: "c0c0c0",
+        skyblue: "87ceeb",
+        slateblue: "6a5acd",
+        slategray: "708090",
+        snow: "fffafa",
+        springgreen: "00ff7f",
+        steelblue: "4682b4",
+        tan: "d2b48c",
+        teal: "008080",
+        thistle: "d8bfd8",
+        tomato: "ff6347",
+        turquoise: "40e0d0",
+        violet: "ee82ee",
+        violetred: "d02090",
+        wheat: "f5deb3",
+        white: "ffffff",
+        whitesmoke: "f5f5f5",
+        yellow: "ffff00",
+        yellowgreen: "9acd32"
+      }[t = (t = t.replace(/ /g, "")).toLowerCase()] || t;
+      for (var r = [{
+          re: /^rgb\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})\)$/,
+          example: ["rgb(123, 234, 45)", "rgb(255,234,245)"],
+          process: function process(t) {
+            return [parseInt(t[1]), parseInt(t[2]), parseInt(t[3])];
+          }
+        }, {
+          re: /^(\w{2})(\w{2})(\w{2})$/,
+          example: ["#00ff00", "336699"],
+          process: function process(t) {
+            return [parseInt(t[1], 16), parseInt(t[2], 16), parseInt(t[3], 16)];
+          }
+        }, {
+          re: /^(\w{1})(\w{1})(\w{1})$/,
+          example: ["#fb0", "f0f"],
+          process: function process(t) {
+            return [parseInt(t[1] + t[1], 16), parseInt(t[2] + t[2], 16), parseInt(t[3] + t[3], 16)];
+          }
+        }], n = 0; n < r.length; n++) {
+        var i = r[n].re,
+          a = r[n].process,
+          o = i.exec(t);
+        o && (e = a(o), this.r = e[0], this.g = e[1], this.b = e[2], this.ok = !0);
+      }
+      this.r = this.r < 0 || isNaN(this.r) ? 0 : this.r > 255 ? 255 : this.r, this.g = this.g < 0 || isNaN(this.g) ? 0 : this.g > 255 ? 255 : this.g, this.b = this.b < 0 || isNaN(this.b) ? 0 : this.b > 255 ? 255 : this.b, this.toRGB = function () {
+        return "rgb(" + this.r + ", " + this.g + ", " + this.b + ")";
+      }, this.toHex = function () {
+        var t = this.r.toString(16),
+          e = this.g.toString(16),
+          r = this.b.toString(16);
+        return 1 == t.length && (t = "0" + t), 1 == e.length && (e = "0" + e), 1 == r.length && (r = "0" + r), "#" + t + e + r;
+      };
+    }
+    /**
+       * @license
+       * Joseph Myers does not specify a particular license for his work.
+       *
+       * Author: Joseph Myers
+       * Accessed from: http://www.myersdaily.org/joseph/javascript/md5.js
+       *
+       * Modified by: Owen Leong
+       */
+    function f(t, e) {
+      var r = t[0],
+        n = t[1],
+        i = t[2],
+        a = t[3];
+      r = p(r, n, i, a, e[0], 7, -680876936), a = p(a, r, n, i, e[1], 12, -389564586), i = p(i, a, r, n, e[2], 17, 606105819), n = p(n, i, a, r, e[3], 22, -1044525330), r = p(r, n, i, a, e[4], 7, -176418897), a = p(a, r, n, i, e[5], 12, 1200080426), i = p(i, a, r, n, e[6], 17, -1473231341), n = p(n, i, a, r, e[7], 22, -45705983), r = p(r, n, i, a, e[8], 7, 1770035416), a = p(a, r, n, i, e[9], 12, -1958414417), i = p(i, a, r, n, e[10], 17, -42063), n = p(n, i, a, r, e[11], 22, -1990404162), r = p(r, n, i, a, e[12], 7, 1804603682), a = p(a, r, n, i, e[13], 12, -40341101), i = p(i, a, r, n, e[14], 17, -1502002290), r = g(r, n = p(n, i, a, r, e[15], 22, 1236535329), i, a, e[1], 5, -165796510), a = g(a, r, n, i, e[6], 9, -1069501632), i = g(i, a, r, n, e[11], 14, 643717713), n = g(n, i, a, r, e[0], 20, -373897302), r = g(r, n, i, a, e[5], 5, -701558691), a = g(a, r, n, i, e[10], 9, 38016083), i = g(i, a, r, n, e[15], 14, -660478335), n = g(n, i, a, r, e[4], 20, -405537848), r = g(r, n, i, a, e[9], 5, 568446438), a = g(a, r, n, i, e[14], 9, -1019803690), i = g(i, a, r, n, e[3], 14, -187363961), n = g(n, i, a, r, e[8], 20, 1163531501), r = g(r, n, i, a, e[13], 5, -1444681467), a = g(a, r, n, i, e[2], 9, -51403784), i = g(i, a, r, n, e[7], 14, 1735328473), r = m(r, n = g(n, i, a, r, e[12], 20, -1926607734), i, a, e[5], 4, -378558), a = m(a, r, n, i, e[8], 11, -2022574463), i = m(i, a, r, n, e[11], 16, 1839030562), n = m(n, i, a, r, e[14], 23, -35309556), r = m(r, n, i, a, e[1], 4, -1530992060), a = m(a, r, n, i, e[4], 11, 1272893353), i = m(i, a, r, n, e[7], 16, -155497632), n = m(n, i, a, r, e[10], 23, -1094730640), r = m(r, n, i, a, e[13], 4, 681279174), a = m(a, r, n, i, e[0], 11, -358537222), i = m(i, a, r, n, e[3], 16, -722521979), n = m(n, i, a, r, e[6], 23, 76029189), r = m(r, n, i, a, e[9], 4, -640364487), a = m(a, r, n, i, e[12], 11, -421815835), i = m(i, a, r, n, e[15], 16, 530742520), r = v(r, n = m(n, i, a, r, e[2], 23, -995338651), i, a, e[0], 6, -198630844), a = v(a, r, n, i, e[7], 10, 1126891415), i = v(i, a, r, n, e[14], 15, -1416354905), n = v(n, i, a, r, e[5], 21, -57434055), r = v(r, n, i, a, e[12], 6, 1700485571), a = v(a, r, n, i, e[3], 10, -1894986606), i = v(i, a, r, n, e[10], 15, -1051523), n = v(n, i, a, r, e[1], 21, -2054922799), r = v(r, n, i, a, e[8], 6, 1873313359), a = v(a, r, n, i, e[15], 10, -30611744), i = v(i, a, r, n, e[6], 15, -1560198380), n = v(n, i, a, r, e[13], 21, 1309151649), r = v(r, n, i, a, e[4], 6, -145523070), a = v(a, r, n, i, e[11], 10, -1120210379), i = v(i, a, r, n, e[2], 15, 718787259), n = v(n, i, a, r, e[9], 21, -343485551), t[0] = S(r, t[0]), t[1] = S(n, t[1]), t[2] = S(i, t[2]), t[3] = S(a, t[3]);
+    }
+    function d(t, e, r, n, i, a) {
+      return e = S(S(e, t), S(n, a)), S(e << i | e >>> 32 - i, r);
+    }
+    function p(t, e, r, n, i, a, o) {
+      return d(e & r | ~e & n, t, e, i, a, o);
+    }
+    function g(t, e, r, n, i, a, o) {
+      return d(e & n | r & ~n, t, e, i, a, o);
+    }
+    function m(t, e, r, n, i, a, o) {
+      return d(e ^ r ^ n, t, e, i, a, o);
+    }
+    function v(t, e, r, n, i, a, o) {
+      return d(r ^ (e | ~n), t, e, i, a, o);
+    }
+    function b(t) {
+      var e,
+        r = t.length,
+        n = [1732584193, -271733879, -1732584194, 271733878];
+      for (e = 64; e <= t.length; e += 64) f(n, y(t.substring(e - 64, e)));
+      t = t.substring(e - 64);
+      var i = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+      for (e = 0; e < t.length; e++) i[e >> 2] |= t.charCodeAt(e) << (e % 4 << 3);
+      if (i[e >> 2] |= 128 << (e % 4 << 3), e > 55) for (f(n, i), e = 0; e < 16; e++) i[e] = 0;
+      return i[14] = 8 * r, f(n, i), n;
+    }
+    function y(t) {
+      var e,
+        r = [];
+      for (e = 0; e < 64; e += 4) r[e >> 2] = t.charCodeAt(e) + (t.charCodeAt(e + 1) << 8) + (t.charCodeAt(e + 2) << 16) + (t.charCodeAt(e + 3) << 24);
+      return r;
+    }
+    c = r.atob.bind(r), u = r.btoa.bind(r);
+    var w = "0123456789abcdef".split("");
+    function N(t) {
+      for (var e = "", r = 0; r < 4; r++) e += w[t >> 8 * r + 4 & 15] + w[t >> 8 * r & 15];
+      return e;
+    }
+    function L(t) {
+      return String.fromCharCode((255 & t) >> 0, (65280 & t) >> 8, (16711680 & t) >> 16, (4278190080 & t) >> 24);
+    }
+    function A(t) {
+      return function (t) {
+        return t.map(L).join("");
+      }(b(t));
+    }
+    var x = "5d41402abc4b2a76b9719d911017c592" != function (t) {
+      for (var e = 0; e < t.length; e++) t[e] = N(t[e]);
+      return t.join("");
+    }(b("hello"));
+    function S(t, e) {
+      if (x) {
+        var r = (65535 & t) + (65535 & e);
+        return (t >> 16) + (e >> 16) + (r >> 16) << 16 | 65535 & r;
+      }
+      return t + e & 4294967295;
+    }
+    /**
+       * @license
+       * FPDF is released under a permissive license: there is no usage restriction.
+       * You may embed it freely in your application (commercial or not), with or
+       * without modifications.
+       *
+       * Reference: http://www.fpdf.org/en/script/script37.php
+       */
+    function _(t, e) {
+      var r, n, i, a;
+      if (t !== r) {
+        for (var o = (i = t, a = 1 + (256 / t.length >> 0), new Array(a + 1).join(i)), s = [], c = 0; c < 256; c++) s[c] = c;
+        var u = 0;
+        for (c = 0; c < 256; c++) {
+          var l = s[c];
+          u = (u + l + o.charCodeAt(c)) % 256, s[c] = s[u], s[u] = l;
+        }
+        r = t, n = s;
+      } else s = n;
+      var h = e.length,
+        f = 0,
+        d = 0,
+        p = "";
+      for (c = 0; c < h; c++) d = (d + (l = s[f = (f + 1) % 256])) % 256, s[f] = s[d], s[d] = l, o = s[(s[f] + s[d]) % 256], p += String.fromCharCode(e.charCodeAt(c) ^ o);
+      return p;
+    }
+    /**
+       * @license
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       * Author: Owen Leong (@owenl131)
+       * Date: 15 Oct 2020
+       * References:
+       * https://www.cs.cmu.edu/~dst/Adobe/Gallery/anon21jul01-pdf-encryption.txt
+       * https://github.com/foliojs/pdfkit/blob/master/lib/security.js
+       * http://www.fpdf.org/en/script/script37.php
+       */
+    var P = {
+      print: 4,
+      modify: 8,
+      copy: 16,
+      "annot-forms": 32
+    };
+    function k(t, e, r, n) {
+      this.v = 1, this.r = 2;
+      var i = 192;
+      t.forEach(function (t) {
+        if (void 0 !== P.perm) throw new Error("Invalid permission: " + t);
+        i += P[t];
+      }), this.padding = "(¿N^NuAd\0NVÿú\b..\0¶Ðh>/\f©þdSiz";
+      var a = (e + this.padding).substr(0, 32),
+        o = (r + this.padding).substr(0, 32);
+      this.O = this.processOwnerPassword(a, o), this.P = -(1 + (255 ^ i)), this.encryptionKey = A(a + this.O + this.lsbFirstWord(this.P) + this.hexToBytes(n)).substr(0, 5), this.U = _(this.encryptionKey, this.padding);
+    }
+    function F(t) {
+      if (/[^\u0000-\u00ff]/.test(t)) throw new Error("Invalid PDF Name Object: " + t + ", Only accept ASCII characters.");
+      for (var e = "", r = t.length, n = 0; n < r; n++) {
+        var i = t.charCodeAt(n);
+        if (i < 33 || 35 === i || 37 === i || 40 === i || 41 === i || 47 === i || 60 === i || 62 === i || 91 === i || 93 === i || 123 === i || 125 === i || i > 126) e += "#" + ("0" + i.toString(16)).slice(-2);else e += t[n];
+      }
+      return e;
+    }
+    function I(t) {
+      if ("object" !== e(t)) throw new Error("Invalid Context passed to initialize PubSub (jsPDF-module)");
+      var n = {};
+      this.subscribe = function (t, e, r) {
+        if (r = r || !1, "string" != typeof t || "function" != typeof e || "boolean" != typeof r) throw new Error("Invalid arguments passed to PubSub.subscribe (jsPDF-module)");
+        n.hasOwnProperty(t) || (n[t] = {});
+        var i = Math.random().toString(35);
+        return n[t][i] = [e, !!r], i;
+      }, this.unsubscribe = function (t) {
+        for (var e in n) if (n[e][t]) return delete n[e][t], 0 === Object.keys(n[e]).length && delete n[e], !0;
+        return !1;
+      }, this.publish = function (e) {
+        if (n.hasOwnProperty(e)) {
+          var a = Array.prototype.slice.call(arguments, 1),
+            o = [];
+          for (var s in n[e]) {
+            var c = n[e][s];
+            try {
+              c[0].apply(t, a);
+            } catch (t) {
+              r.console && i.error("jsPDF PubSub Error", t.message, t);
+            }
+            c[1] && o.push(s);
+          }
+          o.length && o.forEach(this.unsubscribe);
+        }
+      }, this.getTopics = function () {
+        return n;
+      };
+    }
+    function C(t) {
+      if (!(this instanceof C)) return new C(t);
+      var e = "opacity,stroke-opacity".split(",");
+      for (var r in t) t.hasOwnProperty(r) && e.indexOf(r) >= 0 && (this[r] = t[r]);
+      this.id = "", this.objectNumber = -1;
+    }
+    function j(t, e) {
+      this.gState = t, this.matrix = e, this.id = "", this.objectNumber = -1;
+    }
+    function O(t, e, r, n, i) {
+      if (!(this instanceof O)) return new O(t, e, r, n, i);
+      this.type = "axial" === t ? 2 : 3, this.coords = e, this.colors = r, j.call(this, n, i);
+    }
+    function B(t, e, r, n, i) {
+      if (!(this instanceof B)) return new B(t, e, r, n, i);
+      this.boundingBox = t, this.xStep = e, this.yStep = r, this.stream = "", this.cloneIndex = 0, j.call(this, n, i);
+    }
+    function M(t) {
+      var n,
+        a = "string" == typeof arguments[0] ? arguments[0] : "p",
+        o = arguments[1],
+        s = arguments[2],
+        c = arguments[3],
+        f = [],
+        d = 1,
+        p = 16,
+        g = "S",
+        m = null;
+      "object" === e(t = t || {}) && (a = t.orientation, o = t.unit || o, s = t.format || s, c = t.compress || t.compressPdf || c, null !== (m = t.encryption || null) && (m.userPassword = m.userPassword || "", m.ownerPassword = m.ownerPassword || "", m.userPermissions = m.userPermissions || []), d = "number" == typeof t.userUnit ? Math.abs(t.userUnit) : 1, void 0 !== t.precision && (n = t.precision), void 0 !== t.floatPrecision && (p = t.floatPrecision), g = t.defaultPathOperation || "S"), f = t.filters || (!0 === c ? ["FlateEncode"] : f), o = o || "mm", a = ("" + (a || "P")).toLowerCase();
+      var v = t.putOnlyUsedFonts || !1,
+        b = {},
+        y = {
+          internal: {},
+          __private__: {}
+        };
+      y.__private__.PubSub = I;
+      var w = "1.3",
+        N = y.__private__.getPdfVersion = function () {
+          return w;
+        };
+      y.__private__.setPdfVersion = function (t) {
+        w = t;
+      };
+      var L = {
+        a0: [2383.94, 3370.39],
+        a1: [1683.78, 2383.94],
+        a2: [1190.55, 1683.78],
+        a3: [841.89, 1190.55],
+        a4: [595.28, 841.89],
+        a5: [419.53, 595.28],
+        a6: [297.64, 419.53],
+        a7: [209.76, 297.64],
+        a8: [147.4, 209.76],
+        a9: [104.88, 147.4],
+        a10: [73.7, 104.88],
+        b0: [2834.65, 4008.19],
+        b1: [2004.09, 2834.65],
+        b2: [1417.32, 2004.09],
+        b3: [1000.63, 1417.32],
+        b4: [708.66, 1000.63],
+        b5: [498.9, 708.66],
+        b6: [354.33, 498.9],
+        b7: [249.45, 354.33],
+        b8: [175.75, 249.45],
+        b9: [124.72, 175.75],
+        b10: [87.87, 124.72],
+        c0: [2599.37, 3676.54],
+        c1: [1836.85, 2599.37],
+        c2: [1298.27, 1836.85],
+        c3: [918.43, 1298.27],
+        c4: [649.13, 918.43],
+        c5: [459.21, 649.13],
+        c6: [323.15, 459.21],
+        c7: [229.61, 323.15],
+        c8: [161.57, 229.61],
+        c9: [113.39, 161.57],
+        c10: [79.37, 113.39],
+        dl: [311.81, 623.62],
+        letter: [612, 792],
+        "government-letter": [576, 756],
+        legal: [612, 1008],
+        "junior-legal": [576, 360],
+        ledger: [1224, 792],
+        tabloid: [792, 1224],
+        "credit-card": [153, 243]
+      };
+      y.__private__.getPageFormats = function () {
+        return L;
+      };
+      var A = y.__private__.getPageFormat = function (t) {
+        return L[t];
+      };
+      s = s || "a4";
+      var x = {
+          COMPAT: "compat",
+          ADVANCED: "advanced"
+        },
+        S = x.COMPAT;
+      function _() {
+        this.saveGraphicsState(), ht(new Vt(_t, 0, 0, -_t, 0, Rr() * _t).toString() + " cm"), this.setFontSize(this.getFontSize() / _t), g = "n", S = x.ADVANCED;
+      }
+      function P() {
+        this.restoreGraphicsState(), g = "S", S = x.COMPAT;
+      }
+      var j = y.__private__.combineFontStyleAndFontWeight = function (t, e) {
+        if ("bold" == t && "normal" == e || "bold" == t && 400 == e || "normal" == t && "italic" == e || "bold" == t && "italic" == e) throw new Error("Invalid Combination of fontweight and fontstyle");
+        return e && (t = 400 == e || "normal" === e ? "italic" === t ? "italic" : "normal" : 700 != e && "bold" !== e || "normal" !== t ? (700 == e ? "bold" : e) + "" + t : "bold"), t;
+      };
+      y.advancedAPI = function (t) {
+        var e = S === x.COMPAT;
+        return e && _.call(this), "function" != typeof t || (t(this), e && P.call(this)), this;
+      }, y.compatAPI = function (t) {
+        var e = S === x.ADVANCED;
+        return e && P.call(this), "function" != typeof t || (t(this), e && _.call(this)), this;
+      }, y.isAdvancedAPI = function () {
+        return S === x.ADVANCED;
+      };
+      var E,
+        q = function q(t) {
+          if (S !== x.ADVANCED) throw new Error(t + " is only available in 'advanced' API mode. You need to call advancedAPI() first.");
+        },
+        D = y.roundToPrecision = y.__private__.roundToPrecision = function (t, e) {
+          var r = n || e;
+          if (isNaN(t) || isNaN(r)) throw new Error("Invalid argument passed to jsPDF.roundToPrecision");
+          return t.toFixed(r).replace(/0+$/, "");
+        };
+      E = y.hpf = y.__private__.hpf = "number" == typeof p ? function (t) {
+        if (isNaN(t)) throw new Error("Invalid argument passed to jsPDF.hpf");
+        return D(t, p);
+      } : "smart" === p ? function (t) {
+        if (isNaN(t)) throw new Error("Invalid argument passed to jsPDF.hpf");
+        return D(t, t > -1 && t < 1 ? 16 : 5);
+      } : function (t) {
+        if (isNaN(t)) throw new Error("Invalid argument passed to jsPDF.hpf");
+        return D(t, 16);
+      };
+      var R = y.f2 = y.__private__.f2 = function (t) {
+          if (isNaN(t)) throw new Error("Invalid argument passed to jsPDF.f2");
+          return D(t, 2);
+        },
+        T = y.__private__.f3 = function (t) {
+          if (isNaN(t)) throw new Error("Invalid argument passed to jsPDF.f3");
+          return D(t, 3);
+        },
+        U = y.scale = y.__private__.scale = function (t) {
+          if (isNaN(t)) throw new Error("Invalid argument passed to jsPDF.scale");
+          return S === x.COMPAT ? t * _t : S === x.ADVANCED ? t : void 0;
+        },
+        z = function z(t) {
+          return S === x.COMPAT ? Rr() - t : S === x.ADVANCED ? t : void 0;
+        },
+        H = function H(t) {
+          return U(z(t));
+        };
+      y.__private__.setPrecision = y.setPrecision = function (t) {
+        "number" == typeof parseInt(t, 10) && (n = parseInt(t, 10));
+      };
+      var W,
+        V = "00000000000000000000000000000000",
+        G = y.__private__.getFileId = function () {
+          return V;
+        },
+        Y = y.__private__.setFileId = function (t) {
+          return V = void 0 !== t && /^[a-fA-F0-9]{32}$/.test(t) ? t.toUpperCase() : V.split("").map(function () {
+            return "ABCDEF0123456789".charAt(Math.floor(16 * Math.random()));
+          }).join(""), null !== m && (Ye = new k(m.userPermissions, m.userPassword, m.ownerPassword, V)), V;
+        };
+      y.setFileId = function (t) {
+        return Y(t), this;
+      }, y.getFileId = function () {
+        return G();
+      };
+      var J = y.__private__.convertDateToPDFDate = function (t) {
+          var e = t.getTimezoneOffset(),
+            r = e < 0 ? "+" : "-",
+            n = Math.floor(Math.abs(e / 60)),
+            i = Math.abs(e % 60),
+            a = [r, Q(n), "'", Q(i), "'"].join("");
+          return ["D:", t.getFullYear(), Q(t.getMonth() + 1), Q(t.getDate()), Q(t.getHours()), Q(t.getMinutes()), Q(t.getSeconds()), a].join("");
+        },
+        X = y.__private__.convertPDFDateToDate = function (t) {
+          var e = parseInt(t.substr(2, 4), 10),
+            r = parseInt(t.substr(6, 2), 10) - 1,
+            n = parseInt(t.substr(8, 2), 10),
+            i = parseInt(t.substr(10, 2), 10),
+            a = parseInt(t.substr(12, 2), 10),
+            o = parseInt(t.substr(14, 2), 10);
+          return new Date(e, r, n, i, a, o, 0);
+        },
+        K = y.__private__.setCreationDate = function (t) {
+          var e;
+          if (void 0 === t && (t = new Date()), t instanceof Date) e = J(t);else {
+            if (!/^D:(20[0-2][0-9]|203[0-7]|19[7-9][0-9])(0[0-9]|1[0-2])([0-2][0-9]|3[0-1])(0[0-9]|1[0-9]|2[0-3])(0[0-9]|[1-5][0-9])(0[0-9]|[1-5][0-9])(\+0[0-9]|\+1[0-4]|-0[0-9]|-1[0-1])'(0[0-9]|[1-5][0-9])'?$/.test(t)) throw new Error("Invalid argument passed to jsPDF.setCreationDate");
+            e = t;
+          }
+          return W = e;
+        },
+        Z = y.__private__.getCreationDate = function (t) {
+          var e = W;
+          return "jsDate" === t && (e = X(W)), e;
+        };
+      y.setCreationDate = function (t) {
+        return K(t), this;
+      }, y.getCreationDate = function (t) {
+        return Z(t);
+      };
+      var $,
+        Q = y.__private__.padd2 = function (t) {
+          return ("0" + parseInt(t)).slice(-2);
+        },
+        tt = y.__private__.padd2Hex = function (t) {
+          return ("00" + (t = t.toString())).substr(t.length);
+        },
+        et = 0,
+        rt = [],
+        nt = [],
+        it = 0,
+        at = [],
+        ot = [],
+        st = !1,
+        ct = nt,
+        ut = function ut() {
+          et = 0, it = 0, nt = [], rt = [], at = [], Qt = Kt(), te = Kt();
+        };
+      y.__private__.setCustomOutputDestination = function (t) {
+        st = !0, ct = t;
+      };
+      var lt = function lt(t) {
+        st || (ct = t);
+      };
+      y.__private__.resetCustomOutputDestination = function () {
+        st = !1, ct = nt;
+      };
+      var ht = y.__private__.out = function (t) {
+          return t = t.toString(), it += t.length + 1, ct.push(t), ct;
+        },
+        ft = y.__private__.write = function (t) {
+          return ht(1 === arguments.length ? t.toString() : Array.prototype.join.call(arguments, " "));
+        },
+        dt = y.__private__.getArrayBuffer = function (t) {
+          for (var e = t.length, r = new ArrayBuffer(e), n = new Uint8Array(r); e--;) n[e] = t.charCodeAt(e);
+          return r;
+        },
+        pt = [["Helvetica", "helvetica", "normal", "WinAnsiEncoding"], ["Helvetica-Bold", "helvetica", "bold", "WinAnsiEncoding"], ["Helvetica-Oblique", "helvetica", "italic", "WinAnsiEncoding"], ["Helvetica-BoldOblique", "helvetica", "bolditalic", "WinAnsiEncoding"], ["Courier", "courier", "normal", "WinAnsiEncoding"], ["Courier-Bold", "courier", "bold", "WinAnsiEncoding"], ["Courier-Oblique", "courier", "italic", "WinAnsiEncoding"], ["Courier-BoldOblique", "courier", "bolditalic", "WinAnsiEncoding"], ["Times-Roman", "times", "normal", "WinAnsiEncoding"], ["Times-Bold", "times", "bold", "WinAnsiEncoding"], ["Times-Italic", "times", "italic", "WinAnsiEncoding"], ["Times-BoldItalic", "times", "bolditalic", "WinAnsiEncoding"], ["ZapfDingbats", "zapfdingbats", "normal", null], ["Symbol", "symbol", "normal", null]];
+      y.__private__.getStandardFonts = function () {
+        return pt;
+      };
+      var gt = t.fontSize || 16;
+      y.__private__.setFontSize = y.setFontSize = function (t) {
+        return gt = S === x.ADVANCED ? t / _t : t, this;
+      };
+      var mt,
+        vt = y.__private__.getFontSize = y.getFontSize = function () {
+          return S === x.COMPAT ? gt : gt * _t;
+        },
+        bt = t.R2L || !1;
+      y.__private__.setR2L = y.setR2L = function (t) {
+        return bt = t, this;
+      }, y.__private__.getR2L = y.getR2L = function () {
+        return bt;
+      };
+      var yt,
+        wt = y.__private__.setZoomMode = function (t) {
+          var e = [void 0, null, "fullwidth", "fullheight", "fullpage", "original"];
+          if (/^(?:\d+\.\d*|\d*\.\d+|\d+)%$/.test(t)) mt = t;else if (isNaN(t)) {
+            if (-1 === e.indexOf(t)) throw new Error('zoom must be Integer (e.g. 2), a percentage Value (e.g. 300%) or fullwidth, fullheight, fullpage, original. "' + t + '" is not recognized.');
+            mt = t;
+          } else mt = parseInt(t, 10);
+        };
+      y.__private__.getZoomMode = function () {
+        return mt;
+      };
+      var Nt,
+        Lt = y.__private__.setPageMode = function (t) {
+          if (-1 == [void 0, null, "UseNone", "UseOutlines", "UseThumbs", "FullScreen"].indexOf(t)) throw new Error('Page mode must be one of UseNone, UseOutlines, UseThumbs, or FullScreen. "' + t + '" is not recognized.');
+          yt = t;
+        };
+      y.__private__.getPageMode = function () {
+        return yt;
+      };
+      var At = y.__private__.setLayoutMode = function (t) {
+        if (-1 == [void 0, null, "continuous", "single", "twoleft", "tworight", "two"].indexOf(t)) throw new Error('Layout mode must be one of continuous, single, twoleft, tworight. "' + t + '" is not recognized.');
+        Nt = t;
+      };
+      y.__private__.getLayoutMode = function () {
+        return Nt;
+      }, y.__private__.setDisplayMode = y.setDisplayMode = function (t, e, r) {
+        return wt(t), At(e), Lt(r), this;
+      };
+      var xt = {
+        title: "",
+        subject: "",
+        author: "",
+        keywords: "",
+        creator: ""
+      };
+      y.__private__.getDocumentProperty = function (t) {
+        if (-1 === Object.keys(xt).indexOf(t)) throw new Error("Invalid argument passed to jsPDF.getDocumentProperty");
+        return xt[t];
+      }, y.__private__.getDocumentProperties = function () {
+        return xt;
+      }, y.__private__.setDocumentProperties = y.setProperties = y.setDocumentProperties = function (t) {
+        for (var e in xt) xt.hasOwnProperty(e) && t[e] && (xt[e] = t[e]);
+        return this;
+      }, y.__private__.setDocumentProperty = function (t, e) {
+        if (-1 === Object.keys(xt).indexOf(t)) throw new Error("Invalid arguments passed to jsPDF.setDocumentProperty");
+        return xt[t] = e;
+      };
+      var St,
+        _t,
+        Pt,
+        kt,
+        Ft,
+        It = {},
+        Ct = {},
+        jt = [],
+        Ot = {},
+        Bt = {},
+        Mt = {},
+        Et = {},
+        qt = null,
+        Dt = 0,
+        Rt = [],
+        Tt = new I(y),
+        Ut = t.hotfixes || [],
+        zt = {},
+        Ht = {},
+        Wt = [],
+        Vt = function t(e, r, n, i, a, o) {
+          if (!(this instanceof t)) return new t(e, r, n, i, a, o);
+          isNaN(e) && (e = 1), isNaN(r) && (r = 0), isNaN(n) && (n = 0), isNaN(i) && (i = 1), isNaN(a) && (a = 0), isNaN(o) && (o = 0), this._matrix = [e, r, n, i, a, o];
+        };
+      Object.defineProperty(Vt.prototype, "sx", {
+        get: function get() {
+          return this._matrix[0];
+        },
+        set: function set(t) {
+          this._matrix[0] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "shy", {
+        get: function get() {
+          return this._matrix[1];
+        },
+        set: function set(t) {
+          this._matrix[1] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "shx", {
+        get: function get() {
+          return this._matrix[2];
+        },
+        set: function set(t) {
+          this._matrix[2] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "sy", {
+        get: function get() {
+          return this._matrix[3];
+        },
+        set: function set(t) {
+          this._matrix[3] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "tx", {
+        get: function get() {
+          return this._matrix[4];
+        },
+        set: function set(t) {
+          this._matrix[4] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "ty", {
+        get: function get() {
+          return this._matrix[5];
+        },
+        set: function set(t) {
+          this._matrix[5] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "a", {
+        get: function get() {
+          return this._matrix[0];
+        },
+        set: function set(t) {
+          this._matrix[0] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "b", {
+        get: function get() {
+          return this._matrix[1];
+        },
+        set: function set(t) {
+          this._matrix[1] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "c", {
+        get: function get() {
+          return this._matrix[2];
+        },
+        set: function set(t) {
+          this._matrix[2] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "d", {
+        get: function get() {
+          return this._matrix[3];
+        },
+        set: function set(t) {
+          this._matrix[3] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "e", {
+        get: function get() {
+          return this._matrix[4];
+        },
+        set: function set(t) {
+          this._matrix[4] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "f", {
+        get: function get() {
+          return this._matrix[5];
+        },
+        set: function set(t) {
+          this._matrix[5] = t;
+        }
+      }), Object.defineProperty(Vt.prototype, "rotation", {
+        get: function get() {
+          return Math.atan2(this.shx, this.sx);
+        }
+      }), Object.defineProperty(Vt.prototype, "scaleX", {
+        get: function get() {
+          return this.decompose().scale.sx;
+        }
+      }), Object.defineProperty(Vt.prototype, "scaleY", {
+        get: function get() {
+          return this.decompose().scale.sy;
+        }
+      }), Object.defineProperty(Vt.prototype, "isIdentity", {
+        get: function get() {
+          return 1 === this.sx && 0 === this.shy && 0 === this.shx && 1 === this.sy && 0 === this.tx && 0 === this.ty;
+        }
+      }), Vt.prototype.join = function (t) {
+        return [this.sx, this.shy, this.shx, this.sy, this.tx, this.ty].map(E).join(t);
+      }, Vt.prototype.multiply = function (t) {
+        var e = t.sx * this.sx + t.shy * this.shx,
+          r = t.sx * this.shy + t.shy * this.sy,
+          n = t.shx * this.sx + t.sy * this.shx,
+          i = t.shx * this.shy + t.sy * this.sy,
+          a = t.tx * this.sx + t.ty * this.shx + this.tx,
+          o = t.tx * this.shy + t.ty * this.sy + this.ty;
+        return new Vt(e, r, n, i, a, o);
+      }, Vt.prototype.decompose = function () {
+        var t = this.sx,
+          e = this.shy,
+          r = this.shx,
+          n = this.sy,
+          i = this.tx,
+          a = this.ty,
+          o = Math.sqrt(t * t + e * e),
+          s = (t /= o) * r + (e /= o) * n;
+        r -= t * s, n -= e * s;
+        var c = Math.sqrt(r * r + n * n);
+        return s /= c, t * (n /= c) < e * (r /= c) && (t = -t, e = -e, s = -s, o = -o), {
+          scale: new Vt(o, 0, 0, c, 0, 0),
+          translate: new Vt(1, 0, 0, 1, i, a),
+          rotate: new Vt(t, e, -e, t, 0, 0),
+          skew: new Vt(1, 0, s, 1, 0, 0)
+        };
+      }, Vt.prototype.toString = function (t) {
+        return this.join(" ");
+      }, Vt.prototype.inversed = function () {
+        var t = this.sx,
+          e = this.shy,
+          r = this.shx,
+          n = this.sy,
+          i = this.tx,
+          a = this.ty,
+          o = 1 / (t * n - e * r),
+          s = n * o,
+          c = -e * o,
+          u = -r * o,
+          l = t * o;
+        return new Vt(s, c, u, l, -s * i - u * a, -c * i - l * a);
+      }, Vt.prototype.applyToPoint = function (t) {
+        var e = t.x * this.sx + t.y * this.shx + this.tx,
+          r = t.x * this.shy + t.y * this.sy + this.ty;
+        return new Cr(e, r);
+      }, Vt.prototype.applyToRectangle = function (t) {
+        var e = this.applyToPoint(t),
+          r = this.applyToPoint(new Cr(t.x + t.w, t.y + t.h));
+        return new jr(e.x, e.y, r.x - e.x, r.y - e.y);
+      }, Vt.prototype.clone = function () {
+        var t = this.sx,
+          e = this.shy,
+          r = this.shx,
+          n = this.sy,
+          i = this.tx,
+          a = this.ty;
+        return new Vt(t, e, r, n, i, a);
+      }, y.Matrix = Vt;
+      var Gt = y.matrixMult = function (t, e) {
+          return e.multiply(t);
+        },
+        Yt = new Vt(1, 0, 0, 1, 0, 0);
+      y.unitMatrix = y.identityMatrix = Yt;
+      var Jt = function Jt(t, e) {
+        if (!Bt[t]) {
+          var r = (e instanceof O ? "Sh" : "P") + (Object.keys(Ot).length + 1).toString(10);
+          e.id = r, Bt[t] = r, Ot[r] = e, Tt.publish("addPattern", e);
+        }
+      };
+      y.ShadingPattern = O, y.TilingPattern = B, y.addShadingPattern = function (t, e) {
+        return q("addShadingPattern()"), Jt(t, e), this;
+      }, y.beginTilingPattern = function (t) {
+        q("beginTilingPattern()"), Br(t.boundingBox[0], t.boundingBox[1], t.boundingBox[2] - t.boundingBox[0], t.boundingBox[3] - t.boundingBox[1], t.matrix);
+      }, y.endTilingPattern = function (t, e) {
+        q("endTilingPattern()"), e.stream = ot[$].join("\n"), Jt(t, e), Tt.publish("endTilingPattern", e), Wt.pop().restore();
+      };
+      var Xt = y.__private__.newObject = function () {
+          var t = Kt();
+          return Zt(t, !0), t;
+        },
+        Kt = y.__private__.newObjectDeferred = function () {
+          return et++, rt[et] = function () {
+            return it;
+          }, et;
+        },
+        Zt = function Zt(t, e) {
+          return e = "boolean" == typeof e && e, rt[t] = it, e && ht(t + " 0 obj"), t;
+        },
+        $t = y.__private__.newAdditionalObject = function () {
+          var t = {
+            objId: Kt(),
+            content: ""
+          };
+          return at.push(t), t;
+        },
+        Qt = Kt(),
+        te = Kt(),
+        ee = y.__private__.decodeColorString = function (t) {
+          var e = t.split(" ");
+          if (2 !== e.length || "g" !== e[1] && "G" !== e[1]) {
+            if (5 === e.length && ("k" === e[4] || "K" === e[4])) {
+              e = [(1 - e[0]) * (1 - e[3]), (1 - e[1]) * (1 - e[3]), (1 - e[2]) * (1 - e[3]), "r"];
+            }
+          } else {
+            var r = parseFloat(e[0]);
+            e = [r, r, r, "r"];
+          }
+          for (var n = "#", i = 0; i < 3; i++) n += ("0" + Math.floor(255 * parseFloat(e[i])).toString(16)).slice(-2);
+          return n;
+        },
+        re = y.__private__.encodeColorString = function (t) {
+          var r;
+          "string" == typeof t && (t = {
+            ch1: t
+          });
+          var n = t.ch1,
+            i = t.ch2,
+            a = t.ch3,
+            o = t.ch4,
+            s = "draw" === t.pdfColorType ? ["G", "RG", "K"] : ["g", "rg", "k"];
+          if ("string" == typeof n && "#" !== n.charAt(0)) {
+            var c = new h(n);
+            if (c.ok) n = c.toHex();else if (!/^\d*\.?\d*$/.test(n)) throw new Error('Invalid color "' + n + '" passed to jsPDF.encodeColorString.');
+          }
+          if ("string" == typeof n && /^#[0-9A-Fa-f]{3}$/.test(n) && (n = "#" + n[1] + n[1] + n[2] + n[2] + n[3] + n[3]), "string" == typeof n && /^#[0-9A-Fa-f]{6}$/.test(n)) {
+            var u = parseInt(n.substr(1), 16);
+            n = u >> 16 & 255, i = u >> 8 & 255, a = 255 & u;
+          }
+          if (void 0 === i || void 0 === o && n === i && i === a) {
+            if ("string" == typeof n) r = n + " " + s[0];else switch (t.precision) {
+              case 2:
+                r = R(n / 255) + " " + s[0];
+                break;
+              case 3:
+              default:
+                r = T(n / 255) + " " + s[0];
+            }
+          } else if (void 0 === o || "object" === e(o)) {
+            if (o && !isNaN(o.a) && 0 === o.a) return r = ["1.", "1.", "1.", s[1]].join(" ");
+            if ("string" == typeof n) r = [n, i, a, s[1]].join(" ");else switch (t.precision) {
+              case 2:
+                r = [R(n / 255), R(i / 255), R(a / 255), s[1]].join(" ");
+                break;
+              default:
+              case 3:
+                r = [T(n / 255), T(i / 255), T(a / 255), s[1]].join(" ");
+            }
+          } else if ("string" == typeof n) r = [n, i, a, o, s[2]].join(" ");else switch (t.precision) {
+            case 2:
+              r = [R(n), R(i), R(a), R(o), s[2]].join(" ");
+              break;
+            case 3:
+            default:
+              r = [T(n), T(i), T(a), T(o), s[2]].join(" ");
+          }
+          return r;
+        },
+        ne = y.__private__.getFilters = function () {
+          return f;
+        },
+        ie = y.__private__.putStream = function (t) {
+          var e = (t = t || {}).data || "",
+            r = t.filters || ne(),
+            n = t.alreadyAppliedFilters || [],
+            i = t.addLength1 || !1,
+            a = e.length,
+            o = t.objectId,
+            s = function s(t) {
+              return t;
+            };
+          if (null !== m && void 0 === o) throw new Error("ObjectId must be passed to putStream for file encryption");
+          null !== m && (s = Ye.encryptor(o, 0));
+          var c = {};
+          !0 === r && (r = ["FlateEncode"]);
+          var u = t.additionalKeyValues || [],
+            l = (c = void 0 !== M.API.processDataByFilters ? M.API.processDataByFilters(e, r) : {
+              data: e,
+              reverseChain: []
+            }).reverseChain + (Array.isArray(n) ? n.join(" ") : n.toString());
+          if (0 !== c.data.length && (u.push({
+            key: "Length",
+            value: c.data.length
+          }), !0 === i && u.push({
+            key: "Length1",
+            value: a
+          })), 0 != l.length) if (l.split("/").length - 1 == 1) u.push({
+            key: "Filter",
+            value: l
+          });else {
+            u.push({
+              key: "Filter",
+              value: "[" + l + "]"
+            });
+            for (var h = 0; h < u.length; h += 1) if ("DecodeParms" === u[h].key) {
+              for (var f = [], d = 0; d < c.reverseChain.split("/").length - 1; d += 1) f.push("null");
+              f.push(u[h].value), u[h].value = "[" + f.join(" ") + "]";
+            }
+          }
+          ht("<<");
+          for (var p = 0; p < u.length; p++) ht("/" + u[p].key + " " + u[p].value);
+          ht(">>"), 0 !== c.data.length && (ht("stream"), ht(s(c.data)), ht("endstream"));
+        },
+        ae = y.__private__.putPage = function (t) {
+          var e = t.number,
+            r = t.data,
+            n = t.objId,
+            i = t.contentsObjId;
+          Zt(n, !0), ht("<</Type /Page"), ht("/Parent " + t.rootDictionaryObjId + " 0 R"), ht("/Resources " + t.resourceDictionaryObjId + " 0 R"), ht("/MediaBox [" + parseFloat(E(t.mediaBox.bottomLeftX)) + " " + parseFloat(E(t.mediaBox.bottomLeftY)) + " " + E(t.mediaBox.topRightX) + " " + E(t.mediaBox.topRightY) + "]"), null !== t.cropBox && ht("/CropBox [" + E(t.cropBox.bottomLeftX) + " " + E(t.cropBox.bottomLeftY) + " " + E(t.cropBox.topRightX) + " " + E(t.cropBox.topRightY) + "]"), null !== t.bleedBox && ht("/BleedBox [" + E(t.bleedBox.bottomLeftX) + " " + E(t.bleedBox.bottomLeftY) + " " + E(t.bleedBox.topRightX) + " " + E(t.bleedBox.topRightY) + "]"), null !== t.trimBox && ht("/TrimBox [" + E(t.trimBox.bottomLeftX) + " " + E(t.trimBox.bottomLeftY) + " " + E(t.trimBox.topRightX) + " " + E(t.trimBox.topRightY) + "]"), null !== t.artBox && ht("/ArtBox [" + E(t.artBox.bottomLeftX) + " " + E(t.artBox.bottomLeftY) + " " + E(t.artBox.topRightX) + " " + E(t.artBox.topRightY) + "]"), "number" == typeof t.userUnit && 1 !== t.userUnit && ht("/UserUnit " + t.userUnit), Tt.publish("putPage", {
+            objId: n,
+            pageContext: Rt[e],
+            pageNumber: e,
+            page: r
+          }), ht("/Contents " + i + " 0 R"), ht(">>"), ht("endobj");
+          var a = r.join("\n");
+          return S === x.ADVANCED && (a += "\nQ"), Zt(i, !0), ie({
+            data: a,
+            filters: ne(),
+            objectId: i
+          }), ht("endobj"), n;
+        },
+        oe = y.__private__.putPages = function () {
+          var t,
+            e,
+            r = [];
+          for (t = 1; t <= Dt; t++) Rt[t].objId = Kt(), Rt[t].contentsObjId = Kt();
+          for (t = 1; t <= Dt; t++) r.push(ae({
+            number: t,
+            data: ot[t],
+            objId: Rt[t].objId,
+            contentsObjId: Rt[t].contentsObjId,
+            mediaBox: Rt[t].mediaBox,
+            cropBox: Rt[t].cropBox,
+            bleedBox: Rt[t].bleedBox,
+            trimBox: Rt[t].trimBox,
+            artBox: Rt[t].artBox,
+            userUnit: Rt[t].userUnit,
+            rootDictionaryObjId: Qt,
+            resourceDictionaryObjId: te
+          }));
+          Zt(Qt, !0), ht("<</Type /Pages");
+          var n = "/Kids [";
+          for (e = 0; e < Dt; e++) n += r[e] + " 0 R ";
+          ht(n + "]"), ht("/Count " + Dt), ht(">>"), ht("endobj"), Tt.publish("postPutPages");
+        },
+        se = function se(t) {
+          Tt.publish("putFont", {
+            font: t,
+            out: ht,
+            newObject: Xt,
+            putStream: ie
+          }), !0 !== t.isAlreadyPutted && (t.objectNumber = Xt(), ht("<<"), ht("/Type /Font"), ht("/BaseFont /" + F(t.postScriptName)), ht("/Subtype /Type1"), "string" == typeof t.encoding && ht("/Encoding /" + t.encoding), ht("/FirstChar 32"), ht("/LastChar 255"), ht(">>"), ht("endobj"));
+        },
+        ce = function ce() {
+          for (var t in It) It.hasOwnProperty(t) && (!1 === v || !0 === v && b.hasOwnProperty(t)) && se(It[t]);
+        },
+        ue = function ue(t) {
+          t.objectNumber = Xt();
+          var e = [];
+          e.push({
+            key: "Type",
+            value: "/XObject"
+          }), e.push({
+            key: "Subtype",
+            value: "/Form"
+          }), e.push({
+            key: "BBox",
+            value: "[" + [E(t.x), E(t.y), E(t.x + t.width), E(t.y + t.height)].join(" ") + "]"
+          }), e.push({
+            key: "Matrix",
+            value: "[" + t.matrix.toString() + "]"
+          });
+          var r = t.pages[1].join("\n");
+          ie({
+            data: r,
+            additionalKeyValues: e,
+            objectId: t.objectNumber
+          }), ht("endobj");
+        },
+        le = function le() {
+          for (var t in zt) zt.hasOwnProperty(t) && ue(zt[t]);
+        },
+        he = function he(t, e) {
+          var r,
+            n = [],
+            i = 1 / (e - 1);
+          for (r = 0; r < 1; r += i) n.push(r);
+          if (n.push(1), 0 != t[0].offset) {
+            var a = {
+              offset: 0,
+              color: t[0].color
+            };
+            t.unshift(a);
+          }
+          if (1 != t[t.length - 1].offset) {
+            var o = {
+              offset: 1,
+              color: t[t.length - 1].color
+            };
+            t.push(o);
+          }
+          for (var s = "", c = 0, u = 0; u < n.length; u++) {
+            for (r = n[u]; r > t[c + 1].offset;) c++;
+            var l = t[c].offset,
+              h = (r - l) / (t[c + 1].offset - l),
+              f = t[c].color,
+              d = t[c + 1].color;
+            s += tt(Math.round((1 - h) * f[0] + h * d[0]).toString(16)) + tt(Math.round((1 - h) * f[1] + h * d[1]).toString(16)) + tt(Math.round((1 - h) * f[2] + h * d[2]).toString(16));
+          }
+          return s.trim();
+        },
+        fe = function fe(t, e) {
+          e || (e = 21);
+          var r = Xt(),
+            n = he(t.colors, e),
+            i = [];
+          i.push({
+            key: "FunctionType",
+            value: "0"
+          }), i.push({
+            key: "Domain",
+            value: "[0.0 1.0]"
+          }), i.push({
+            key: "Size",
+            value: "[" + e + "]"
+          }), i.push({
+            key: "BitsPerSample",
+            value: "8"
+          }), i.push({
+            key: "Range",
+            value: "[0.0 1.0 0.0 1.0 0.0 1.0]"
+          }), i.push({
+            key: "Decode",
+            value: "[0.0 1.0 0.0 1.0 0.0 1.0]"
+          }), ie({
+            data: n,
+            additionalKeyValues: i,
+            alreadyAppliedFilters: ["/ASCIIHexDecode"],
+            objectId: r
+          }), ht("endobj"), t.objectNumber = Xt(), ht("<< /ShadingType " + t.type), ht("/ColorSpace /DeviceRGB");
+          var a = "/Coords [" + E(parseFloat(t.coords[0])) + " " + E(parseFloat(t.coords[1])) + " ";
+          2 === t.type ? a += E(parseFloat(t.coords[2])) + " " + E(parseFloat(t.coords[3])) : a += E(parseFloat(t.coords[2])) + " " + E(parseFloat(t.coords[3])) + " " + E(parseFloat(t.coords[4])) + " " + E(parseFloat(t.coords[5])), ht(a += "]"), t.matrix && ht("/Matrix [" + t.matrix.toString() + "]"), ht("/Function " + r + " 0 R"), ht("/Extend [true true]"), ht(">>"), ht("endobj");
+        },
+        de = function de(t, e) {
+          var r = Kt(),
+            n = Xt();
+          e.push({
+            resourcesOid: r,
+            objectOid: n
+          }), t.objectNumber = n;
+          var i = [];
+          i.push({
+            key: "Type",
+            value: "/Pattern"
+          }), i.push({
+            key: "PatternType",
+            value: "1"
+          }), i.push({
+            key: "PaintType",
+            value: "1"
+          }), i.push({
+            key: "TilingType",
+            value: "1"
+          }), i.push({
+            key: "BBox",
+            value: "[" + t.boundingBox.map(E).join(" ") + "]"
+          }), i.push({
+            key: "XStep",
+            value: E(t.xStep)
+          }), i.push({
+            key: "YStep",
+            value: E(t.yStep)
+          }), i.push({
+            key: "Resources",
+            value: r + " 0 R"
+          }), t.matrix && i.push({
+            key: "Matrix",
+            value: "[" + t.matrix.toString() + "]"
+          }), ie({
+            data: t.stream,
+            additionalKeyValues: i,
+            objectId: t.objectNumber
+          }), ht("endobj");
+        },
+        pe = function pe(t) {
+          var e;
+          for (e in Ot) Ot.hasOwnProperty(e) && (Ot[e] instanceof O ? fe(Ot[e]) : Ot[e] instanceof B && de(Ot[e], t));
+        },
+        ge = function ge(t) {
+          for (var e in t.objectNumber = Xt(), ht("<<"), t) switch (e) {
+            case "opacity":
+              ht("/ca " + R(t[e]));
+              break;
+            case "stroke-opacity":
+              ht("/CA " + R(t[e]));
+          }
+          ht(">>"), ht("endobj");
+        },
+        me = function me() {
+          var t;
+          for (t in Mt) Mt.hasOwnProperty(t) && ge(Mt[t]);
+        },
+        ve = function ve() {
+          for (var t in ht("/XObject <<"), zt) zt.hasOwnProperty(t) && zt[t].objectNumber >= 0 && ht("/" + t + " " + zt[t].objectNumber + " 0 R");
+          Tt.publish("putXobjectDict"), ht(">>");
+        },
+        be = function be() {
+          Ye.oid = Xt(), ht("<<"), ht("/Filter /Standard"), ht("/V " + Ye.v), ht("/R " + Ye.r), ht("/U <" + Ye.toHexString(Ye.U) + ">"), ht("/O <" + Ye.toHexString(Ye.O) + ">"), ht("/P " + Ye.P), ht(">>"), ht("endobj");
+        },
+        ye = function ye() {
+          for (var t in ht("/Font <<"), It) It.hasOwnProperty(t) && (!1 === v || !0 === v && b.hasOwnProperty(t)) && ht("/" + t + " " + It[t].objectNumber + " 0 R");
+          ht(">>");
+        },
+        we = function we() {
+          if (Object.keys(Ot).length > 0) {
+            for (var t in ht("/Shading <<"), Ot) Ot.hasOwnProperty(t) && Ot[t] instanceof O && Ot[t].objectNumber >= 0 && ht("/" + t + " " + Ot[t].objectNumber + " 0 R");
+            Tt.publish("putShadingPatternDict"), ht(">>");
+          }
+        },
+        Ne = function Ne(t) {
+          if (Object.keys(Ot).length > 0) {
+            for (var e in ht("/Pattern <<"), Ot) Ot.hasOwnProperty(e) && Ot[e] instanceof y.TilingPattern && Ot[e].objectNumber >= 0 && Ot[e].objectNumber < t && ht("/" + e + " " + Ot[e].objectNumber + " 0 R");
+            Tt.publish("putTilingPatternDict"), ht(">>");
+          }
+        },
+        Le = function Le() {
+          if (Object.keys(Mt).length > 0) {
+            var t;
+            for (t in ht("/ExtGState <<"), Mt) Mt.hasOwnProperty(t) && Mt[t].objectNumber >= 0 && ht("/" + t + " " + Mt[t].objectNumber + " 0 R");
+            Tt.publish("putGStateDict"), ht(">>");
+          }
+        },
+        Ae = function Ae(t) {
+          Zt(t.resourcesOid, !0), ht("<<"), ht("/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]"), ye(), we(), Ne(t.objectOid), Le(), ve(), ht(">>"), ht("endobj");
+        },
+        xe = function xe() {
+          var t = [];
+          ce(), me(), le(), pe(t), Tt.publish("putResources"), t.forEach(Ae), Ae({
+            resourcesOid: te,
+            objectOid: Number.MAX_SAFE_INTEGER
+          }), Tt.publish("postPutResources");
+        },
+        Se = function Se() {
+          Tt.publish("putAdditionalObjects");
+          for (var t = 0; t < at.length; t++) {
+            var e = at[t];
+            Zt(e.objId, !0), ht(e.content), ht("endobj");
+          }
+          Tt.publish("postPutAdditionalObjects");
+        },
+        _e = function _e(t) {
+          Ct[t.fontName] = Ct[t.fontName] || {}, Ct[t.fontName][t.fontStyle] = t.id;
+        },
+        Pe = function Pe(t, e, r, n, i) {
+          var a = {
+            id: "F" + (Object.keys(It).length + 1).toString(10),
+            postScriptName: t,
+            fontName: e,
+            fontStyle: r,
+            encoding: n,
+            isStandardFont: i || !1,
+            metadata: {}
+          };
+          return Tt.publish("addFont", {
+            font: a,
+            instance: this
+          }), It[a.id] = a, _e(a), a.id;
+        },
+        ke = function ke(t) {
+          for (var e = 0, r = pt.length; e < r; e++) {
+            var n = Pe.call(this, t[e][0], t[e][1], t[e][2], pt[e][3], !0);
+            !1 === v && (b[n] = !0);
+            var i = t[e][0].split("-");
+            _e({
+              id: n,
+              fontName: i[0],
+              fontStyle: i[1] || ""
+            });
+          }
+          Tt.publish("addFonts", {
+            fonts: It,
+            dictionary: Ct
+          });
+        },
+        Fe = function Fe(t) {
+          return t.foo = function () {
+            try {
+              return t.apply(this, arguments);
+            } catch (t) {
+              var e = t.stack || "";
+              ~e.indexOf(" at ") && (e = e.split(" at ")[1]);
+              var n = "Error in function " + e.split("\n")[0].split("<")[0] + ": " + t.message;
+              if (!r.console) throw new Error(n);
+              r.console.error(n, t), r.alert && alert(n);
+            }
+          }, t.foo.bar = t, t.foo;
+        },
+        Ie = function Ie(t, e) {
+          var r, n, i, a, o, s, c, u, l;
+          if (i = (e = e || {}).sourceEncoding || "Unicode", o = e.outputEncoding, (e.autoencode || o) && It[St].metadata && It[St].metadata[i] && It[St].metadata[i].encoding && (a = It[St].metadata[i].encoding, !o && It[St].encoding && (o = It[St].encoding), !o && a.codePages && (o = a.codePages[0]), "string" == typeof o && (o = a[o]), o)) {
+            for (c = !1, s = [], r = 0, n = t.length; r < n; r++) (u = o[t.charCodeAt(r)]) ? s.push(String.fromCharCode(u)) : s.push(t[r]), s[r].charCodeAt(0) >> 8 && (c = !0);
+            t = s.join("");
+          }
+          for (r = t.length; void 0 === c && 0 !== r;) t.charCodeAt(r - 1) >> 8 && (c = !0), r--;
+          if (!c) return t;
+          for (s = e.noBOM ? [] : [254, 255], r = 0, n = t.length; r < n; r++) {
+            if ((l = (u = t.charCodeAt(r)) >> 8) >> 8) throw new Error("Character at position " + r + " of string '" + t + "' exceeds 16bits. Cannot be encoded into UCS-2 BE");
+            s.push(l), s.push(u - (l << 8));
+          }
+          return String.fromCharCode.apply(void 0, s);
+        },
+        Ce = y.__private__.pdfEscape = y.pdfEscape = function (t, e) {
+          return Ie(t, e).replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+        },
+        je = y.__private__.beginPage = function (t) {
+          ot[++Dt] = [], Rt[Dt] = {
+            objId: 0,
+            contentsObjId: 0,
+            userUnit: Number(d),
+            artBox: null,
+            bleedBox: null,
+            cropBox: null,
+            trimBox: null,
+            mediaBox: {
+              bottomLeftX: 0,
+              bottomLeftY: 0,
+              topRightX: Number(t[0]),
+              topRightY: Number(t[1])
+            }
+          }, Me(Dt), lt(ot[$]);
+        },
+        Oe = function Oe(t, e) {
+          var r, n, o;
+          switch (a = e || a, "string" == typeof t && (r = A(t.toLowerCase()), Array.isArray(r) && (n = r[0], o = r[1])), Array.isArray(t) && (n = t[0] * _t, o = t[1] * _t), isNaN(n) && (n = s[0], o = s[1]), (n > 14400 || o > 14400) && (i.warn("A page in a PDF can not be wider or taller than 14400 userUnit. jsPDF limits the width/height to 14400"), n = Math.min(14400, n), o = Math.min(14400, o)), s = [n, o], a.substr(0, 1)) {
+            case "l":
+              o > n && (s = [o, n]);
+              break;
+            case "p":
+              n > o && (s = [o, n]);
+          }
+          je(s), pr(fr), ht(Lr), 0 !== kr && ht(kr + " J"), 0 !== Fr && ht(Fr + " j"), Tt.publish("addPage", {
+            pageNumber: Dt
+          });
+        },
+        Be = function Be(t) {
+          t > 0 && t <= Dt && (ot.splice(t, 1), Rt.splice(t, 1), Dt--, $ > Dt && ($ = Dt), this.setPage($));
+        },
+        Me = function Me(t) {
+          t > 0 && t <= Dt && ($ = t);
+        },
+        Ee = y.__private__.getNumberOfPages = y.getNumberOfPages = function () {
+          return ot.length - 1;
+        },
+        qe = function qe(t, e, r) {
+          var n,
+            a = void 0;
+          return r = r || {}, t = void 0 !== t ? t : It[St].fontName, e = void 0 !== e ? e : It[St].fontStyle, n = t.toLowerCase(), void 0 !== Ct[n] && void 0 !== Ct[n][e] ? a = Ct[n][e] : void 0 !== Ct[t] && void 0 !== Ct[t][e] ? a = Ct[t][e] : !1 === r.disableWarning && i.warn("Unable to look up font label for font '" + t + "', '" + e + "'. Refer to getFontList() for available fonts."), a || r.noFallback || null == (a = Ct.times[e]) && (a = Ct.times.normal), a;
+        },
+        De = y.__private__.putInfo = function () {
+          var t = Xt(),
+            e = function e(t) {
+              return t;
+            };
+          for (var r in null !== m && (e = Ye.encryptor(t, 0)), ht("<<"), ht("/Producer (" + Ce(e("jsPDF " + M.version)) + ")"), xt) xt.hasOwnProperty(r) && xt[r] && ht("/" + r.substr(0, 1).toUpperCase() + r.substr(1) + " (" + Ce(e(xt[r])) + ")");
+          ht("/CreationDate (" + Ce(e(W)) + ")"), ht(">>"), ht("endobj");
+        },
+        Re = y.__private__.putCatalog = function (t) {
+          var e = (t = t || {}).rootDictionaryObjId || Qt;
+          switch (Xt(), ht("<<"), ht("/Type /Catalog"), ht("/Pages " + e + " 0 R"), mt || (mt = "fullwidth"), mt) {
+            case "fullwidth":
+              ht("/OpenAction [3 0 R /FitH null]");
+              break;
+            case "fullheight":
+              ht("/OpenAction [3 0 R /FitV null]");
+              break;
+            case "fullpage":
+              ht("/OpenAction [3 0 R /Fit]");
+              break;
+            case "original":
+              ht("/OpenAction [3 0 R /XYZ null null 1]");
+              break;
+            default:
+              var r = "" + mt;
+              "%" === r.substr(r.length - 1) && (mt = parseInt(mt) / 100), "number" == typeof mt && ht("/OpenAction [3 0 R /XYZ null null " + R(mt) + "]");
+          }
+          switch (Nt || (Nt = "continuous"), Nt) {
+            case "continuous":
+              ht("/PageLayout /OneColumn");
+              break;
+            case "single":
+              ht("/PageLayout /SinglePage");
+              break;
+            case "two":
+            case "twoleft":
+              ht("/PageLayout /TwoColumnLeft");
+              break;
+            case "tworight":
+              ht("/PageLayout /TwoColumnRight");
+          }
+          yt && ht("/PageMode /" + yt), Tt.publish("putCatalog"), ht(">>"), ht("endobj");
+        },
+        Te = y.__private__.putTrailer = function () {
+          ht("trailer"), ht("<<"), ht("/Size " + (et + 1)), ht("/Root " + et + " 0 R"), ht("/Info " + (et - 1) + " 0 R"), null !== m && ht("/Encrypt " + Ye.oid + " 0 R"), ht("/ID [ <" + V + "> <" + V + "> ]"), ht(">>");
+        },
+        Ue = y.__private__.putHeader = function () {
+          ht("%PDF-" + w), ht("%ºß¬à");
+        },
+        ze = y.__private__.putXRef = function () {
+          var t = "0000000000";
+          ht("xref"), ht("0 " + (et + 1)), ht("0000000000 65535 f ");
+          for (var e = 1; e <= et; e++) {
+            "function" == typeof rt[e] ? ht((t + rt[e]()).slice(-10) + " 00000 n ") : void 0 !== rt[e] ? ht((t + rt[e]).slice(-10) + " 00000 n ") : ht("0000000000 00000 n ");
+          }
+        },
+        He = y.__private__.buildDocument = function () {
+          ut(), lt(nt), Tt.publish("buildDocument"), Ue(), oe(), Se(), xe(), null !== m && be(), De(), Re();
+          var t = it;
+          return ze(), Te(), ht("startxref"), ht("" + t), ht("%%EOF"), lt(ot[$]), nt.join("\n");
+        },
+        We = y.__private__.getBlob = function (t) {
+          return new Blob([dt(t)], {
+            type: "application/pdf"
+          });
+        },
+        Ve = y.output = y.__private__.output = Fe(function (t, e) {
+          switch ("string" == typeof (e = e || {}) ? e = {
+            filename: e
+          } : e.filename = e.filename || "generated.pdf", t) {
+            case void 0:
+              return He();
+            case "save":
+              y.save(e.filename);
+              break;
+            case "arraybuffer":
+              return dt(He());
+            case "blob":
+              return We(He());
+            case "bloburi":
+            case "bloburl":
+              if (void 0 !== r.URL && "function" == typeof r.URL.createObjectURL) return r.URL && r.URL.createObjectURL(We(He())) || void 0;
+              i.warn("bloburl is not supported by your system, because URL.createObjectURL is not supported by your browser.");
+              break;
+            case "datauristring":
+            case "dataurlstring":
+              var n = "",
+                a = He();
+              try {
+                n = u(a);
+              } catch (t) {
+                n = u(unescape(encodeURIComponent(a)));
+              }
+              return "data:application/pdf;filename=" + e.filename + ";base64," + n;
+            case "pdfobjectnewwindow":
+              if ("[object Window]" === Object.prototype.toString.call(r)) {
+                var o = "https://cdnjs.cloudflare.com/ajax/libs/pdfobject/2.1.1/pdfobject.min.js",
+                  s = ' integrity="sha512-4ze/a9/4jqu+tX9dfOqJYSvyYd5M6qum/3HpCLr+/Jqf0whc37VUbkpNGHR7/8pSnCFw47T1fmIpwBV7UySh3g==" crossorigin="anonymous"';
+                e.pdfObjectUrl && (o = e.pdfObjectUrl, s = "");
+                var c = '<html><style>html, body { padding: 0; margin: 0; } iframe { width: 100%; height: 100%; border: 0;}  </style><body><script src="' + o + '"' + s + '><\/script><script >PDFObject.embed("' + this.output("dataurlstring") + '", ' + JSON.stringify(e) + ");<\/script></body></html>",
+                  l = r.open();
+                return null !== l && l.document.write(c), l;
+              }
+              throw new Error("The option pdfobjectnewwindow just works in a browser-environment.");
+            case "pdfjsnewwindow":
+              if ("[object Window]" === Object.prototype.toString.call(r)) {
+                var h = '<html><style>html, body { padding: 0; margin: 0; } iframe { width: 100%; height: 100%; border: 0;}  </style><body><iframe id="pdfViewer" src="' + (e.pdfJsUrl || "examples/PDF.js/web/viewer.html") + "?file=&downloadName=" + e.filename + '" width="500px" height="400px" /></body></html>',
+                  f = r.open();
+                if (null !== f) {
+                  f.document.write(h);
+                  var d = this;
+                  f.document.documentElement.querySelector("#pdfViewer").onload = function () {
+                    f.document.title = e.filename, f.document.documentElement.querySelector("#pdfViewer").contentWindow.PDFViewerApplication.open(d.output("bloburl"));
+                  };
+                }
+                return f;
+              }
+              throw new Error("The option pdfjsnewwindow just works in a browser-environment.");
+            case "dataurlnewwindow":
+              if ("[object Window]" !== Object.prototype.toString.call(r)) throw new Error("The option dataurlnewwindow just works in a browser-environment.");
+              var p = '<html><style>html, body { padding: 0; margin: 0; } iframe { width: 100%; height: 100%; border: 0;}  </style><body><iframe src="' + this.output("datauristring", e) + '"></iframe></body></html>',
+                g = r.open();
+              if (null !== g && (g.document.write(p), g.document.title = e.filename), g || "undefined" == typeof safari) return g;
+              break;
+            case "datauri":
+            case "dataurl":
+              return r.document.location.href = this.output("datauristring", e);
+            default:
+              return null;
+          }
+        }),
+        Ge = function Ge(t) {
+          return !0 === Array.isArray(Ut) && Ut.indexOf(t) > -1;
+        };
+      switch (o) {
+        case "pt":
+          _t = 1;
+          break;
+        case "mm":
+          _t = 72 / 25.4;
+          break;
+        case "cm":
+          _t = 72 / 2.54;
+          break;
+        case "in":
+          _t = 72;
+          break;
+        case "px":
+          _t = 1 == Ge("px_scaling") ? .75 : 96 / 72;
+          break;
+        case "pc":
+        case "em":
+          _t = 12;
+          break;
+        case "ex":
+          _t = 6;
+          break;
+        default:
+          if ("number" != typeof o) throw new Error("Invalid unit: " + o);
+          _t = o;
+      }
+      var Ye = null;
+      K(), Y();
+      var Je = function Je(t) {
+          return null !== m ? Ye.encryptor(t, 0) : function (t) {
+            return t;
+          };
+        },
+        Xe = y.__private__.getPageInfo = y.getPageInfo = function (t) {
+          if (isNaN(t) || t % 1 != 0) throw new Error("Invalid argument passed to jsPDF.getPageInfo");
+          return {
+            objId: Rt[t].objId,
+            pageNumber: t,
+            pageContext: Rt[t]
+          };
+        },
+        Ke = y.__private__.getPageInfoByObjId = function (t) {
+          if (isNaN(t) || t % 1 != 0) throw new Error("Invalid argument passed to jsPDF.getPageInfoByObjId");
+          for (var e in Rt) if (Rt[e].objId === t) break;
+          return Xe(e);
+        },
+        Ze = y.__private__.getCurrentPageInfo = y.getCurrentPageInfo = function () {
+          return {
+            objId: Rt[$].objId,
+            pageNumber: $,
+            pageContext: Rt[$]
+          };
+        };
+      y.addPage = function () {
+        return Oe.apply(this, arguments), this;
+      }, y.setPage = function () {
+        return Me.apply(this, arguments), lt.call(this, ot[$]), this;
+      }, y.insertPage = function (t) {
+        return this.addPage(), this.movePage($, t), this;
+      }, y.movePage = function (t, e) {
+        var r, n;
+        if (t > e) {
+          r = ot[t], n = Rt[t];
+          for (var i = t; i > e; i--) ot[i] = ot[i - 1], Rt[i] = Rt[i - 1];
+          ot[e] = r, Rt[e] = n, this.setPage(e);
+        } else if (t < e) {
+          r = ot[t], n = Rt[t];
+          for (var a = t; a < e; a++) ot[a] = ot[a + 1], Rt[a] = Rt[a + 1];
+          ot[e] = r, Rt[e] = n, this.setPage(e);
+        }
+        return this;
+      }, y.deletePage = function () {
+        return Be.apply(this, arguments), this;
+      }, y.__private__.text = y.text = function (t, r, n, i, a) {
+        var o,
+          s,
+          c,
+          u,
+          l,
+          h,
+          f,
+          d,
+          p,
+          g = (i = i || {}).scope || this;
+        if ("number" == typeof t && "number" == typeof r && ("string" == typeof n || Array.isArray(n))) {
+          var m = n;
+          n = r, r = t, t = m;
+        }
+        if (arguments[3] instanceof Vt == !1 ? (c = arguments[4], u = arguments[5], "object" === e(f = arguments[3]) && null !== f || ("string" == typeof c && (u = c, c = null), "string" == typeof f && (u = f, f = null), "number" == typeof f && (c = f, f = null), i = {
+          flags: f,
+          angle: c,
+          align: u
+        })) : (q("The transform parameter of text() with a Matrix value"), p = a), isNaN(r) || isNaN(n) || null == t) throw new Error("Invalid arguments passed to jsPDF.text");
+        if (0 === t.length) return g;
+        var v = "",
+          y = !1,
+          w = "number" == typeof i.lineHeightFactor ? i.lineHeightFactor : hr,
+          N = g.internal.scaleFactor;
+        function L(t) {
+          return t = t.split("\t").join(Array(i.TabLen || 9).join(" ")), Ce(t, f);
+        }
+        function A(t) {
+          for (var e, r = t.concat(), n = [], i = r.length; i--;) "string" == typeof (e = r.shift()) ? n.push(e) : Array.isArray(t) && (1 === e.length || void 0 === e[1] && void 0 === e[2]) ? n.push(e[0]) : n.push([e[0], e[1], e[2]]);
+          return n;
+        }
+        function _(t, e) {
+          var r;
+          if ("string" == typeof t) r = e(t)[0];else if (Array.isArray(t)) {
+            for (var n, i, a = t.concat(), o = [], s = a.length; s--;) "string" == typeof (n = a.shift()) ? o.push(e(n)[0]) : Array.isArray(n) && "string" == typeof n[0] && (i = e(n[0], n[1], n[2]), o.push([i[0], i[1], i[2]]));
+            r = o;
+          }
+          return r;
+        }
+        var P = !1,
+          k = !0;
+        if ("string" == typeof t) P = !0;else if (Array.isArray(t)) {
+          var F = t.concat();
+          s = [];
+          for (var I, C = F.length; C--;) ("string" != typeof (I = F.shift()) || Array.isArray(I) && "string" != typeof I[0]) && (k = !1);
+          P = k;
+        }
+        if (!1 === P) throw new Error('Type of text must be string or Array. "' + t + '" is not recognized.');
+        "string" == typeof t && (t = t.match(/[\r?\n]/) ? t.split(/\r\n|\r|\n/g) : [t]);
+        var j = gt / g.internal.scaleFactor,
+          O = j * (w - 1);
+        switch (i.baseline) {
+          case "bottom":
+            n -= O;
+            break;
+          case "top":
+            n += j - O;
+            break;
+          case "hanging":
+            n += j - 2 * O;
+            break;
+          case "middle":
+            n += j / 2 - O;
+        }
+        if ((h = i.maxWidth || 0) > 0 && ("string" == typeof t ? t = g.splitTextToSize(t, h) : "[object Array]" === Object.prototype.toString.call(t) && (t = t.reduce(function (t, e) {
+          return t.concat(g.splitTextToSize(e, h));
+        }, []))), o = {
+          text: t,
+          x: r,
+          y: n,
+          options: i,
+          mutex: {
+            pdfEscape: Ce,
+            activeFontKey: St,
+            fonts: It,
+            activeFontSize: gt
+          }
+        }, Tt.publish("preProcessText", o), t = o.text, c = (i = o.options).angle, p instanceof Vt == !1 && c && "number" == typeof c) {
+          c *= Math.PI / 180, 0 === i.rotationDirection && (c = -c), S === x.ADVANCED && (c = -c);
+          var B = Math.cos(c),
+            M = Math.sin(c);
+          p = new Vt(B, M, -M, B, 0, 0);
+        } else c && c instanceof Vt && (p = c);
+        S !== x.ADVANCED || p || (p = Yt), void 0 !== (l = i.charSpace || _r) && (v += E(U(l)) + " Tc\n", this.setCharSpace(this.getCharSpace() || 0)), void 0 !== (d = i.horizontalScale) && (v += E(100 * d) + " Tz\n");
+        i.lang;
+        var D = -1,
+          R = void 0 !== i.renderingMode ? i.renderingMode : i.stroke,
+          T = g.internal.getCurrentPageInfo().pageContext;
+        switch (R) {
+          case 0:
+          case !1:
+          case "fill":
+            D = 0;
+            break;
+          case 1:
+          case !0:
+          case "stroke":
+            D = 1;
+            break;
+          case 2:
+          case "fillThenStroke":
+            D = 2;
+            break;
+          case 3:
+          case "invisible":
+            D = 3;
+            break;
+          case 4:
+          case "fillAndAddForClipping":
+            D = 4;
+            break;
+          case 5:
+          case "strokeAndAddPathForClipping":
+            D = 5;
+            break;
+          case 6:
+          case "fillThenStrokeAndAddToPathForClipping":
+            D = 6;
+            break;
+          case 7:
+          case "addToPathForClipping":
+            D = 7;
+        }
+        var z = void 0 !== T.usedRenderingMode ? T.usedRenderingMode : -1;
+        -1 !== D ? v += D + " Tr\n" : -1 !== z && (v += "0 Tr\n"), -1 !== D && (T.usedRenderingMode = D), u = i.align || "left";
+        var H,
+          W = gt * w,
+          V = g.internal.pageSize.getWidth(),
+          G = It[St];
+        l = i.charSpace || _r, h = i.maxWidth || 0, f = Object.assign({
+          autoencode: !0,
+          noBOM: !0
+        }, i.flags);
+        var Y = [],
+          J = function J(t) {
+            return g.getStringUnitWidth(t, {
+              font: G,
+              charSpace: l,
+              fontSize: gt,
+              doKerning: !1
+            }) * gt / N;
+          };
+        if ("[object Array]" === Object.prototype.toString.call(t)) {
+          var X;
+          s = A(t), "left" !== u && (H = s.map(J));
+          var K,
+            Z = 0;
+          if ("right" === u) {
+            r -= H[0], t = [], C = s.length;
+            for (var $ = 0; $ < C; $++) 0 === $ ? (K = br(r), X = yr(n)) : (K = U(Z - H[$]), X = -W), t.push([s[$], K, X]), Z = H[$];
+          } else if ("center" === u) {
+            r -= H[0] / 2, t = [], C = s.length;
+            for (var Q = 0; Q < C; Q++) 0 === Q ? (K = br(r), X = yr(n)) : (K = U((Z - H[Q]) / 2), X = -W), t.push([s[Q], K, X]), Z = H[Q];
+          } else if ("left" === u) {
+            t = [], C = s.length;
+            for (var tt = 0; tt < C; tt++) t.push(s[tt]);
+          } else if ("justify" === u && "Identity-H" === G.encoding) {
+            t = [], C = s.length, h = 0 !== h ? h : V;
+            for (var et = 0, rt = 0; rt < C; rt++) if (X = 0 === rt ? yr(n) : -W, K = 0 === rt ? br(r) : et, rt < C - 1) {
+              var nt = U((h - H[rt]) / (s[rt].split(" ").length - 1)),
+                it = s[rt].split(" ");
+              t.push([it[0] + " ", K, X]), et = 0;
+              for (var at = 1; at < it.length; at++) {
+                var ot = (J(it[at - 1] + " " + it[at]) - J(it[at])) * N + nt;
+                at == it.length - 1 ? t.push([it[at], ot, 0]) : t.push([it[at] + " ", ot, 0]), et -= ot;
+              }
+            } else t.push([s[rt], K, X]);
+            t.push(["", et, 0]);
+          } else {
+            if ("justify" !== u) throw new Error('Unrecognized alignment option, use "left", "center", "right" or "justify".');
+            t = [], C = s.length, h = 0 !== h ? h : V;
+            for (rt = 0; rt < C; rt++) X = 0 === rt ? yr(n) : -W, K = 0 === rt ? br(r) : 0, rt < C - 1 ? Y.push(E(U((h - H[rt]) / (s[rt].split(" ").length - 1)))) : Y.push(0), t.push([s[rt], K, X]);
+          }
+        }
+        var st = "boolean" == typeof i.R2L ? i.R2L : bt;
+        !0 === st && (t = _(t, function (t, e, r) {
+          return [t.split("").reverse().join(""), e, r];
+        })), o = {
+          text: t,
+          x: r,
+          y: n,
+          options: i,
+          mutex: {
+            pdfEscape: Ce,
+            activeFontKey: St,
+            fonts: It,
+            activeFontSize: gt
+          }
+        }, Tt.publish("postProcessText", o), t = o.text, y = o.mutex.isHex || !1;
+        var ct = It[St].encoding;
+        "WinAnsiEncoding" !== ct && "StandardEncoding" !== ct || (t = _(t, function (t, e, r) {
+          return [L(t), e, r];
+        })), s = A(t), t = [];
+        for (var ut, lt, ft, dt = 0, pt = 1, mt = Array.isArray(s[0]) ? pt : dt, vt = "", yt = function yt(t, e, r) {
+            var n = "";
+            return r instanceof Vt ? (r = "number" == typeof i.angle ? Gt(r, new Vt(1, 0, 0, 1, t, e)) : Gt(new Vt(1, 0, 0, 1, t, e), r), S === x.ADVANCED && (r = Gt(new Vt(1, 0, 0, -1, 0, 0), r)), n = r.join(" ") + " Tm\n") : n = E(t) + " " + E(e) + " Td\n", n;
+          }, wt = 0; wt < s.length; wt++) {
+          switch (vt = "", mt) {
+            case pt:
+              ft = (y ? "<" : "(") + s[wt][0] + (y ? ">" : ")"), ut = parseFloat(s[wt][1]), lt = parseFloat(s[wt][2]);
+              break;
+            case dt:
+              ft = (y ? "<" : "(") + s[wt] + (y ? ">" : ")"), ut = br(r), lt = yr(n);
+          }
+          void 0 !== Y && void 0 !== Y[wt] && (vt = Y[wt] + " Tw\n"), 0 === wt ? t.push(vt + yt(ut, lt, p) + ft) : mt === dt ? t.push(vt + ft) : mt === pt && t.push(vt + yt(ut, lt, p) + ft);
+        }
+        t = mt === dt ? t.join(" Tj\nT* ") : t.join(" Tj\n"), t += " Tj\n";
+        var Nt = "BT\n/";
+        return Nt += St + " " + gt + " Tf\n", Nt += E(gt * w) + " TL\n", Nt += xr + "\n", Nt += v, Nt += t, ht(Nt += "ET"), b[St] = !0, g;
+      };
+      var $e = y.__private__.clip = y.clip = function (t) {
+        return ht("evenodd" === t ? "W*" : "W"), this;
+      };
+      y.clipEvenOdd = function () {
+        return $e("evenodd");
+      }, y.__private__.discardPath = y.discardPath = function () {
+        return ht("n"), this;
+      };
+      var Qe = y.__private__.isValidStyle = function (t) {
+        var e = !1;
+        return -1 !== [void 0, null, "S", "D", "F", "DF", "FD", "f", "f*", "B", "B*", "n"].indexOf(t) && (e = !0), e;
+      };
+      y.__private__.setDefaultPathOperation = y.setDefaultPathOperation = function (t) {
+        return Qe(t) && (g = t), this;
+      };
+      var tr = y.__private__.getStyle = y.getStyle = function (t) {
+          var e = g;
+          switch (t) {
+            case "D":
+            case "S":
+              e = "S";
+              break;
+            case "F":
+              e = "f";
+              break;
+            case "FD":
+            case "DF":
+              e = "B";
+              break;
+            case "f":
+            case "f*":
+            case "B":
+            case "B*":
+              e = t;
+          }
+          return e;
+        },
+        er = y.close = function () {
+          return ht("h"), this;
+        };
+      y.stroke = function () {
+        return ht("S"), this;
+      }, y.fill = function (t) {
+        return rr("f", t), this;
+      }, y.fillEvenOdd = function (t) {
+        return rr("f*", t), this;
+      }, y.fillStroke = function (t) {
+        return rr("B", t), this;
+      }, y.fillStrokeEvenOdd = function (t) {
+        return rr("B*", t), this;
+      };
+      var rr = function rr(t, r) {
+          "object" === e(r) ? ar(r, t) : ht(t);
+        },
+        nr = function nr(t) {
+          null === t || S === x.ADVANCED && void 0 === t || (t = tr(t), ht(t));
+        };
+      function ir(t, e, r, n, i) {
+        var a = new B(e || this.boundingBox, r || this.xStep, n || this.yStep, this.gState, i || this.matrix);
+        a.stream = this.stream;
+        var o = t + "$$" + this.cloneIndex++ + "$$";
+        return Jt(o, a), a;
+      }
+      var ar = function ar(t, e) {
+          var r = Bt[t.key],
+            n = Ot[r];
+          if (n instanceof O) ht("q"), ht(or(e)), n.gState && y.setGState(n.gState), ht(t.matrix.toString() + " cm"), ht("/" + r + " sh"), ht("Q");else if (n instanceof B) {
+            var i = new Vt(1, 0, 0, -1, 0, Rr());
+            t.matrix && (i = i.multiply(t.matrix || Yt), r = ir.call(n, t.key, t.boundingBox, t.xStep, t.yStep, i).id), ht("q"), ht("/Pattern cs"), ht("/" + r + " scn"), n.gState && y.setGState(n.gState), ht(e), ht("Q");
+          }
+        },
+        or = function or(t) {
+          switch (t) {
+            case "f":
+            case "F":
+              return "W n";
+            case "f*":
+              return "W* n";
+            case "B":
+              return "W S";
+            case "B*":
+              return "W* S";
+            case "S":
+              return "W S";
+            case "n":
+              return "W n";
+          }
+        },
+        sr = y.moveTo = function (t, e) {
+          return ht(E(U(t)) + " " + E(H(e)) + " m"), this;
+        },
+        cr = y.lineTo = function (t, e) {
+          return ht(E(U(t)) + " " + E(H(e)) + " l"), this;
+        },
+        ur = y.curveTo = function (t, e, r, n, i, a) {
+          return ht([E(U(t)), E(H(e)), E(U(r)), E(H(n)), E(U(i)), E(H(a)), "c"].join(" ")), this;
+        };
+      y.__private__.line = y.line = function (t, e, r, n, i) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n) || !Qe(i)) throw new Error("Invalid arguments passed to jsPDF.line");
+        return S === x.COMPAT ? this.lines([[r - t, n - e]], t, e, [1, 1], i || "S") : this.lines([[r - t, n - e]], t, e, [1, 1]).stroke();
+      }, y.__private__.lines = y.lines = function (t, e, r, n, i, a) {
+        var o, s, c, u, l, h, f, d, p, g, m, v;
+        if ("number" == typeof t && (v = r, r = e, e = t, t = v), n = n || [1, 1], a = a || !1, isNaN(e) || isNaN(r) || !Array.isArray(t) || !Array.isArray(n) || !Qe(i) || "boolean" != typeof a) throw new Error("Invalid arguments passed to jsPDF.lines");
+        for (sr(e, r), o = n[0], s = n[1], u = t.length, g = e, m = r, c = 0; c < u; c++) 2 === (l = t[c]).length ? (g = l[0] * o + g, m = l[1] * s + m, cr(g, m)) : (h = l[0] * o + g, f = l[1] * s + m, d = l[2] * o + g, p = l[3] * s + m, g = l[4] * o + g, m = l[5] * s + m, ur(h, f, d, p, g, m));
+        return a && er(), nr(i), this;
+      }, y.path = function (t) {
+        for (var e = 0; e < t.length; e++) {
+          var r = t[e],
+            n = r.c;
+          switch (r.op) {
+            case "m":
+              sr(n[0], n[1]);
+              break;
+            case "l":
+              cr(n[0], n[1]);
+              break;
+            case "c":
+              ur.apply(this, n);
+              break;
+            case "h":
+              er();
+          }
+        }
+        return this;
+      }, y.__private__.rect = y.rect = function (t, e, r, n, i) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n) || !Qe(i)) throw new Error("Invalid arguments passed to jsPDF.rect");
+        return S === x.COMPAT && (n = -n), ht([E(U(t)), E(H(e)), E(U(r)), E(U(n)), "re"].join(" ")), nr(i), this;
+      }, y.__private__.triangle = y.triangle = function (t, e, r, n, i, a, o) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n) || isNaN(i) || isNaN(a) || !Qe(o)) throw new Error("Invalid arguments passed to jsPDF.triangle");
+        return this.lines([[r - t, n - e], [i - r, a - n], [t - i, e - a]], t, e, [1, 1], o, !0), this;
+      }, y.__private__.roundedRect = y.roundedRect = function (t, e, r, n, i, a, o) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n) || isNaN(i) || isNaN(a) || !Qe(o)) throw new Error("Invalid arguments passed to jsPDF.roundedRect");
+        var s = 4 / 3 * (Math.SQRT2 - 1);
+        return i = Math.min(i, .5 * r), a = Math.min(a, .5 * n), this.lines([[r - 2 * i, 0], [i * s, 0, i, a - a * s, i, a], [0, n - 2 * a], [0, a * s, -i * s, a, -i, a], [2 * i - r, 0], [-i * s, 0, -i, -a * s, -i, -a], [0, 2 * a - n], [0, -a * s, i * s, -a, i, -a]], t + i, e, [1, 1], o, !0), this;
+      }, y.__private__.ellipse = y.ellipse = function (t, e, r, n, i) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n) || !Qe(i)) throw new Error("Invalid arguments passed to jsPDF.ellipse");
+        var a = 4 / 3 * (Math.SQRT2 - 1) * r,
+          o = 4 / 3 * (Math.SQRT2 - 1) * n;
+        return sr(t + r, e), ur(t + r, e - o, t + a, e - n, t, e - n), ur(t - a, e - n, t - r, e - o, t - r, e), ur(t - r, e + o, t - a, e + n, t, e + n), ur(t + a, e + n, t + r, e + o, t + r, e), nr(i), this;
+      }, y.__private__.circle = y.circle = function (t, e, r, n) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || !Qe(n)) throw new Error("Invalid arguments passed to jsPDF.circle");
+        return this.ellipse(t, e, r, r, n);
+      }, y.setFont = function (t, e, r) {
+        return r && (e = j(e, r)), St = qe(t, e, {
+          disableWarning: !1
+        }), this;
+      };
+      var lr = y.__private__.getFont = y.getFont = function () {
+        return It[qe.apply(y, arguments)];
+      };
+      y.__private__.getFontList = y.getFontList = function () {
+        var t,
+          e,
+          r = {};
+        for (t in Ct) if (Ct.hasOwnProperty(t)) for (e in r[t] = [], Ct[t]) Ct[t].hasOwnProperty(e) && r[t].push(e);
+        return r;
+      }, y.addFont = function (t, e, r, n, i) {
+        var a = ["StandardEncoding", "MacRomanEncoding", "Identity-H", "WinAnsiEncoding"];
+        return arguments[3] && -1 !== a.indexOf(arguments[3]) ? i = arguments[3] : arguments[3] && -1 == a.indexOf(arguments[3]) && (r = j(r, n)), i = i || "Identity-H", Pe.call(this, t, e, r, i);
+      };
+      var hr,
+        fr = t.lineWidth || .200025,
+        dr = y.__private__.getLineWidth = y.getLineWidth = function () {
+          return fr;
+        },
+        pr = y.__private__.setLineWidth = y.setLineWidth = function (t) {
+          return fr = t, ht(E(U(t)) + " w"), this;
+        };
+      y.__private__.setLineDash = M.API.setLineDash = M.API.setLineDashPattern = function (t, e) {
+        if (t = t || [], e = e || 0, isNaN(e) || !Array.isArray(t)) throw new Error("Invalid arguments passed to jsPDF.setLineDash");
+        return t = t.map(function (t) {
+          return E(U(t));
+        }).join(" "), e = E(U(e)), ht("[" + t + "] " + e + " d"), this;
+      };
+      var gr = y.__private__.getLineHeight = y.getLineHeight = function () {
+        return gt * hr;
+      };
+      y.__private__.getLineHeight = y.getLineHeight = function () {
+        return gt * hr;
+      };
+      var mr = y.__private__.setLineHeightFactor = y.setLineHeightFactor = function (t) {
+          return "number" == typeof (t = t || 1.15) && (hr = t), this;
+        },
+        vr = y.__private__.getLineHeightFactor = y.getLineHeightFactor = function () {
+          return hr;
+        };
+      mr(t.lineHeight);
+      var br = y.__private__.getHorizontalCoordinate = function (t) {
+          return U(t);
+        },
+        yr = y.__private__.getVerticalCoordinate = function (t) {
+          return S === x.ADVANCED ? t : Rt[$].mediaBox.topRightY - Rt[$].mediaBox.bottomLeftY - U(t);
+        },
+        wr = y.__private__.getHorizontalCoordinateString = y.getHorizontalCoordinateString = function (t) {
+          return E(br(t));
+        },
+        Nr = y.__private__.getVerticalCoordinateString = y.getVerticalCoordinateString = function (t) {
+          return E(yr(t));
+        },
+        Lr = t.strokeColor || "0 G";
+      y.__private__.getStrokeColor = y.getDrawColor = function () {
+        return ee(Lr);
+      }, y.__private__.setStrokeColor = y.setDrawColor = function (t, e, r, n) {
+        return Lr = re({
+          ch1: t,
+          ch2: e,
+          ch3: r,
+          ch4: n,
+          pdfColorType: "draw",
+          precision: 2
+        }), ht(Lr), this;
+      };
+      var Ar = t.fillColor || "0 g";
+      y.__private__.getFillColor = y.getFillColor = function () {
+        return ee(Ar);
+      }, y.__private__.setFillColor = y.setFillColor = function (t, e, r, n) {
+        return Ar = re({
+          ch1: t,
+          ch2: e,
+          ch3: r,
+          ch4: n,
+          pdfColorType: "fill",
+          precision: 2
+        }), ht(Ar), this;
+      };
+      var xr = t.textColor || "0 g",
+        Sr = y.__private__.getTextColor = y.getTextColor = function () {
+          return ee(xr);
+        };
+      y.__private__.setTextColor = y.setTextColor = function (t, e, r, n) {
+        return xr = re({
+          ch1: t,
+          ch2: e,
+          ch3: r,
+          ch4: n,
+          pdfColorType: "text",
+          precision: 3
+        }), this;
+      };
+      var _r = t.charSpace,
+        Pr = y.__private__.getCharSpace = y.getCharSpace = function () {
+          return parseFloat(_r || 0);
+        };
+      y.__private__.setCharSpace = y.setCharSpace = function (t) {
+        if (isNaN(t)) throw new Error("Invalid argument passed to jsPDF.setCharSpace");
+        return _r = t, this;
+      };
+      var kr = 0;
+      y.CapJoinStyles = {
+        0: 0,
+        butt: 0,
+        but: 0,
+        miter: 0,
+        1: 1,
+        round: 1,
+        rounded: 1,
+        circle: 1,
+        2: 2,
+        projecting: 2,
+        project: 2,
+        square: 2,
+        bevel: 2
+      }, y.__private__.setLineCap = y.setLineCap = function (t) {
+        var e = y.CapJoinStyles[t];
+        if (void 0 === e) throw new Error("Line cap style of '" + t + "' is not recognized. See or extend .CapJoinStyles property for valid styles");
+        return kr = e, ht(e + " J"), this;
+      };
+      var Fr = 0;
+      y.__private__.setLineJoin = y.setLineJoin = function (t) {
+        var e = y.CapJoinStyles[t];
+        if (void 0 === e) throw new Error("Line join style of '" + t + "' is not recognized. See or extend .CapJoinStyles property for valid styles");
+        return Fr = e, ht(e + " j"), this;
+      }, y.__private__.setLineMiterLimit = y.__private__.setMiterLimit = y.setLineMiterLimit = y.setMiterLimit = function (t) {
+        if (t = t || 0, isNaN(t)) throw new Error("Invalid argument passed to jsPDF.setLineMiterLimit");
+        return ht(E(U(t)) + " M"), this;
+      }, y.GState = C, y.setGState = function (t) {
+        (t = "string" == typeof t ? Mt[Et[t]] : Ir(null, t)).equals(qt) || (ht("/" + t.id + " gs"), qt = t);
+      };
+      var Ir = function Ir(t, e) {
+        if (!t || !Et[t]) {
+          var r = !1;
+          for (var n in Mt) if (Mt.hasOwnProperty(n) && Mt[n].equals(e)) {
+            r = !0;
+            break;
+          }
+          if (r) e = Mt[n];else {
+            var i = "GS" + (Object.keys(Mt).length + 1).toString(10);
+            Mt[i] = e, e.id = i;
+          }
+          return t && (Et[t] = e.id), Tt.publish("addGState", e), e;
+        }
+      };
+      y.addGState = function (t, e) {
+        return Ir(t, e), this;
+      }, y.saveGraphicsState = function () {
+        return ht("q"), jt.push({
+          key: St,
+          size: gt,
+          color: xr
+        }), this;
+      }, y.restoreGraphicsState = function () {
+        ht("Q");
+        var t = jt.pop();
+        return St = t.key, gt = t.size, xr = t.color, qt = null, this;
+      }, y.setCurrentTransformationMatrix = function (t) {
+        return ht(t.toString() + " cm"), this;
+      }, y.comment = function (t) {
+        return ht("#" + t), this;
+      };
+      var Cr = function Cr(t, e) {
+          var r = t || 0;
+          Object.defineProperty(this, "x", {
+            enumerable: !0,
+            get: function get() {
+              return r;
+            },
+            set: function set(t) {
+              isNaN(t) || (r = parseFloat(t));
+            }
+          });
+          var n = e || 0;
+          Object.defineProperty(this, "y", {
+            enumerable: !0,
+            get: function get() {
+              return n;
+            },
+            set: function set(t) {
+              isNaN(t) || (n = parseFloat(t));
+            }
+          });
+          var i = "pt";
+          return Object.defineProperty(this, "type", {
+            enumerable: !0,
+            get: function get() {
+              return i;
+            },
+            set: function set(t) {
+              i = t.toString();
+            }
+          }), this;
+        },
+        jr = function jr(t, e, r, n) {
+          Cr.call(this, t, e), this.type = "rect";
+          var i = r || 0;
+          Object.defineProperty(this, "w", {
+            enumerable: !0,
+            get: function get() {
+              return i;
+            },
+            set: function set(t) {
+              isNaN(t) || (i = parseFloat(t));
+            }
+          });
+          var a = n || 0;
+          return Object.defineProperty(this, "h", {
+            enumerable: !0,
+            get: function get() {
+              return a;
+            },
+            set: function set(t) {
+              isNaN(t) || (a = parseFloat(t));
+            }
+          }), this;
+        },
+        Or = function Or() {
+          this.page = Dt, this.currentPage = $, this.pages = ot.slice(0), this.pagesContext = Rt.slice(0), this.x = Pt, this.y = kt, this.matrix = Ft, this.width = qr($), this.height = Rr($), this.outputDestination = ct, this.id = "", this.objectNumber = -1;
+        };
+      Or.prototype.restore = function () {
+        Dt = this.page, $ = this.currentPage, Rt = this.pagesContext, ot = this.pages, Pt = this.x, kt = this.y, Ft = this.matrix, Dr($, this.width), Tr($, this.height), ct = this.outputDestination;
+      };
+      var Br = function Br(t, e, r, n, i) {
+          Wt.push(new Or()), Dt = $ = 0, ot = [], Pt = t, kt = e, Ft = i, je([r, n]);
+        },
+        Mr = function Mr(t) {
+          if (Ht[t]) Wt.pop().restore();else {
+            var e = new Or(),
+              r = "Xo" + (Object.keys(zt).length + 1).toString(10);
+            e.id = r, Ht[t] = r, zt[r] = e, Tt.publish("addFormObject", e), Wt.pop().restore();
+          }
+        };
+      for (var Er in y.beginFormObject = function (t, e, r, n, i) {
+        return Br(t, e, r, n, i), this;
+      }, y.endFormObject = function (t) {
+        return Mr(t), this;
+      }, y.doFormObject = function (t, e) {
+        var r = zt[Ht[t]];
+        return ht("q"), ht(e.toString() + " cm"), ht("/" + r.id + " Do"), ht("Q"), this;
+      }, y.getFormObject = function (t) {
+        var e = zt[Ht[t]];
+        return {
+          x: e.x,
+          y: e.y,
+          width: e.width,
+          height: e.height,
+          matrix: e.matrix
+        };
+      }, y.save = function (t, e) {
+        return t = t || "generated.pdf", (e = e || {}).returnPromise = e.returnPromise || !1, !1 === e.returnPromise ? (l(We(He()), t), "function" == typeof l.unload && r.setTimeout && setTimeout(l.unload, 911), this) : new Promise(function (e, n) {
+          try {
+            var i = l(We(He()), t);
+            "function" == typeof l.unload && r.setTimeout && setTimeout(l.unload, 911), e(i);
+          } catch (t) {
+            n(t.message);
+          }
+        });
+      }, M.API) M.API.hasOwnProperty(Er) && ("events" === Er && M.API.events.length ? function (t, e) {
+        var r, n, i;
+        for (i = e.length - 1; -1 !== i; i--) r = e[i][0], n = e[i][1], t.subscribe.apply(t, [r].concat("function" == typeof n ? [n] : n));
+      }(Tt, M.API.events) : y[Er] = M.API[Er]);
+      var qr = y.getPageWidth = function (t) {
+          return (Rt[t = t || $].mediaBox.topRightX - Rt[t].mediaBox.bottomLeftX) / _t;
+        },
+        Dr = y.setPageWidth = function (t, e) {
+          Rt[t].mediaBox.topRightX = e * _t + Rt[t].mediaBox.bottomLeftX;
+        },
+        Rr = y.getPageHeight = function (t) {
+          return (Rt[t = t || $].mediaBox.topRightY - Rt[t].mediaBox.bottomLeftY) / _t;
+        },
+        Tr = y.setPageHeight = function (t, e) {
+          Rt[t].mediaBox.topRightY = e * _t + Rt[t].mediaBox.bottomLeftY;
+        };
+      return y.internal = {
+        pdfEscape: Ce,
+        getStyle: tr,
+        getFont: lr,
+        getFontSize: vt,
+        getCharSpace: Pr,
+        getTextColor: Sr,
+        getLineHeight: gr,
+        getLineHeightFactor: vr,
+        getLineWidth: dr,
+        write: ft,
+        getHorizontalCoordinate: br,
+        getVerticalCoordinate: yr,
+        getCoordinateString: wr,
+        getVerticalCoordinateString: Nr,
+        collections: {},
+        newObject: Xt,
+        newAdditionalObject: $t,
+        newObjectDeferred: Kt,
+        newObjectDeferredBegin: Zt,
+        getFilters: ne,
+        putStream: ie,
+        events: Tt,
+        scaleFactor: _t,
+        pageSize: {
+          getWidth: function getWidth() {
+            return qr($);
+          },
+          setWidth: function setWidth(t) {
+            Dr($, t);
+          },
+          getHeight: function getHeight() {
+            return Rr($);
+          },
+          setHeight: function setHeight(t) {
+            Tr($, t);
+          }
+        },
+        encryptionOptions: m,
+        encryption: Ye,
+        getEncryptor: Je,
+        output: Ve,
+        getNumberOfPages: Ee,
+        pages: ot,
+        out: ht,
+        f2: R,
+        f3: T,
+        getPageInfo: Xe,
+        getPageInfoByObjId: Ke,
+        getCurrentPageInfo: Ze,
+        getPDFVersion: N,
+        Point: Cr,
+        Rectangle: jr,
+        Matrix: Vt,
+        hasHotfix: Ge
+      }, Object.defineProperty(y.internal.pageSize, "width", {
+        get: function get() {
+          return qr($);
+        },
+        set: function set(t) {
+          Dr($, t);
+        },
+        enumerable: !0,
+        configurable: !0
+      }), Object.defineProperty(y.internal.pageSize, "height", {
+        get: function get() {
+          return Rr($);
+        },
+        set: function set(t) {
+          Tr($, t);
+        },
+        enumerable: !0,
+        configurable: !0
+      }), ke.call(y, pt), St = "F1", Oe(s, a), Tt.publish("initialized"), y;
+    }
+    k.prototype.lsbFirstWord = function (t) {
+      return String.fromCharCode(t >> 0 & 255, t >> 8 & 255, t >> 16 & 255, t >> 24 & 255);
+    }, k.prototype.toHexString = function (t) {
+      return t.split("").map(function (t) {
+        return ("0" + (255 & t.charCodeAt(0)).toString(16)).slice(-2);
+      }).join("");
+    }, k.prototype.hexToBytes = function (t) {
+      for (var e = [], r = 0; r < t.length; r += 2) e.push(String.fromCharCode(parseInt(t.substr(r, 2), 16)));
+      return e.join("");
+    }, k.prototype.processOwnerPassword = function (t, e) {
+      return _(A(e).substr(0, 5), t);
+    }, k.prototype.encryptor = function (t, e) {
+      var r = A(this.encryptionKey + String.fromCharCode(255 & t, t >> 8 & 255, t >> 16 & 255, 255 & e, e >> 8 & 255)).substr(0, 10);
+      return function (t) {
+        return _(r, t);
+      };
+    }, C.prototype.equals = function (t) {
+      var r,
+        n = "id,objectNumber,equals";
+      if (!t || e(t) !== e(this)) return !1;
+      var i = 0;
+      for (r in this) if (!(n.indexOf(r) >= 0)) {
+        if (this.hasOwnProperty(r) && !t.hasOwnProperty(r)) return !1;
+        if (this[r] !== t[r]) return !1;
+        i++;
+      }
+      for (r in t) t.hasOwnProperty(r) && n.indexOf(r) < 0 && i--;
+      return 0 === i;
+    }, M.API = {
+      events: []
+    }, M.version = "2.5.2";
+    var E = M.API,
+      q = 1,
+      D = function D(t) {
+        return t.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+      },
+      R = function R(t) {
+        return t.replace(/\\\\/g, "\\").replace(/\\\(/g, "(").replace(/\\\)/g, ")");
+      },
+      T = function T(t) {
+        return t.toFixed(2);
+      },
+      U = function U(t) {
+        return t.toFixed(5);
+      };
+    E.__acroform__ = {};
+    var z = function z(t, e) {
+        t.prototype = Object.create(e.prototype), t.prototype.constructor = t;
+      },
+      H = function H(t) {
+        return t * q;
+      },
+      W = function W(t) {
+        var e = new ct(),
+          r = Lt.internal.getHeight(t) || 0,
+          n = Lt.internal.getWidth(t) || 0;
+        return e.BBox = [0, 0, Number(T(n)), Number(T(r))], e;
+      },
+      V = E.__acroform__.setBit = function (t, e) {
+        if (t = t || 0, e = e || 0, isNaN(t) || isNaN(e)) throw new Error("Invalid arguments passed to jsPDF.API.__acroform__.setBit");
+        return t |= 1 << e;
+      },
+      G = E.__acroform__.clearBit = function (t, e) {
+        if (t = t || 0, e = e || 0, isNaN(t) || isNaN(e)) throw new Error("Invalid arguments passed to jsPDF.API.__acroform__.clearBit");
+        return t &= ~(1 << e);
+      },
+      Y = E.__acroform__.getBit = function (t, e) {
+        if (isNaN(t) || isNaN(e)) throw new Error("Invalid arguments passed to jsPDF.API.__acroform__.getBit");
+        return 0 == (t & 1 << e) ? 0 : 1;
+      },
+      J = E.__acroform__.getBitForPdf = function (t, e) {
+        if (isNaN(t) || isNaN(e)) throw new Error("Invalid arguments passed to jsPDF.API.__acroform__.getBitForPdf");
+        return Y(t, e - 1);
+      },
+      X = E.__acroform__.setBitForPdf = function (t, e) {
+        if (isNaN(t) || isNaN(e)) throw new Error("Invalid arguments passed to jsPDF.API.__acroform__.setBitForPdf");
+        return V(t, e - 1);
+      },
+      K = E.__acroform__.clearBitForPdf = function (t, e) {
+        if (isNaN(t) || isNaN(e)) throw new Error("Invalid arguments passed to jsPDF.API.__acroform__.clearBitForPdf");
+        return G(t, e - 1);
+      },
+      Z = E.__acroform__.calculateCoordinates = function (t, e) {
+        var r = e.internal.getHorizontalCoordinate,
+          n = e.internal.getVerticalCoordinate,
+          i = t[0],
+          a = t[1],
+          o = t[2],
+          s = t[3],
+          c = {};
+        return c.lowerLeft_X = r(i) || 0, c.lowerLeft_Y = n(a + s) || 0, c.upperRight_X = r(i + o) || 0, c.upperRight_Y = n(a) || 0, [Number(T(c.lowerLeft_X)), Number(T(c.lowerLeft_Y)), Number(T(c.upperRight_X)), Number(T(c.upperRight_Y))];
+      },
+      $ = function $(t) {
+        if (t.appearanceStreamContent) return t.appearanceStreamContent;
+        if (t.V || t.DV) {
+          var e = [],
+            r = t._V || t.DV,
+            n = Q(t, r),
+            i = t.scope.internal.getFont(t.fontName, t.fontStyle).id;
+          e.push("/Tx BMC"), e.push("q"), e.push("BT"), e.push(t.scope.__private__.encodeColorString(t.color)), e.push("/" + i + " " + T(n.fontSize) + " Tf"), e.push("1 0 0 1 0 0 Tm"), e.push(n.text), e.push("ET"), e.push("Q"), e.push("EMC");
+          var a = W(t);
+          return a.scope = t.scope, a.stream = e.join("\n"), a;
+        }
+      },
+      Q = function Q(t, e) {
+        var r = 0 === t.fontSize ? t.maxFontSize : t.fontSize,
+          n = {
+            text: "",
+            fontSize: ""
+          },
+          i = (e = ")" == (e = "(" == e.substr(0, 1) ? e.substr(1) : e).substr(e.length - 1) ? e.substr(0, e.length - 1) : e).split(" ");
+        i = t.multiline ? i.map(function (t) {
+          return t.split("\n");
+        }) : i.map(function (t) {
+          return [t];
+        });
+        var a = r,
+          o = Lt.internal.getHeight(t) || 0;
+        o = o < 0 ? -o : o;
+        var s = Lt.internal.getWidth(t) || 0;
+        s = s < 0 ? -s : s;
+        var c = function c(e, r, n) {
+          if (e + 1 < i.length) {
+            var a = r + " " + i[e + 1][0];
+            return tt(a, t, n).width <= s - 4;
+          }
+          return !1;
+        };
+        a++;
+        t: for (; a > 0;) {
+          e = "", a--;
+          var u,
+            l,
+            h = tt("3", t, a).height,
+            f = t.multiline ? o - a : (o - h) / 2,
+            d = f += 2,
+            p = 0,
+            g = 0,
+            m = 0;
+          if (a <= 0) {
+            e = "(...) Tj\n", e += "% Width of Text: " + tt(e, t, a = 12).width + ", FieldWidth:" + s + "\n";
+            break;
+          }
+          for (var v = "", b = 0, y = 0; y < i.length; y++) if (i.hasOwnProperty(y)) {
+            var w = !1;
+            if (1 !== i[y].length && m !== i[y].length - 1) {
+              if ((h + 2) * (b + 2) + 2 > o) continue t;
+              v += i[y][m], w = !0, g = y, y--;
+            } else {
+              v = " " == (v += i[y][m] + " ").substr(v.length - 1) ? v.substr(0, v.length - 1) : v;
+              var N = parseInt(y),
+                L = c(N, v, a),
+                A = y >= i.length - 1;
+              if (L && !A) {
+                v += " ", m = 0;
+                continue;
+              }
+              if (L || A) {
+                if (A) g = N;else if (t.multiline && (h + 2) * (b + 2) + 2 > o) continue t;
+              } else {
+                if (!t.multiline) continue t;
+                if ((h + 2) * (b + 2) + 2 > o) continue t;
+                g = N;
+              }
+            }
+            for (var x = "", S = p; S <= g; S++) {
+              var _ = i[S];
+              if (t.multiline) {
+                if (S === g) {
+                  x += _[m] + " ", m = (m + 1) % _.length;
+                  continue;
+                }
+                if (S === p) {
+                  x += _[_.length - 1] + " ";
+                  continue;
+                }
+              }
+              x += _[0] + " ";
+            }
+            switch (x = " " == x.substr(x.length - 1) ? x.substr(0, x.length - 1) : x, l = tt(x, t, a).width, t.textAlign) {
+              case "right":
+                u = s - l - 2;
+                break;
+              case "center":
+                u = (s - l) / 2;
+                break;
+              case "left":
+              default:
+                u = 2;
+            }
+            e += T(u) + " " + T(d) + " Td\n", e += "(" + D(x) + ") Tj\n", e += -T(u) + " 0 Td\n", d = -(a + 2), l = 0, p = w ? g : g + 1, b++, v = "";
+          }
+          break;
+        }
+        return n.text = e, n.fontSize = a, n;
+      },
+      tt = function tt(t, e, r) {
+        var n = e.scope.internal.getFont(e.fontName, e.fontStyle),
+          i = e.scope.getStringUnitWidth(t, {
+            font: n,
+            fontSize: parseFloat(r),
+            charSpace: 0
+          }) * parseFloat(r);
+        return {
+          height: e.scope.getStringUnitWidth("3", {
+            font: n,
+            fontSize: parseFloat(r),
+            charSpace: 0
+          }) * parseFloat(r) * 1.5,
+          width: i
+        };
+      },
+      et = {
+        fields: [],
+        xForms: [],
+        acroFormDictionaryRoot: null,
+        printedOut: !1,
+        internal: null,
+        isInitialized: !1
+      },
+      rt = function rt(t, e) {
+        var r = {
+          type: "reference",
+          object: t
+        };
+        void 0 === e.internal.getPageInfo(t.page).pageContext.annotations.find(function (t) {
+          return t.type === r.type && t.object === r.object;
+        }) && e.internal.getPageInfo(t.page).pageContext.annotations.push(r);
+      },
+      nt = function nt(t, r) {
+        for (var n in t) if (t.hasOwnProperty(n)) {
+          var i = n,
+            a = t[n];
+          r.internal.newObjectDeferredBegin(a.objId, !0), "object" === e(a) && "function" == typeof a.putStream && a.putStream(), delete t[i];
+        }
+      },
+      it = function it(t, r) {
+        if (r.scope = t, void 0 !== t.internal && (void 0 === t.internal.acroformPlugin || !1 === t.internal.acroformPlugin.isInitialized)) {
+          if (lt.FieldNum = 0, t.internal.acroformPlugin = JSON.parse(JSON.stringify(et)), t.internal.acroformPlugin.acroFormDictionaryRoot) throw new Error("Exception while creating AcroformDictionary");
+          q = t.internal.scaleFactor, t.internal.acroformPlugin.acroFormDictionaryRoot = new ut(), t.internal.acroformPlugin.acroFormDictionaryRoot.scope = t, t.internal.acroformPlugin.acroFormDictionaryRoot._eventID = t.internal.events.subscribe("postPutResources", function () {
+            !function (t) {
+              t.internal.events.unsubscribe(t.internal.acroformPlugin.acroFormDictionaryRoot._eventID), delete t.internal.acroformPlugin.acroFormDictionaryRoot._eventID, t.internal.acroformPlugin.printedOut = !0;
+            }(t);
+          }), t.internal.events.subscribe("buildDocument", function () {
+            !function (t) {
+              t.internal.acroformPlugin.acroFormDictionaryRoot.objId = void 0;
+              var e = t.internal.acroformPlugin.acroFormDictionaryRoot.Fields;
+              for (var r in e) if (e.hasOwnProperty(r)) {
+                var n = e[r];
+                n.objId = void 0, n.hasAnnotation && rt(n, t);
+              }
+            }(t);
+          }), t.internal.events.subscribe("putCatalog", function () {
+            !function (t) {
+              if (void 0 === t.internal.acroformPlugin.acroFormDictionaryRoot) throw new Error("putCatalogCallback: Root missing.");
+              t.internal.write("/AcroForm " + t.internal.acroformPlugin.acroFormDictionaryRoot.objId + " 0 R");
+            }(t);
+          }), t.internal.events.subscribe("postPutPages", function (r) {
+            !function (t, r) {
+              var n = !t;
+              for (var i in t || (r.internal.newObjectDeferredBegin(r.internal.acroformPlugin.acroFormDictionaryRoot.objId, !0), r.internal.acroformPlugin.acroFormDictionaryRoot.putStream()), t = t || r.internal.acroformPlugin.acroFormDictionaryRoot.Kids) if (t.hasOwnProperty(i)) {
+                var a = t[i],
+                  o = [],
+                  s = a.Rect;
+                if (a.Rect && (a.Rect = Z(a.Rect, r)), r.internal.newObjectDeferredBegin(a.objId, !0), a.DA = Lt.createDefaultAppearanceStream(a), "object" === e(a) && "function" == typeof a.getKeyValueListForStream && (o = a.getKeyValueListForStream()), a.Rect = s, a.hasAppearanceStream && !a.appearanceStreamContent) {
+                  var c = $(a);
+                  o.push({
+                    key: "AP",
+                    value: "<</N " + c + ">>"
+                  }), r.internal.acroformPlugin.xForms.push(c);
+                }
+                if (a.appearanceStreamContent) {
+                  var u = "";
+                  for (var l in a.appearanceStreamContent) if (a.appearanceStreamContent.hasOwnProperty(l)) {
+                    var h = a.appearanceStreamContent[l];
+                    if (u += "/" + l + " ", u += "<<", Object.keys(h).length >= 1 || Array.isArray(h)) {
+                      for (var i in h) if (h.hasOwnProperty(i)) {
+                        var f = h[i];
+                        "function" == typeof f && (f = f.call(r, a)), u += "/" + i + " " + f + " ", r.internal.acroformPlugin.xForms.indexOf(f) >= 0 || r.internal.acroformPlugin.xForms.push(f);
+                      }
+                    } else "function" == typeof (f = h) && (f = f.call(r, a)), u += "/" + i + " " + f, r.internal.acroformPlugin.xForms.indexOf(f) >= 0 || r.internal.acroformPlugin.xForms.push(f);
+                    u += ">>";
+                  }
+                  o.push({
+                    key: "AP",
+                    value: "<<\n" + u + ">>"
+                  });
+                }
+                r.internal.putStream({
+                  additionalKeyValues: o,
+                  objectId: a.objId
+                }), r.internal.out("endobj");
+              }
+              n && nt(r.internal.acroformPlugin.xForms, r);
+            }(r, t);
+          }), t.internal.acroformPlugin.isInitialized = !0;
+        }
+      },
+      at = E.__acroform__.arrayToPdfArray = function (t, r, n) {
+        var i = function i(t) {
+          return t;
+        };
+        if (Array.isArray(t)) {
+          for (var a = "[", o = 0; o < t.length; o++) switch (0 !== o && (a += " "), e(t[o])) {
+            case "boolean":
+            case "number":
+            case "object":
+              a += t[o].toString();
+              break;
+            case "string":
+              "/" !== t[o].substr(0, 1) ? (void 0 !== r && n && (i = n.internal.getEncryptor(r)), a += "(" + D(i(t[o].toString())) + ")") : a += t[o].toString();
+          }
+          return a += "]";
+        }
+        throw new Error("Invalid argument passed to jsPDF.__acroform__.arrayToPdfArray");
+      };
+    var ot = function ot(t, e, r) {
+        var n = function n(t) {
+          return t;
+        };
+        return void 0 !== e && r && (n = r.internal.getEncryptor(e)), (t = t || "").toString(), t = "(" + D(n(t)) + ")";
+      },
+      st = function st() {
+        this._objId = void 0, this._scope = void 0, Object.defineProperty(this, "objId", {
+          get: function get() {
+            if (void 0 === this._objId) {
+              if (void 0 === this.scope) return;
+              this._objId = this.scope.internal.newObjectDeferred();
+            }
+            return this._objId;
+          },
+          set: function set(t) {
+            this._objId = t;
+          }
+        }), Object.defineProperty(this, "scope", {
+          value: this._scope,
+          writable: !0
+        });
+      };
+    st.prototype.toString = function () {
+      return this.objId + " 0 R";
+    }, st.prototype.putStream = function () {
+      var t = this.getKeyValueListForStream();
+      this.scope.internal.putStream({
+        data: this.stream,
+        additionalKeyValues: t,
+        objectId: this.objId
+      }), this.scope.internal.out("endobj");
+    }, st.prototype.getKeyValueListForStream = function () {
+      var t = [],
+        e = Object.getOwnPropertyNames(this).filter(function (t) {
+          return "content" != t && "appearanceStreamContent" != t && "scope" != t && "objId" != t && "_" != t.substring(0, 1);
+        });
+      for (var r in e) if (!1 === Object.getOwnPropertyDescriptor(this, e[r]).configurable) {
+        var n = e[r],
+          i = this[n];
+        i && (Array.isArray(i) ? t.push({
+          key: n,
+          value: at(i, this.objId, this.scope)
+        }) : i instanceof st ? (i.scope = this.scope, t.push({
+          key: n,
+          value: i.objId + " 0 R"
+        })) : "function" != typeof i && t.push({
+          key: n,
+          value: i
+        }));
+      }
+      return t;
+    };
+    var ct = function ct() {
+      st.call(this), Object.defineProperty(this, "Type", {
+        value: "/XObject",
+        configurable: !1,
+        writable: !0
+      }), Object.defineProperty(this, "Subtype", {
+        value: "/Form",
+        configurable: !1,
+        writable: !0
+      }), Object.defineProperty(this, "FormType", {
+        value: 1,
+        configurable: !1,
+        writable: !0
+      });
+      var t,
+        e = [];
+      Object.defineProperty(this, "BBox", {
+        configurable: !1,
+        get: function get() {
+          return e;
+        },
+        set: function set(t) {
+          e = t;
+        }
+      }), Object.defineProperty(this, "Resources", {
+        value: "2 0 R",
+        configurable: !1,
+        writable: !0
+      }), Object.defineProperty(this, "stream", {
+        enumerable: !1,
+        configurable: !0,
+        set: function set(e) {
+          t = e.trim();
+        },
+        get: function get() {
+          return t || null;
+        }
+      });
+    };
+    z(ct, st);
+    var ut = function ut() {
+      st.call(this);
+      var t,
+        e = [];
+      Object.defineProperty(this, "Kids", {
+        enumerable: !1,
+        configurable: !0,
+        get: function get() {
+          return e.length > 0 ? e : void 0;
+        }
+      }), Object.defineProperty(this, "Fields", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          return e;
+        }
+      }), Object.defineProperty(this, "DA", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          if (t) {
+            var e = function e(t) {
+              return t;
+            };
+            return this.scope && (e = this.scope.internal.getEncryptor(this.objId)), "(" + D(e(t)) + ")";
+          }
+        },
+        set: function set(e) {
+          t = e;
+        }
+      });
+    };
+    z(ut, st);
+    var lt = function t() {
+      st.call(this);
+      var e = 4;
+      Object.defineProperty(this, "F", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          return e;
+        },
+        set: function set(t) {
+          if (isNaN(t)) throw new Error('Invalid value "' + t + '" for attribute F supplied.');
+          e = t;
+        }
+      }), Object.defineProperty(this, "showWhenPrinted", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(e, 3));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.F = X(e, 3) : this.F = K(e, 3);
+        }
+      });
+      var r = 0;
+      Object.defineProperty(this, "Ff", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          return r;
+        },
+        set: function set(t) {
+          if (isNaN(t)) throw new Error('Invalid value "' + t + '" for attribute Ff supplied.');
+          r = t;
+        }
+      });
+      var n = [];
+      Object.defineProperty(this, "Rect", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          if (0 !== n.length) return n;
+        },
+        set: function set(t) {
+          n = void 0 !== t ? t : [];
+        }
+      }), Object.defineProperty(this, "x", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return !n || isNaN(n[0]) ? 0 : n[0];
+        },
+        set: function set(t) {
+          n[0] = t;
+        }
+      }), Object.defineProperty(this, "y", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return !n || isNaN(n[1]) ? 0 : n[1];
+        },
+        set: function set(t) {
+          n[1] = t;
+        }
+      }), Object.defineProperty(this, "width", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return !n || isNaN(n[2]) ? 0 : n[2];
+        },
+        set: function set(t) {
+          n[2] = t;
+        }
+      }), Object.defineProperty(this, "height", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return !n || isNaN(n[3]) ? 0 : n[3];
+        },
+        set: function set(t) {
+          n[3] = t;
+        }
+      });
+      var i = "";
+      Object.defineProperty(this, "FT", {
+        enumerable: !0,
+        configurable: !1,
+        get: function get() {
+          return i;
+        },
+        set: function set(t) {
+          switch (t) {
+            case "/Btn":
+            case "/Tx":
+            case "/Ch":
+            case "/Sig":
+              i = t;
+              break;
+            default:
+              throw new Error('Invalid value "' + t + '" for attribute FT supplied.');
+          }
+        }
+      });
+      var a = null;
+      Object.defineProperty(this, "T", {
+        enumerable: !0,
+        configurable: !1,
+        get: function get() {
+          if (!a || a.length < 1) {
+            if (this instanceof bt) return;
+            a = "FieldObject" + t.FieldNum++;
+          }
+          var e = function e(t) {
+            return t;
+          };
+          return this.scope && (e = this.scope.internal.getEncryptor(this.objId)), "(" + D(e(a)) + ")";
+        },
+        set: function set(t) {
+          a = t.toString();
+        }
+      }), Object.defineProperty(this, "fieldName", {
+        configurable: !0,
+        enumerable: !0,
+        get: function get() {
+          return a;
+        },
+        set: function set(t) {
+          a = t;
+        }
+      });
+      var o = "helvetica";
+      Object.defineProperty(this, "fontName", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return o;
+        },
+        set: function set(t) {
+          o = t;
+        }
+      });
+      var s = "normal";
+      Object.defineProperty(this, "fontStyle", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return s;
+        },
+        set: function set(t) {
+          s = t;
+        }
+      });
+      var c = 0;
+      Object.defineProperty(this, "fontSize", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return c;
+        },
+        set: function set(t) {
+          c = t;
+        }
+      });
+      var u = void 0;
+      Object.defineProperty(this, "maxFontSize", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return void 0 === u ? 50 / q : u;
+        },
+        set: function set(t) {
+          u = t;
+        }
+      });
+      var l = "black";
+      Object.defineProperty(this, "color", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return l;
+        },
+        set: function set(t) {
+          l = t;
+        }
+      });
+      var h = "/F1 0 Tf 0 g";
+      Object.defineProperty(this, "DA", {
+        enumerable: !0,
+        configurable: !1,
+        get: function get() {
+          if (!(!h || this instanceof bt || this instanceof wt)) return ot(h, this.objId, this.scope);
+        },
+        set: function set(t) {
+          t = t.toString(), h = t;
+        }
+      });
+      var f = null;
+      Object.defineProperty(this, "DV", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          if (f) return this instanceof gt == !1 ? ot(f, this.objId, this.scope) : f;
+        },
+        set: function set(t) {
+          t = t.toString(), f = this instanceof gt == !1 ? "(" === t.substr(0, 1) ? R(t.substr(1, t.length - 2)) : R(t) : t;
+        }
+      }), Object.defineProperty(this, "defaultValue", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return this instanceof gt == !0 ? R(f.substr(1, f.length - 1)) : f;
+        },
+        set: function set(t) {
+          t = t.toString(), f = this instanceof gt == !0 ? "/" + t : t;
+        }
+      });
+      var d = null;
+      Object.defineProperty(this, "_V", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          if (d) return d;
+        },
+        set: function set(t) {
+          this.V = t;
+        }
+      }), Object.defineProperty(this, "V", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          if (d) return this instanceof gt == !1 ? ot(d, this.objId, this.scope) : d;
+        },
+        set: function set(t) {
+          t = t.toString(), d = this instanceof gt == !1 ? "(" === t.substr(0, 1) ? R(t.substr(1, t.length - 2)) : R(t) : t;
+        }
+      }), Object.defineProperty(this, "value", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return this instanceof gt == !0 ? R(d.substr(1, d.length - 1)) : d;
+        },
+        set: function set(t) {
+          t = t.toString(), d = this instanceof gt == !0 ? "/" + t : t;
+        }
+      }), Object.defineProperty(this, "hasAnnotation", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return this.Rect;
+        }
+      }), Object.defineProperty(this, "Type", {
+        enumerable: !0,
+        configurable: !1,
+        get: function get() {
+          return this.hasAnnotation ? "/Annot" : null;
+        }
+      }), Object.defineProperty(this, "Subtype", {
+        enumerable: !0,
+        configurable: !1,
+        get: function get() {
+          return this.hasAnnotation ? "/Widget" : null;
+        }
+      });
+      var p,
+        g = !1;
+      Object.defineProperty(this, "hasAppearanceStream", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return g;
+        },
+        set: function set(t) {
+          t = Boolean(t), g = t;
+        }
+      }), Object.defineProperty(this, "page", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          if (p) return p;
+        },
+        set: function set(t) {
+          p = t;
+        }
+      }), Object.defineProperty(this, "readOnly", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 1));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 1) : this.Ff = K(this.Ff, 1);
+        }
+      }), Object.defineProperty(this, "required", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 2));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 2) : this.Ff = K(this.Ff, 2);
+        }
+      }), Object.defineProperty(this, "noExport", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 3));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 3) : this.Ff = K(this.Ff, 3);
+        }
+      });
+      var m = null;
+      Object.defineProperty(this, "Q", {
+        enumerable: !0,
+        configurable: !1,
+        get: function get() {
+          if (null !== m) return m;
+        },
+        set: function set(t) {
+          if (-1 === [0, 1, 2].indexOf(t)) throw new Error('Invalid value "' + t + '" for attribute Q supplied.');
+          m = t;
+        }
+      }), Object.defineProperty(this, "textAlign", {
+        get: function get() {
+          var t;
+          switch (m) {
+            case 0:
+            default:
+              t = "left";
+              break;
+            case 1:
+              t = "center";
+              break;
+            case 2:
+              t = "right";
+          }
+          return t;
+        },
+        configurable: !0,
+        enumerable: !0,
+        set: function set(t) {
+          switch (t) {
+            case "right":
+            case 2:
+              m = 2;
+              break;
+            case "center":
+            case 1:
+              m = 1;
+              break;
+            case "left":
+            case 0:
+            default:
+              m = 0;
+          }
+        }
+      });
+    };
+    z(lt, st);
+    var ht = function ht() {
+      lt.call(this), this.FT = "/Ch", this.V = "()", this.fontName = "zapfdingbats";
+      var t = 0;
+      Object.defineProperty(this, "TI", {
+        enumerable: !0,
+        configurable: !1,
+        get: function get() {
+          return t;
+        },
+        set: function set(e) {
+          t = e;
+        }
+      }), Object.defineProperty(this, "topIndex", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return t;
+        },
+        set: function set(e) {
+          t = e;
+        }
+      });
+      var e = [];
+      Object.defineProperty(this, "Opt", {
+        enumerable: !0,
+        configurable: !1,
+        get: function get() {
+          return at(e, this.objId, this.scope);
+        },
+        set: function set(t) {
+          var r, n;
+          n = [], "string" == typeof (r = t) && (n = function (t, e, r) {
+            r || (r = 1);
+            for (var n, i = []; n = e.exec(t);) i.push(n[r]);
+            return i;
+          }(r, /\((.*?)\)/g)), e = n;
+        }
+      }), this.getOptions = function () {
+        return e;
+      }, this.setOptions = function (t) {
+        e = t, this.sort && e.sort();
+      }, this.addOption = function (t) {
+        t = (t = t || "").toString(), e.push(t), this.sort && e.sort();
+      }, this.removeOption = function (t, r) {
+        for (r = r || !1, t = (t = t || "").toString(); -1 !== e.indexOf(t) && (e.splice(e.indexOf(t), 1), !1 !== r););
+      }, Object.defineProperty(this, "combo", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 18));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 18) : this.Ff = K(this.Ff, 18);
+        }
+      }), Object.defineProperty(this, "edit", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 19));
+        },
+        set: function set(t) {
+          !0 === this.combo && (!0 === Boolean(t) ? this.Ff = X(this.Ff, 19) : this.Ff = K(this.Ff, 19));
+        }
+      }), Object.defineProperty(this, "sort", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 20));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? (this.Ff = X(this.Ff, 20), e.sort()) : this.Ff = K(this.Ff, 20);
+        }
+      }), Object.defineProperty(this, "multiSelect", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 22));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 22) : this.Ff = K(this.Ff, 22);
+        }
+      }), Object.defineProperty(this, "doNotSpellCheck", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 23));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 23) : this.Ff = K(this.Ff, 23);
+        }
+      }), Object.defineProperty(this, "commitOnSelChange", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 27));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 27) : this.Ff = K(this.Ff, 27);
+        }
+      }), this.hasAppearanceStream = !1;
+    };
+    z(ht, lt);
+    var ft = function ft() {
+      ht.call(this), this.fontName = "helvetica", this.combo = !1;
+    };
+    z(ft, ht);
+    var dt = function dt() {
+      ft.call(this), this.combo = !0;
+    };
+    z(dt, ft);
+    var pt = function pt() {
+      dt.call(this), this.edit = !0;
+    };
+    z(pt, dt);
+    var gt = function gt() {
+      lt.call(this), this.FT = "/Btn", Object.defineProperty(this, "noToggleToOff", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 15));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 15) : this.Ff = K(this.Ff, 15);
+        }
+      }), Object.defineProperty(this, "radio", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 16));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 16) : this.Ff = K(this.Ff, 16);
+        }
+      }), Object.defineProperty(this, "pushButton", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 17));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 17) : this.Ff = K(this.Ff, 17);
+        }
+      }), Object.defineProperty(this, "radioIsUnison", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 26));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 26) : this.Ff = K(this.Ff, 26);
+        }
+      });
+      var t,
+        r = {};
+      Object.defineProperty(this, "MK", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          var t = function t(_t2) {
+            return _t2;
+          };
+          if (this.scope && (t = this.scope.internal.getEncryptor(this.objId)), 0 !== Object.keys(r).length) {
+            var e,
+              n = [];
+            for (e in n.push("<<"), r) n.push("/" + e + " (" + D(t(r[e])) + ")");
+            return n.push(">>"), n.join("\n");
+          }
+        },
+        set: function set(t) {
+          "object" === e(t) && (r = t);
+        }
+      }), Object.defineProperty(this, "caption", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return r.CA || "";
+        },
+        set: function set(t) {
+          "string" == typeof t && (r.CA = t);
+        }
+      }), Object.defineProperty(this, "AS", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          return t;
+        },
+        set: function set(e) {
+          t = e;
+        }
+      }), Object.defineProperty(this, "appearanceState", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return t.substr(1, t.length - 1);
+        },
+        set: function set(e) {
+          t = "/" + e;
+        }
+      });
+    };
+    z(gt, lt);
+    var mt = function mt() {
+      gt.call(this), this.pushButton = !0;
+    };
+    z(mt, gt);
+    var vt = function vt() {
+      gt.call(this), this.radio = !0, this.pushButton = !1;
+      var t = [];
+      Object.defineProperty(this, "Kids", {
+        enumerable: !0,
+        configurable: !1,
+        get: function get() {
+          return t;
+        },
+        set: function set(e) {
+          t = void 0 !== e ? e : [];
+        }
+      });
+    };
+    z(vt, gt);
+    var bt = function bt() {
+      var t, r;
+      lt.call(this), Object.defineProperty(this, "Parent", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          return t;
+        },
+        set: function set(e) {
+          t = e;
+        }
+      }), Object.defineProperty(this, "optionName", {
+        enumerable: !1,
+        configurable: !0,
+        get: function get() {
+          return r;
+        },
+        set: function set(t) {
+          r = t;
+        }
+      });
+      var n,
+        i = {};
+      Object.defineProperty(this, "MK", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          var t = function t(_t3) {
+            return _t3;
+          };
+          this.scope && (t = this.scope.internal.getEncryptor(this.objId));
+          var e,
+            r = [];
+          for (e in r.push("<<"), i) r.push("/" + e + " (" + D(t(i[e])) + ")");
+          return r.push(">>"), r.join("\n");
+        },
+        set: function set(t) {
+          "object" === e(t) && (i = t);
+        }
+      }), Object.defineProperty(this, "caption", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return i.CA || "";
+        },
+        set: function set(t) {
+          "string" == typeof t && (i.CA = t);
+        }
+      }), Object.defineProperty(this, "AS", {
+        enumerable: !1,
+        configurable: !1,
+        get: function get() {
+          return n;
+        },
+        set: function set(t) {
+          n = t;
+        }
+      }), Object.defineProperty(this, "appearanceState", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return n.substr(1, n.length - 1);
+        },
+        set: function set(t) {
+          n = "/" + t;
+        }
+      }), this.caption = "l", this.appearanceState = "Off", this._AppearanceType = Lt.RadioButton.Circle, this.appearanceStreamContent = this._AppearanceType.createAppearanceStream(this.optionName);
+    };
+    z(bt, lt), vt.prototype.setAppearance = function (t) {
+      if (!("createAppearanceStream" in t) || !("getCA" in t)) throw new Error("Couldn't assign Appearance to RadioButton. Appearance was Invalid!");
+      for (var e in this.Kids) if (this.Kids.hasOwnProperty(e)) {
+        var r = this.Kids[e];
+        r.appearanceStreamContent = t.createAppearanceStream(r.optionName), r.caption = t.getCA();
+      }
+    }, vt.prototype.createOption = function (t) {
+      var e = new bt();
+      return e.Parent = this, e.optionName = t, this.Kids.push(e), At.call(this.scope, e), e;
+    };
+    var yt = function yt() {
+      gt.call(this), this.fontName = "zapfdingbats", this.caption = "3", this.appearanceState = "On", this.value = "On", this.textAlign = "center", this.appearanceStreamContent = Lt.CheckBox.createAppearanceStream();
+    };
+    z(yt, gt);
+    var wt = function wt() {
+      lt.call(this), this.FT = "/Tx", Object.defineProperty(this, "multiline", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 13));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 13) : this.Ff = K(this.Ff, 13);
+        }
+      }), Object.defineProperty(this, "fileSelect", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 21));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 21) : this.Ff = K(this.Ff, 21);
+        }
+      }), Object.defineProperty(this, "doNotSpellCheck", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 23));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 23) : this.Ff = K(this.Ff, 23);
+        }
+      }), Object.defineProperty(this, "doNotScroll", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 24));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 24) : this.Ff = K(this.Ff, 24);
+        }
+      }), Object.defineProperty(this, "comb", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 25));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 25) : this.Ff = K(this.Ff, 25);
+        }
+      }), Object.defineProperty(this, "richText", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 26));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 26) : this.Ff = K(this.Ff, 26);
+        }
+      });
+      var t = null;
+      Object.defineProperty(this, "MaxLen", {
+        enumerable: !0,
+        configurable: !1,
+        get: function get() {
+          return t;
+        },
+        set: function set(e) {
+          t = e;
+        }
+      }), Object.defineProperty(this, "maxLength", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return t;
+        },
+        set: function set(e) {
+          Number.isInteger(e) && (t = e);
+        }
+      }), Object.defineProperty(this, "hasAppearanceStream", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return this.V || this.DV;
+        }
+      });
+    };
+    z(wt, lt);
+    var Nt = function Nt() {
+      wt.call(this), Object.defineProperty(this, "password", {
+        enumerable: !0,
+        configurable: !0,
+        get: function get() {
+          return Boolean(J(this.Ff, 14));
+        },
+        set: function set(t) {
+          !0 === Boolean(t) ? this.Ff = X(this.Ff, 14) : this.Ff = K(this.Ff, 14);
+        }
+      }), this.password = !0;
+    };
+    z(Nt, wt);
+    var Lt = {
+      CheckBox: {
+        createAppearanceStream: function createAppearanceStream() {
+          return {
+            N: {
+              On: Lt.CheckBox.YesNormal
+            },
+            D: {
+              On: Lt.CheckBox.YesPushDown,
+              Off: Lt.CheckBox.OffPushDown
+            }
+          };
+        },
+        YesPushDown: function YesPushDown(t) {
+          var e = W(t);
+          e.scope = t.scope;
+          var r = [],
+            n = t.scope.internal.getFont(t.fontName, t.fontStyle).id,
+            i = t.scope.__private__.encodeColorString(t.color),
+            a = Q(t, t.caption);
+          return r.push("0.749023 g"), r.push("0 0 " + T(Lt.internal.getWidth(t)) + " " + T(Lt.internal.getHeight(t)) + " re"), r.push("f"), r.push("BMC"), r.push("q"), r.push("0 0 1 rg"), r.push("/" + n + " " + T(a.fontSize) + " Tf " + i), r.push("BT"), r.push(a.text), r.push("ET"), r.push("Q"), r.push("EMC"), e.stream = r.join("\n"), e;
+        },
+        YesNormal: function YesNormal(t) {
+          var e = W(t);
+          e.scope = t.scope;
+          var r = t.scope.internal.getFont(t.fontName, t.fontStyle).id,
+            n = t.scope.__private__.encodeColorString(t.color),
+            i = [],
+            a = Lt.internal.getHeight(t),
+            o = Lt.internal.getWidth(t),
+            s = Q(t, t.caption);
+          return i.push("1 g"), i.push("0 0 " + T(o) + " " + T(a) + " re"), i.push("f"), i.push("q"), i.push("0 0 1 rg"), i.push("0 0 " + T(o - 1) + " " + T(a - 1) + " re"), i.push("W"), i.push("n"), i.push("0 g"), i.push("BT"), i.push("/" + r + " " + T(s.fontSize) + " Tf " + n), i.push(s.text), i.push("ET"), i.push("Q"), e.stream = i.join("\n"), e;
+        },
+        OffPushDown: function OffPushDown(t) {
+          var e = W(t);
+          e.scope = t.scope;
+          var r = [];
+          return r.push("0.749023 g"), r.push("0 0 " + T(Lt.internal.getWidth(t)) + " " + T(Lt.internal.getHeight(t)) + " re"), r.push("f"), e.stream = r.join("\n"), e;
+        }
+      },
+      RadioButton: {
+        Circle: {
+          createAppearanceStream: function createAppearanceStream(t) {
+            var e = {
+              D: {
+                Off: Lt.RadioButton.Circle.OffPushDown
+              },
+              N: {}
+            };
+            return e.N[t] = Lt.RadioButton.Circle.YesNormal, e.D[t] = Lt.RadioButton.Circle.YesPushDown, e;
+          },
+          getCA: function getCA() {
+            return "l";
+          },
+          YesNormal: function YesNormal(t) {
+            var e = W(t);
+            e.scope = t.scope;
+            var r = [],
+              n = Lt.internal.getWidth(t) <= Lt.internal.getHeight(t) ? Lt.internal.getWidth(t) / 4 : Lt.internal.getHeight(t) / 4;
+            n = Number((.9 * n).toFixed(5));
+            var i = Lt.internal.Bezier_C,
+              a = Number((n * i).toFixed(5));
+            return r.push("q"), r.push("1 0 0 1 " + U(Lt.internal.getWidth(t) / 2) + " " + U(Lt.internal.getHeight(t) / 2) + " cm"), r.push(n + " 0 m"), r.push(n + " " + a + " " + a + " " + n + " 0 " + n + " c"), r.push("-" + a + " " + n + " -" + n + " " + a + " -" + n + " 0 c"), r.push("-" + n + " -" + a + " -" + a + " -" + n + " 0 -" + n + " c"), r.push(a + " -" + n + " " + n + " -" + a + " " + n + " 0 c"), r.push("f"), r.push("Q"), e.stream = r.join("\n"), e;
+          },
+          YesPushDown: function YesPushDown(t) {
+            var e = W(t);
+            e.scope = t.scope;
+            var r = [],
+              n = Lt.internal.getWidth(t) <= Lt.internal.getHeight(t) ? Lt.internal.getWidth(t) / 4 : Lt.internal.getHeight(t) / 4;
+            n = Number((.9 * n).toFixed(5));
+            var i = Number((2 * n).toFixed(5)),
+              a = Number((i * Lt.internal.Bezier_C).toFixed(5)),
+              o = Number((n * Lt.internal.Bezier_C).toFixed(5));
+            return r.push("0.749023 g"), r.push("q"), r.push("1 0 0 1 " + U(Lt.internal.getWidth(t) / 2) + " " + U(Lt.internal.getHeight(t) / 2) + " cm"), r.push(i + " 0 m"), r.push(i + " " + a + " " + a + " " + i + " 0 " + i + " c"), r.push("-" + a + " " + i + " -" + i + " " + a + " -" + i + " 0 c"), r.push("-" + i + " -" + a + " -" + a + " -" + i + " 0 -" + i + " c"), r.push(a + " -" + i + " " + i + " -" + a + " " + i + " 0 c"), r.push("f"), r.push("Q"), r.push("0 g"), r.push("q"), r.push("1 0 0 1 " + U(Lt.internal.getWidth(t) / 2) + " " + U(Lt.internal.getHeight(t) / 2) + " cm"), r.push(n + " 0 m"), r.push(n + " " + o + " " + o + " " + n + " 0 " + n + " c"), r.push("-" + o + " " + n + " -" + n + " " + o + " -" + n + " 0 c"), r.push("-" + n + " -" + o + " -" + o + " -" + n + " 0 -" + n + " c"), r.push(o + " -" + n + " " + n + " -" + o + " " + n + " 0 c"), r.push("f"), r.push("Q"), e.stream = r.join("\n"), e;
+          },
+          OffPushDown: function OffPushDown(t) {
+            var e = W(t);
+            e.scope = t.scope;
+            var r = [],
+              n = Lt.internal.getWidth(t) <= Lt.internal.getHeight(t) ? Lt.internal.getWidth(t) / 4 : Lt.internal.getHeight(t) / 4;
+            n = Number((.9 * n).toFixed(5));
+            var i = Number((2 * n).toFixed(5)),
+              a = Number((i * Lt.internal.Bezier_C).toFixed(5));
+            return r.push("0.749023 g"), r.push("q"), r.push("1 0 0 1 " + U(Lt.internal.getWidth(t) / 2) + " " + U(Lt.internal.getHeight(t) / 2) + " cm"), r.push(i + " 0 m"), r.push(i + " " + a + " " + a + " " + i + " 0 " + i + " c"), r.push("-" + a + " " + i + " -" + i + " " + a + " -" + i + " 0 c"), r.push("-" + i + " -" + a + " -" + a + " -" + i + " 0 -" + i + " c"), r.push(a + " -" + i + " " + i + " -" + a + " " + i + " 0 c"), r.push("f"), r.push("Q"), e.stream = r.join("\n"), e;
+          }
+        },
+        Cross: {
+          createAppearanceStream: function createAppearanceStream(t) {
+            var e = {
+              D: {
+                Off: Lt.RadioButton.Cross.OffPushDown
+              },
+              N: {}
+            };
+            return e.N[t] = Lt.RadioButton.Cross.YesNormal, e.D[t] = Lt.RadioButton.Cross.YesPushDown, e;
+          },
+          getCA: function getCA() {
+            return "8";
+          },
+          YesNormal: function YesNormal(t) {
+            var e = W(t);
+            e.scope = t.scope;
+            var r = [],
+              n = Lt.internal.calculateCross(t);
+            return r.push("q"), r.push("1 1 " + T(Lt.internal.getWidth(t) - 2) + " " + T(Lt.internal.getHeight(t) - 2) + " re"), r.push("W"), r.push("n"), r.push(T(n.x1.x) + " " + T(n.x1.y) + " m"), r.push(T(n.x2.x) + " " + T(n.x2.y) + " l"), r.push(T(n.x4.x) + " " + T(n.x4.y) + " m"), r.push(T(n.x3.x) + " " + T(n.x3.y) + " l"), r.push("s"), r.push("Q"), e.stream = r.join("\n"), e;
+          },
+          YesPushDown: function YesPushDown(t) {
+            var e = W(t);
+            e.scope = t.scope;
+            var r = Lt.internal.calculateCross(t),
+              n = [];
+            return n.push("0.749023 g"), n.push("0 0 " + T(Lt.internal.getWidth(t)) + " " + T(Lt.internal.getHeight(t)) + " re"), n.push("f"), n.push("q"), n.push("1 1 " + T(Lt.internal.getWidth(t) - 2) + " " + T(Lt.internal.getHeight(t) - 2) + " re"), n.push("W"), n.push("n"), n.push(T(r.x1.x) + " " + T(r.x1.y) + " m"), n.push(T(r.x2.x) + " " + T(r.x2.y) + " l"), n.push(T(r.x4.x) + " " + T(r.x4.y) + " m"), n.push(T(r.x3.x) + " " + T(r.x3.y) + " l"), n.push("s"), n.push("Q"), e.stream = n.join("\n"), e;
+          },
+          OffPushDown: function OffPushDown(t) {
+            var e = W(t);
+            e.scope = t.scope;
+            var r = [];
+            return r.push("0.749023 g"), r.push("0 0 " + T(Lt.internal.getWidth(t)) + " " + T(Lt.internal.getHeight(t)) + " re"), r.push("f"), e.stream = r.join("\n"), e;
+          }
+        }
+      },
+      createDefaultAppearanceStream: function createDefaultAppearanceStream(t) {
+        var e = t.scope.internal.getFont(t.fontName, t.fontStyle).id,
+          r = t.scope.__private__.encodeColorString(t.color);
+        return "/" + e + " " + t.fontSize + " Tf " + r;
+      }
+    };
+    Lt.internal = {
+      Bezier_C: .551915024494,
+      calculateCross: function calculateCross(t) {
+        var e = Lt.internal.getWidth(t),
+          r = Lt.internal.getHeight(t),
+          n = Math.min(e, r);
+        return {
+          x1: {
+            x: (e - n) / 2,
+            y: (r - n) / 2 + n
+          },
+          x2: {
+            x: (e - n) / 2 + n,
+            y: (r - n) / 2
+          },
+          x3: {
+            x: (e - n) / 2,
+            y: (r - n) / 2
+          },
+          x4: {
+            x: (e - n) / 2 + n,
+            y: (r - n) / 2 + n
+          }
+        };
+      }
+    }, Lt.internal.getWidth = function (t) {
+      var r = 0;
+      return "object" === e(t) && (r = H(t.Rect[2])), r;
+    }, Lt.internal.getHeight = function (t) {
+      var r = 0;
+      return "object" === e(t) && (r = H(t.Rect[3])), r;
+    };
+    var At = E.addField = function (t) {
+      if (it(this, t), !(t instanceof lt)) throw new Error("Invalid argument passed to jsPDF.addField.");
+      var e;
+      return (e = t).scope.internal.acroformPlugin.printedOut && (e.scope.internal.acroformPlugin.printedOut = !1, e.scope.internal.acroformPlugin.acroFormDictionaryRoot = null), e.scope.internal.acroformPlugin.acroFormDictionaryRoot.Fields.push(e), t.page = t.scope.internal.getCurrentPageInfo().pageNumber, this;
+    };
+    E.AcroFormChoiceField = ht, E.AcroFormListBox = ft, E.AcroFormComboBox = dt, E.AcroFormEditBox = pt, E.AcroFormButton = gt, E.AcroFormPushButton = mt, E.AcroFormRadioButton = vt, E.AcroFormCheckBox = yt, E.AcroFormTextField = wt, E.AcroFormPasswordField = Nt, E.AcroFormAppearance = Lt, E.AcroForm = {
+      ChoiceField: ht,
+      ListBox: ft,
+      ComboBox: dt,
+      EditBox: pt,
+      Button: gt,
+      PushButton: mt,
+      RadioButton: vt,
+      CheckBox: yt,
+      TextField: wt,
+      PasswordField: Nt,
+      Appearance: Lt
+    }, M.AcroForm = {
+      ChoiceField: ht,
+      ListBox: ft,
+      ComboBox: dt,
+      EditBox: pt,
+      Button: gt,
+      PushButton: mt,
+      RadioButton: vt,
+      CheckBox: yt,
+      TextField: wt,
+      PasswordField: Nt,
+      Appearance: Lt
+    };
+    var xt = M.AcroForm;
+    function St(t) {
+      return t.reduce(function (t, e, r) {
+        return t[e] = r, t;
+      }, {});
+    }
+    !function (t) {
+      t.__addimage__ = {};
+      var r = "UNKNOWN",
+        n = {
+          PNG: [[137, 80, 78, 71]],
+          TIFF: [[77, 77, 0, 42], [73, 73, 42, 0]],
+          JPEG: [[255, 216, 255, 224, void 0, void 0, 74, 70, 73, 70, 0], [255, 216, 255, 225, void 0, void 0, 69, 120, 105, 102, 0, 0], [255, 216, 255, 219], [255, 216, 255, 238]],
+          JPEG2000: [[0, 0, 0, 12, 106, 80, 32, 32]],
+          GIF87a: [[71, 73, 70, 56, 55, 97]],
+          GIF89a: [[71, 73, 70, 56, 57, 97]],
+          WEBP: [[82, 73, 70, 70, void 0, void 0, void 0, void 0, 87, 69, 66, 80]],
+          BMP: [[66, 77], [66, 65], [67, 73], [67, 80], [73, 67], [80, 84]]
+        },
+        i = t.__addimage__.getImageFileTypeByImageData = function (t, e) {
+          var i,
+            a,
+            o,
+            s,
+            c,
+            u = r;
+          if ("RGBA" === (e = e || r) || void 0 !== t.data && t.data instanceof Uint8ClampedArray && "height" in t && "width" in t) return "RGBA";
+          if (x(t)) for (c in n) for (o = n[c], i = 0; i < o.length; i += 1) {
+            for (s = !0, a = 0; a < o[i].length; a += 1) if (void 0 !== o[i][a] && o[i][a] !== t[a]) {
+              s = !1;
+              break;
+            }
+            if (!0 === s) {
+              u = c;
+              break;
+            }
+          } else for (c in n) for (o = n[c], i = 0; i < o.length; i += 1) {
+            for (s = !0, a = 0; a < o[i].length; a += 1) if (void 0 !== o[i][a] && o[i][a] !== t.charCodeAt(a)) {
+              s = !1;
+              break;
+            }
+            if (!0 === s) {
+              u = c;
+              break;
+            }
+          }
+          return u === r && e !== r && (u = e), u;
+        },
+        a = function t(e) {
+          for (var r = this.internal.write, n = this.internal.putStream, i = (0, this.internal.getFilters)(); -1 !== i.indexOf("FlateEncode");) i.splice(i.indexOf("FlateEncode"), 1);
+          e.objectId = this.internal.newObject();
+          var a = [];
+          if (a.push({
+            key: "Type",
+            value: "/XObject"
+          }), a.push({
+            key: "Subtype",
+            value: "/Image"
+          }), a.push({
+            key: "Width",
+            value: e.width
+          }), a.push({
+            key: "Height",
+            value: e.height
+          }), e.colorSpace === b.INDEXED ? a.push({
+            key: "ColorSpace",
+            value: "[/Indexed /DeviceRGB " + (e.palette.length / 3 - 1) + " " + ("sMask" in e && void 0 !== e.sMask ? e.objectId + 2 : e.objectId + 1) + " 0 R]"
+          }) : (a.push({
+            key: "ColorSpace",
+            value: "/" + e.colorSpace
+          }), e.colorSpace === b.DEVICE_CMYK && a.push({
+            key: "Decode",
+            value: "[1 0 1 0 1 0 1 0]"
+          })), a.push({
+            key: "BitsPerComponent",
+            value: e.bitsPerComponent
+          }), "decodeParameters" in e && void 0 !== e.decodeParameters && a.push({
+            key: "DecodeParms",
+            value: "<<" + e.decodeParameters + ">>"
+          }), "transparency" in e && Array.isArray(e.transparency)) {
+            for (var o = "", s = 0, c = e.transparency.length; s < c; s++) o += e.transparency[s] + " " + e.transparency[s] + " ";
+            a.push({
+              key: "Mask",
+              value: "[" + o + "]"
+            });
+          }
+          void 0 !== e.sMask && a.push({
+            key: "SMask",
+            value: e.objectId + 1 + " 0 R"
+          });
+          var u = void 0 !== e.filter ? ["/" + e.filter] : void 0;
+          if (n({
+            data: e.data,
+            additionalKeyValues: a,
+            alreadyAppliedFilters: u,
+            objectId: e.objectId
+          }), r("endobj"), "sMask" in e && void 0 !== e.sMask) {
+            var l = "/Predictor " + e.predictor + " /Colors 1 /BitsPerComponent " + e.bitsPerComponent + " /Columns " + e.width,
+              h = {
+                width: e.width,
+                height: e.height,
+                colorSpace: "DeviceGray",
+                bitsPerComponent: e.bitsPerComponent,
+                decodeParameters: l,
+                data: e.sMask
+              };
+            "filter" in e && (h.filter = e.filter), t.call(this, h);
+          }
+          if (e.colorSpace === b.INDEXED) {
+            var f = this.internal.newObject();
+            n({
+              data: _(new Uint8Array(e.palette)),
+              objectId: f
+            }), r("endobj");
+          }
+        },
+        o = function o() {
+          var t = this.internal.collections.addImage_images;
+          for (var e in t) a.call(this, t[e]);
+        },
+        s = function s() {
+          var t,
+            e = this.internal.collections.addImage_images,
+            r = this.internal.write;
+          for (var n in e) r("/I" + (t = e[n]).index, t.objectId, "0", "R");
+        },
+        u = function u() {
+          this.internal.collections.addImage_images || (this.internal.collections.addImage_images = {}, this.internal.events.subscribe("putResources", o), this.internal.events.subscribe("putXobjectDict", s));
+        },
+        l = function l() {
+          var t = this.internal.collections.addImage_images;
+          return u.call(this), t;
+        },
+        h = function h() {
+          return Object.keys(this.internal.collections.addImage_images).length;
+        },
+        f = function f(e) {
+          return "function" == typeof t["process" + e.toUpperCase()];
+        },
+        d = function d(t) {
+          return "object" === e(t) && 1 === t.nodeType;
+        },
+        p = function p(e, r) {
+          if ("IMG" === e.nodeName && e.hasAttribute("src")) {
+            var n = "" + e.getAttribute("src");
+            if (0 === n.indexOf("data:image/")) return c(unescape(n).split("base64,").pop());
+            var i = t.loadFile(n, !0);
+            if (void 0 !== i) return i;
+          }
+          if ("CANVAS" === e.nodeName) {
+            if (0 === e.width || 0 === e.height) throw new Error("Given canvas must have data. Canvas width: " + e.width + ", height: " + e.height);
+            var a;
+            switch (r) {
+              case "PNG":
+                a = "image/png";
+                break;
+              case "WEBP":
+                a = "image/webp";
+                break;
+              case "JPEG":
+              case "JPG":
+              default:
+                a = "image/jpeg";
+            }
+            return c(e.toDataURL(a, 1).split("base64,").pop());
+          }
+        },
+        g = function g(t) {
+          var e = this.internal.collections.addImage_images;
+          if (e) for (var r in e) if (t === e[r].alias) return e[r];
+        },
+        m = function m(t, e, r) {
+          return t || e || (t = -96, e = -96), t < 0 && (t = -1 * r.width * 72 / t / this.internal.scaleFactor), e < 0 && (e = -1 * r.height * 72 / e / this.internal.scaleFactor), 0 === t && (t = e * r.width / r.height), 0 === e && (e = t * r.height / r.width), [t, e];
+        },
+        v = function v(t, e, r, n, i, a) {
+          var o = m.call(this, r, n, i),
+            s = this.internal.getCoordinateString,
+            c = this.internal.getVerticalCoordinateString,
+            u = l.call(this);
+          if (r = o[0], n = o[1], u[i.index] = i, a) {
+            a *= Math.PI / 180;
+            var h = Math.cos(a),
+              f = Math.sin(a),
+              d = function d(t) {
+                return t.toFixed(4);
+              },
+              p = [d(h), d(f), d(-1 * f), d(h), 0, 0, "cm"];
+          }
+          this.internal.write("q"), a ? (this.internal.write([1, "0", "0", 1, s(t), c(e + n), "cm"].join(" ")), this.internal.write(p.join(" ")), this.internal.write([s(r), "0", "0", s(n), "0", "0", "cm"].join(" "))) : this.internal.write([s(r), "0", "0", s(n), s(t), c(e + n), "cm"].join(" ")), this.isAdvancedAPI() && this.internal.write([1, 0, 0, -1, 0, 0, "cm"].join(" ")), this.internal.write("/I" + i.index + " Do"), this.internal.write("Q");
+        },
+        b = t.color_spaces = {
+          DEVICE_RGB: "DeviceRGB",
+          DEVICE_GRAY: "DeviceGray",
+          DEVICE_CMYK: "DeviceCMYK",
+          CAL_GREY: "CalGray",
+          CAL_RGB: "CalRGB",
+          LAB: "Lab",
+          ICC_BASED: "ICCBased",
+          INDEXED: "Indexed",
+          PATTERN: "Pattern",
+          SEPARATION: "Separation",
+          DEVICE_N: "DeviceN"
+        };
+      t.decode = {
+        DCT_DECODE: "DCTDecode",
+        FLATE_DECODE: "FlateDecode",
+        LZW_DECODE: "LZWDecode",
+        JPX_DECODE: "JPXDecode",
+        JBIG2_DECODE: "JBIG2Decode",
+        ASCII85_DECODE: "ASCII85Decode",
+        ASCII_HEX_DECODE: "ASCIIHexDecode",
+        RUN_LENGTH_DECODE: "RunLengthDecode",
+        CCITT_FAX_DECODE: "CCITTFaxDecode"
+      };
+      var y = t.image_compression = {
+          NONE: "NONE",
+          FAST: "FAST",
+          MEDIUM: "MEDIUM",
+          SLOW: "SLOW"
+        },
+        w = t.__addimage__.sHashCode = function (t) {
+          var e,
+            r,
+            n = 0;
+          if ("string" == typeof t) for (r = t.length, e = 0; e < r; e++) n = (n << 5) - n + t.charCodeAt(e), n |= 0;else if (x(t)) for (r = t.byteLength / 2, e = 0; e < r; e++) n = (n << 5) - n + t[e], n |= 0;
+          return n;
+        },
+        N = t.__addimage__.validateStringAsBase64 = function (t) {
+          (t = t || "").toString().trim();
+          var e = !0;
+          return 0 === t.length && (e = !1), t.length % 4 != 0 && (e = !1), !1 === /^[A-Za-z0-9+/]+$/.test(t.substr(0, t.length - 2)) && (e = !1), !1 === /^[A-Za-z0-9/][A-Za-z0-9+/]|[A-Za-z0-9+/]=|==$/.test(t.substr(-2)) && (e = !1), e;
+        },
+        L = t.__addimage__.extractImageFromDataUrl = function (t) {
+          var e = (t = t || "").split("base64,"),
+            r = null;
+          if (2 === e.length) {
+            var n = /^data:(\w*\/\w*);*(charset=(?!charset=)[\w=-]*)*;*$/.exec(e[0]);
+            Array.isArray(n) && (r = {
+              mimeType: n[1],
+              charset: n[2],
+              data: e[1]
+            });
+          }
+          return r;
+        },
+        A = t.__addimage__.supportsArrayBuffer = function () {
+          return "undefined" != typeof ArrayBuffer && "undefined" != typeof Uint8Array;
+        };
+      t.__addimage__.isArrayBuffer = function (t) {
+        return A() && t instanceof ArrayBuffer;
+      };
+      var x = t.__addimage__.isArrayBufferView = function (t) {
+          return A() && "undefined" != typeof Uint32Array && (t instanceof Int8Array || t instanceof Uint8Array || "undefined" != typeof Uint8ClampedArray && t instanceof Uint8ClampedArray || t instanceof Int16Array || t instanceof Uint16Array || t instanceof Int32Array || t instanceof Uint32Array || t instanceof Float32Array || t instanceof Float64Array);
+        },
+        S = t.__addimage__.binaryStringToUint8Array = function (t) {
+          for (var e = t.length, r = new Uint8Array(e), n = 0; n < e; n++) r[n] = t.charCodeAt(n);
+          return r;
+        },
+        _ = t.__addimage__.arrayBufferToBinaryString = function (t) {
+          for (var e = "", r = x(t) ? t : new Uint8Array(t), n = 0; n < r.length; n += 8192) e += String.fromCharCode.apply(null, r.subarray(n, n + 8192));
+          return e;
+        };
+      t.addImage = function () {
+        var t, n, i, a, o, s, c, l, h;
+        if ("number" == typeof arguments[1] ? (n = r, i = arguments[1], a = arguments[2], o = arguments[3], s = arguments[4], c = arguments[5], l = arguments[6], h = arguments[7]) : (n = arguments[1], i = arguments[2], a = arguments[3], o = arguments[4], s = arguments[5], c = arguments[6], l = arguments[7], h = arguments[8]), "object" === e(t = arguments[0]) && !d(t) && "imageData" in t) {
+          var f = t;
+          t = f.imageData, n = f.format || n || r, i = f.x || i || 0, a = f.y || a || 0, o = f.w || f.width || o, s = f.h || f.height || s, c = f.alias || c, l = f.compression || l, h = f.rotation || f.angle || h;
+        }
+        var p = this.internal.getFilters();
+        if (void 0 === l && -1 !== p.indexOf("FlateEncode") && (l = "SLOW"), isNaN(i) || isNaN(a)) throw new Error("Invalid coordinates passed to jsPDF.addImage");
+        u.call(this);
+        var g = P.call(this, t, n, c, l);
+        return v.call(this, i, a, o, s, g, h), this;
+      };
+      var P = function P(e, n, a, o) {
+          var s, c, u;
+          if ("string" == typeof e && i(e) === r) {
+            e = unescape(e);
+            var l = k(e, !1);
+            ("" !== l || void 0 !== (l = t.loadFile(e, !0))) && (e = l);
+          }
+          if (d(e) && (e = p(e, n)), n = i(e, n), !f(n)) throw new Error("addImage does not support files of type '" + n + "', please ensure that a plugin for '" + n + "' support is added.");
+          if ((null == (u = a) || 0 === u.length) && (a = function (t) {
+            return "string" == typeof t || x(t) ? w(t) : x(t.data) ? w(t.data) : null;
+          }(e)), (s = g.call(this, a)) || (A() && (e instanceof Uint8Array || "RGBA" === n || (c = e, e = S(e))), s = this["process" + n.toUpperCase()](e, h.call(this), a, function (e) {
+            return e && "string" == typeof e && (e = e.toUpperCase()), e in t.image_compression ? e : y.NONE;
+          }(o), c)), !s) throw new Error("An unknown error occurred whilst processing the image.");
+          return s;
+        },
+        k = t.__addimage__.convertBase64ToBinaryString = function (t, e) {
+          var r;
+          e = "boolean" != typeof e || e;
+          var n,
+            i = "";
+          if ("string" == typeof t) {
+            n = null !== (r = L(t)) ? r.data : t;
+            try {
+              i = c(n);
+            } catch (t) {
+              if (e) throw N(n) ? new Error("atob-Error in jsPDF.convertBase64ToBinaryString " + t.message) : new Error("Supplied Data is not a valid base64-String jsPDF.convertBase64ToBinaryString ");
+            }
+          }
+          return i;
+        };
+      t.getImageProperties = function (e) {
+        var n,
+          a,
+          o = "";
+        if (d(e) && (e = p(e)), "string" == typeof e && i(e) === r && ("" === (o = k(e, !1)) && (o = t.loadFile(e) || ""), e = o), a = i(e), !f(a)) throw new Error("addImage does not support files of type '" + a + "', please ensure that a plugin for '" + a + "' support is added.");
+        if (!A() || e instanceof Uint8Array || (e = S(e)), !(n = this["process" + a.toUpperCase()](e))) throw new Error("An unknown error occurred whilst processing the image");
+        return n.fileType = a, n;
+      };
+    }(M.API),
+    /**
+       * @license
+       * Copyright (c) 2014 Steven Spungin (TwelveTone LLC)  steven@twelvetone.tv
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      var e = function e(t) {
+        if (void 0 !== t && "" != t) return !0;
+      };
+      M.API.events.push(["addPage", function (t) {
+        this.internal.getPageInfo(t.pageNumber).pageContext.annotations = [];
+      }]), t.events.push(["putPage", function (t) {
+        for (var r, n, i, a = this.internal.getCoordinateString, o = this.internal.getVerticalCoordinateString, s = this.internal.getPageInfoByObjId(t.objId), c = t.pageContext.annotations, u = !1, l = 0; l < c.length && !u; l++) switch ((r = c[l]).type) {
+          case "link":
+            (e(r.options.url) || e(r.options.pageNumber)) && (u = !0);
+            break;
+          case "reference":
+          case "text":
+          case "freetext":
+            u = !0;
+        }
+        if (0 != u) {
+          this.internal.write("/Annots [");
+          for (var h = 0; h < c.length; h++) {
+            r = c[h];
+            var f = this.internal.pdfEscape,
+              d = this.internal.getEncryptor(t.objId);
+            switch (r.type) {
+              case "reference":
+                this.internal.write(" " + r.object.objId + " 0 R ");
+                break;
+              case "text":
+                var p = this.internal.newAdditionalObject(),
+                  g = this.internal.newAdditionalObject(),
+                  m = this.internal.getEncryptor(p.objId),
+                  v = r.title || "Note";
+                i = "<</Type /Annot /Subtype /Text " + (n = "/Rect [" + a(r.bounds.x) + " " + o(r.bounds.y + r.bounds.h) + " " + a(r.bounds.x + r.bounds.w) + " " + o(r.bounds.y) + "] ") + "/Contents (" + f(m(r.contents)) + ")", i += " /Popup " + g.objId + " 0 R", i += " /P " + s.objId + " 0 R", i += " /T (" + f(m(v)) + ") >>", p.content = i;
+                var b = p.objId + " 0 R";
+                i = "<</Type /Annot /Subtype /Popup " + (n = "/Rect [" + a(r.bounds.x + 30) + " " + o(r.bounds.y + r.bounds.h) + " " + a(r.bounds.x + r.bounds.w + 30) + " " + o(r.bounds.y) + "] ") + " /Parent " + b, r.open && (i += " /Open true"), i += " >>", g.content = i, this.internal.write(p.objId, "0 R", g.objId, "0 R");
+                break;
+              case "freetext":
+                n = "/Rect [" + a(r.bounds.x) + " " + o(r.bounds.y) + " " + a(r.bounds.x + r.bounds.w) + " " + o(r.bounds.y + r.bounds.h) + "] ";
+                var y = r.color || "#000000";
+                i = "<</Type /Annot /Subtype /FreeText " + n + "/Contents (" + f(d(r.contents)) + ")", i += " /DS(font: Helvetica,sans-serif 12.0pt; text-align:left; color:#" + y + ")", i += " /Border [0 0 0]", i += " >>", this.internal.write(i);
+                break;
+              case "link":
+                if (r.options.name) {
+                  var w = this.annotations._nameMap[r.options.name];
+                  r.options.pageNumber = w.page, r.options.top = w.y;
+                } else r.options.top || (r.options.top = 0);
+                if (n = "/Rect [" + r.finalBounds.x + " " + r.finalBounds.y + " " + r.finalBounds.w + " " + r.finalBounds.h + "] ", i = "", r.options.url) i = "<</Type /Annot /Subtype /Link " + n + "/Border [0 0 0] /A <</S /URI /URI (" + f(d(r.options.url)) + ") >>";else if (r.options.pageNumber) {
+                  switch (i = "<</Type /Annot /Subtype /Link " + n + "/Border [0 0 0] /Dest [" + this.internal.getPageInfo(r.options.pageNumber).objId + " 0 R", r.options.magFactor = r.options.magFactor || "XYZ", r.options.magFactor) {
+                    case "Fit":
+                      i += " /Fit]";
+                      break;
+                    case "FitH":
+                      i += " /FitH " + r.options.top + "]";
+                      break;
+                    case "FitV":
+                      r.options.left = r.options.left || 0, i += " /FitV " + r.options.left + "]";
+                      break;
+                    case "XYZ":
+                    default:
+                      var N = o(r.options.top);
+                      r.options.left = r.options.left || 0, void 0 === r.options.zoom && (r.options.zoom = 0), i += " /XYZ " + r.options.left + " " + N + " " + r.options.zoom + "]";
+                  }
+                }
+                "" != i && (i += " >>", this.internal.write(i));
+            }
+          }
+          this.internal.write("]");
+        }
+      }]), t.createAnnotation = function (t) {
+        var e = this.internal.getCurrentPageInfo();
+        switch (t.type) {
+          case "link":
+            this.link(t.bounds.x, t.bounds.y, t.bounds.w, t.bounds.h, t);
+            break;
+          case "text":
+          case "freetext":
+            e.pageContext.annotations.push(t);
+        }
+      }, t.link = function (t, e, r, n, i) {
+        var a = this.internal.getCurrentPageInfo(),
+          o = this.internal.getCoordinateString,
+          s = this.internal.getVerticalCoordinateString;
+        a.pageContext.annotations.push({
+          finalBounds: {
+            x: o(t),
+            y: s(e),
+            w: o(t + r),
+            h: s(e + n)
+          },
+          options: i,
+          type: "link"
+        });
+      }, t.textWithLink = function (t, e, r, n) {
+        var i,
+          a,
+          o = this.getTextWidth(t),
+          s = this.internal.getLineHeight() / this.internal.scaleFactor;
+        if (void 0 !== n.maxWidth) {
+          a = n.maxWidth;
+          var c = this.splitTextToSize(t, a).length;
+          i = Math.ceil(s * c);
+        } else a = o, i = s;
+        return this.text(t, e, r, n), r += .2 * s, "center" === n.align && (e -= o / 2), "right" === n.align && (e -= o), this.link(e, r - s, a, i, n), o;
+      }, t.getTextWidth = function (t) {
+        var e = this.internal.getFontSize();
+        return this.getStringUnitWidth(t) * e / this.internal.scaleFactor;
+      };
+    }(M.API),
+    /**
+       * @license
+       * Copyright (c) 2017 Aras Abbasi
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      var e = {
+          1569: [65152],
+          1570: [65153, 65154],
+          1571: [65155, 65156],
+          1572: [65157, 65158],
+          1573: [65159, 65160],
+          1574: [65161, 65162, 65163, 65164],
+          1575: [65165, 65166],
+          1576: [65167, 65168, 65169, 65170],
+          1577: [65171, 65172],
+          1578: [65173, 65174, 65175, 65176],
+          1579: [65177, 65178, 65179, 65180],
+          1580: [65181, 65182, 65183, 65184],
+          1581: [65185, 65186, 65187, 65188],
+          1582: [65189, 65190, 65191, 65192],
+          1583: [65193, 65194],
+          1584: [65195, 65196],
+          1585: [65197, 65198],
+          1586: [65199, 65200],
+          1587: [65201, 65202, 65203, 65204],
+          1588: [65205, 65206, 65207, 65208],
+          1589: [65209, 65210, 65211, 65212],
+          1590: [65213, 65214, 65215, 65216],
+          1591: [65217, 65218, 65219, 65220],
+          1592: [65221, 65222, 65223, 65224],
+          1593: [65225, 65226, 65227, 65228],
+          1594: [65229, 65230, 65231, 65232],
+          1601: [65233, 65234, 65235, 65236],
+          1602: [65237, 65238, 65239, 65240],
+          1603: [65241, 65242, 65243, 65244],
+          1604: [65245, 65246, 65247, 65248],
+          1605: [65249, 65250, 65251, 65252],
+          1606: [65253, 65254, 65255, 65256],
+          1607: [65257, 65258, 65259, 65260],
+          1608: [65261, 65262],
+          1609: [65263, 65264, 64488, 64489],
+          1610: [65265, 65266, 65267, 65268],
+          1649: [64336, 64337],
+          1655: [64477],
+          1657: [64358, 64359, 64360, 64361],
+          1658: [64350, 64351, 64352, 64353],
+          1659: [64338, 64339, 64340, 64341],
+          1662: [64342, 64343, 64344, 64345],
+          1663: [64354, 64355, 64356, 64357],
+          1664: [64346, 64347, 64348, 64349],
+          1667: [64374, 64375, 64376, 64377],
+          1668: [64370, 64371, 64372, 64373],
+          1670: [64378, 64379, 64380, 64381],
+          1671: [64382, 64383, 64384, 64385],
+          1672: [64392, 64393],
+          1676: [64388, 64389],
+          1677: [64386, 64387],
+          1678: [64390, 64391],
+          1681: [64396, 64397],
+          1688: [64394, 64395],
+          1700: [64362, 64363, 64364, 64365],
+          1702: [64366, 64367, 64368, 64369],
+          1705: [64398, 64399, 64400, 64401],
+          1709: [64467, 64468, 64469, 64470],
+          1711: [64402, 64403, 64404, 64405],
+          1713: [64410, 64411, 64412, 64413],
+          1715: [64406, 64407, 64408, 64409],
+          1722: [64414, 64415],
+          1723: [64416, 64417, 64418, 64419],
+          1726: [64426, 64427, 64428, 64429],
+          1728: [64420, 64421],
+          1729: [64422, 64423, 64424, 64425],
+          1733: [64480, 64481],
+          1734: [64473, 64474],
+          1735: [64471, 64472],
+          1736: [64475, 64476],
+          1737: [64482, 64483],
+          1739: [64478, 64479],
+          1740: [64508, 64509, 64510, 64511],
+          1744: [64484, 64485, 64486, 64487],
+          1746: [64430, 64431],
+          1747: [64432, 64433]
+        },
+        r = {
+          65247: {
+            65154: 65269,
+            65156: 65271,
+            65160: 65273,
+            65166: 65275
+          },
+          65248: {
+            65154: 65270,
+            65156: 65272,
+            65160: 65274,
+            65166: 65276
+          },
+          65165: {
+            65247: {
+              65248: {
+                65258: 65010
+              }
+            }
+          },
+          1617: {
+            1612: 64606,
+            1613: 64607,
+            1614: 64608,
+            1615: 64609,
+            1616: 64610
+          }
+        },
+        n = {
+          1612: 64606,
+          1613: 64607,
+          1614: 64608,
+          1615: 64609,
+          1616: 64610
+        },
+        i = [1570, 1571, 1573, 1575];
+      t.__arabicParser__ = {};
+      var a = t.__arabicParser__.isInArabicSubstitutionA = function (t) {
+          return void 0 !== e[t.charCodeAt(0)];
+        },
+        o = t.__arabicParser__.isArabicLetter = function (t) {
+          return "string" == typeof t && /^[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]+$/.test(t);
+        },
+        s = t.__arabicParser__.isArabicEndLetter = function (t) {
+          return o(t) && a(t) && e[t.charCodeAt(0)].length <= 2;
+        },
+        c = t.__arabicParser__.isArabicAlfLetter = function (t) {
+          return o(t) && i.indexOf(t.charCodeAt(0)) >= 0;
+        };
+      t.__arabicParser__.arabicLetterHasIsolatedForm = function (t) {
+        return o(t) && a(t) && e[t.charCodeAt(0)].length >= 1;
+      };
+      var u = t.__arabicParser__.arabicLetterHasFinalForm = function (t) {
+        return o(t) && a(t) && e[t.charCodeAt(0)].length >= 2;
+      };
+      t.__arabicParser__.arabicLetterHasInitialForm = function (t) {
+        return o(t) && a(t) && e[t.charCodeAt(0)].length >= 3;
+      };
+      var l = t.__arabicParser__.arabicLetterHasMedialForm = function (t) {
+          return o(t) && a(t) && 4 == e[t.charCodeAt(0)].length;
+        },
+        h = t.__arabicParser__.resolveLigatures = function (t) {
+          var e = 0,
+            n = r,
+            i = "",
+            a = 0;
+          for (e = 0; e < t.length; e += 1) void 0 !== n[t.charCodeAt(e)] ? (a++, "number" == typeof (n = n[t.charCodeAt(e)]) && (i += String.fromCharCode(n), n = r, a = 0), e === t.length - 1 && (n = r, i += t.charAt(e - (a - 1)), e -= a - 1, a = 0)) : (n = r, i += t.charAt(e - a), e -= a, a = 0);
+          return i;
+        };
+      t.__arabicParser__.isArabicDiacritic = function (t) {
+        return void 0 !== t && void 0 !== n[t.charCodeAt(0)];
+      };
+      var f = t.__arabicParser__.getCorrectForm = function (t, e, r) {
+          return o(t) ? !1 === a(t) ? -1 : !u(t) || !o(e) && !o(r) || !o(r) && s(e) || s(t) && !o(e) || s(t) && c(e) || s(t) && s(e) ? 0 : l(t) && o(e) && !s(e) && o(r) && u(r) ? 3 : s(t) || !o(r) ? 1 : 2 : -1;
+        },
+        d = function d(t) {
+          var r = 0,
+            n = 0,
+            i = 0,
+            a = "",
+            s = "",
+            c = "",
+            u = (t = t || "").split("\\s+"),
+            l = [];
+          for (r = 0; r < u.length; r += 1) {
+            for (l.push(""), n = 0; n < u[r].length; n += 1) a = u[r][n], s = u[r][n - 1], c = u[r][n + 1], o(a) ? (i = f(a, s, c), l[r] += -1 !== i ? String.fromCharCode(e[a.charCodeAt(0)][i]) : a) : l[r] += a;
+            l[r] = h(l[r]);
+          }
+          return l.join(" ");
+        },
+        p = t.__arabicParser__.processArabic = t.processArabic = function () {
+          var t,
+            e = "string" == typeof arguments[0] ? arguments[0] : arguments[0].text,
+            r = [];
+          if (Array.isArray(e)) {
+            var n = 0;
+            for (r = [], n = 0; n < e.length; n += 1) Array.isArray(e[n]) ? r.push([d(e[n][0]), e[n][1], e[n][2]]) : r.push([d(e[n])]);
+            t = r;
+          } else t = d(e);
+          return "string" == typeof arguments[0] ? t : (arguments[0].text = t, arguments[0]);
+        };
+      t.events.push(["preProcessText", p]);
+    }(M.API),
+    /** @license
+       * jsPDF Autoprint Plugin
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      t.autoPrint = function (t) {
+        var e;
+        switch ((t = t || {}).variant = t.variant || "non-conform", t.variant) {
+          case "javascript":
+            this.addJS("print({});");
+            break;
+          case "non-conform":
+          default:
+            this.internal.events.subscribe("postPutResources", function () {
+              e = this.internal.newObject(), this.internal.out("<<"), this.internal.out("/S /Named"), this.internal.out("/Type /Action"), this.internal.out("/N /Print"), this.internal.out(">>"), this.internal.out("endobj");
+            }), this.internal.events.subscribe("putCatalog", function () {
+              this.internal.out("/OpenAction " + e + " 0 R");
+            });
+        }
+        return this;
+      };
+    }(M.API),
+    /**
+       * @license
+       * Copyright (c) 2014 Steven Spungin (TwelveTone LLC)  steven@twelvetone.tv
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      var e = function e() {
+        var t = void 0;
+        Object.defineProperty(this, "pdf", {
+          get: function get() {
+            return t;
+          },
+          set: function set(e) {
+            t = e;
+          }
+        });
+        var e = 150;
+        Object.defineProperty(this, "width", {
+          get: function get() {
+            return e;
+          },
+          set: function set(t) {
+            e = isNaN(t) || !1 === Number.isInteger(t) || t < 0 ? 150 : t, this.getContext("2d").pageWrapXEnabled && (this.getContext("2d").pageWrapX = e + 1);
+          }
+        });
+        var r = 300;
+        Object.defineProperty(this, "height", {
+          get: function get() {
+            return r;
+          },
+          set: function set(t) {
+            r = isNaN(t) || !1 === Number.isInteger(t) || t < 0 ? 300 : t, this.getContext("2d").pageWrapYEnabled && (this.getContext("2d").pageWrapY = r + 1);
+          }
+        });
+        var n = [];
+        Object.defineProperty(this, "childNodes", {
+          get: function get() {
+            return n;
+          },
+          set: function set(t) {
+            n = t;
+          }
+        });
+        var i = {};
+        Object.defineProperty(this, "style", {
+          get: function get() {
+            return i;
+          },
+          set: function set(t) {
+            i = t;
+          }
+        }), Object.defineProperty(this, "parentNode", {});
+      };
+      e.prototype.getContext = function (t, e) {
+        var r;
+        if ("2d" !== (t = t || "2d")) return null;
+        for (r in e) this.pdf.context2d.hasOwnProperty(r) && (this.pdf.context2d[r] = e[r]);
+        return this.pdf.context2d._canvas = this, this.pdf.context2d;
+      }, e.prototype.toDataURL = function () {
+        throw new Error("toDataURL is not implemented.");
+      }, t.events.push(["initialized", function () {
+        this.canvas = new e(), this.canvas.pdf = this;
+      }]);
+    }(M.API), function (t) {
+      var r = {
+          left: 0,
+          top: 0,
+          bottom: 0,
+          right: 0
+        },
+        n = !1,
+        i = function i() {
+          void 0 === this.internal.__cell__ && (this.internal.__cell__ = {}, this.internal.__cell__.padding = 3, this.internal.__cell__.headerFunction = void 0, this.internal.__cell__.margins = Object.assign({}, r), this.internal.__cell__.margins.width = this.getPageWidth(), a.call(this));
+        },
+        a = function a() {
+          this.internal.__cell__.lastCell = new o(), this.internal.__cell__.pages = 1;
+        },
+        o = function o() {
+          var t = arguments[0];
+          Object.defineProperty(this, "x", {
+            enumerable: !0,
+            get: function get() {
+              return t;
+            },
+            set: function set(e) {
+              t = e;
+            }
+          });
+          var e = arguments[1];
+          Object.defineProperty(this, "y", {
+            enumerable: !0,
+            get: function get() {
+              return e;
+            },
+            set: function set(t) {
+              e = t;
+            }
+          });
+          var r = arguments[2];
+          Object.defineProperty(this, "width", {
+            enumerable: !0,
+            get: function get() {
+              return r;
+            },
+            set: function set(t) {
+              r = t;
+            }
+          });
+          var n = arguments[3];
+          Object.defineProperty(this, "height", {
+            enumerable: !0,
+            get: function get() {
+              return n;
+            },
+            set: function set(t) {
+              n = t;
+            }
+          });
+          var i = arguments[4];
+          Object.defineProperty(this, "text", {
+            enumerable: !0,
+            get: function get() {
+              return i;
+            },
+            set: function set(t) {
+              i = t;
+            }
+          });
+          var a = arguments[5];
+          Object.defineProperty(this, "lineNumber", {
+            enumerable: !0,
+            get: function get() {
+              return a;
+            },
+            set: function set(t) {
+              a = t;
+            }
+          });
+          var o = arguments[6];
+          return Object.defineProperty(this, "align", {
+            enumerable: !0,
+            get: function get() {
+              return o;
+            },
+            set: function set(t) {
+              o = t;
+            }
+          }), this;
+        };
+      o.prototype.clone = function () {
+        return new o(this.x, this.y, this.width, this.height, this.text, this.lineNumber, this.align);
+      }, o.prototype.toArray = function () {
+        return [this.x, this.y, this.width, this.height, this.text, this.lineNumber, this.align];
+      }, t.setHeaderFunction = function (t) {
+        return i.call(this), this.internal.__cell__.headerFunction = "function" == typeof t ? t : void 0, this;
+      }, t.getTextDimensions = function (t, e) {
+        i.call(this);
+        var r = (e = e || {}).fontSize || this.getFontSize(),
+          n = e.font || this.getFont(),
+          a = e.scaleFactor || this.internal.scaleFactor,
+          o = 0,
+          s = 0,
+          c = 0,
+          u = this;
+        if (!Array.isArray(t) && "string" != typeof t) {
+          if ("number" != typeof t) throw new Error("getTextDimensions expects text-parameter to be of type String or type Number or an Array of Strings.");
+          t = String(t);
+        }
+        var l = e.maxWidth;
+        l > 0 ? "string" == typeof t ? t = this.splitTextToSize(t, l) : "[object Array]" === Object.prototype.toString.call(t) && (t = t.reduce(function (t, e) {
+          return t.concat(u.splitTextToSize(e, l));
+        }, [])) : t = Array.isArray(t) ? t : [t];
+        for (var h = 0; h < t.length; h++) o < (c = this.getStringUnitWidth(t[h], {
+          font: n
+        }) * r) && (o = c);
+        return 0 !== o && (s = t.length), {
+          w: o /= a,
+          h: Math.max((s * r * this.getLineHeightFactor() - r * (this.getLineHeightFactor() - 1)) / a, 0)
+        };
+      }, t.cellAddPage = function () {
+        i.call(this), this.addPage();
+        var t = this.internal.__cell__.margins || r;
+        return this.internal.__cell__.lastCell = new o(t.left, t.top, void 0, void 0), this.internal.__cell__.pages += 1, this;
+      };
+      var s = t.cell = function () {
+        var t;
+        t = arguments[0] instanceof o ? arguments[0] : new o(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4], arguments[5]), i.call(this);
+        var e = this.internal.__cell__.lastCell,
+          a = this.internal.__cell__.padding,
+          s = this.internal.__cell__.margins || r,
+          c = this.internal.__cell__.tableHeaderRow,
+          u = this.internal.__cell__.printHeaders;
+        return void 0 !== e.lineNumber && (e.lineNumber === t.lineNumber ? (t.x = (e.x || 0) + (e.width || 0), t.y = e.y || 0) : e.y + e.height + t.height + s.bottom > this.getPageHeight() ? (this.cellAddPage(), t.y = s.top, u && c && (this.printHeaderRow(t.lineNumber, !0), t.y += c[0].height)) : t.y = e.y + e.height || t.y), void 0 !== t.text[0] && (this.rect(t.x, t.y, t.width, t.height, !0 === n ? "FD" : void 0), "right" === t.align ? this.text(t.text, t.x + t.width - a, t.y + a, {
+          align: "right",
+          baseline: "top"
+        }) : "center" === t.align ? this.text(t.text, t.x + t.width / 2, t.y + a, {
+          align: "center",
+          baseline: "top",
+          maxWidth: t.width - a - a
+        }) : this.text(t.text, t.x + a, t.y + a, {
+          align: "left",
+          baseline: "top",
+          maxWidth: t.width - a - a
+        })), this.internal.__cell__.lastCell = t, this;
+      };
+      t.table = function (t, n, u, l, h) {
+        if (i.call(this), !u) throw new Error("No data for PDF table.");
+        var f,
+          d,
+          p,
+          g,
+          m = [],
+          v = [],
+          b = [],
+          y = {},
+          w = {},
+          N = [],
+          L = [],
+          A = (h = h || {}).autoSize || !1,
+          x = !1 !== h.printHeaders,
+          S = h.css && void 0 !== h.css["font-size"] ? 16 * h.css["font-size"] : h.fontSize || 12,
+          _ = h.margins || Object.assign({
+            width: this.getPageWidth()
+          }, r),
+          P = "number" == typeof h.padding ? h.padding : 3,
+          k = h.headerBackgroundColor || "#c8c8c8",
+          F = h.headerTextColor || "#000";
+        if (a.call(this), this.internal.__cell__.printHeaders = x, this.internal.__cell__.margins = _, this.internal.__cell__.table_font_size = S, this.internal.__cell__.padding = P, this.internal.__cell__.headerBackgroundColor = k, this.internal.__cell__.headerTextColor = F, this.setFontSize(S), null == l) v = m = Object.keys(u[0]), b = m.map(function () {
+          return "left";
+        });else if (Array.isArray(l) && "object" === e(l[0])) for (m = l.map(function (t) {
+          return t.name;
+        }), v = l.map(function (t) {
+          return t.prompt || t.name || "";
+        }), b = l.map(function (t) {
+          return t.align || "left";
+        }), f = 0; f < l.length; f += 1) w[l[f].name] = l[f].width * (19.049976 / 25.4);else Array.isArray(l) && "string" == typeof l[0] && (v = m = l, b = m.map(function () {
+          return "left";
+        }));
+        if (A || Array.isArray(l) && "string" == typeof l[0]) for (f = 0; f < m.length; f += 1) {
+          for (y[g = m[f]] = u.map(function (t) {
+            return t[g];
+          }), this.setFont(void 0, "bold"), N.push(this.getTextDimensions(v[f], {
+            fontSize: this.internal.__cell__.table_font_size,
+            scaleFactor: this.internal.scaleFactor
+          }).w), d = y[g], this.setFont(void 0, "normal"), p = 0; p < d.length; p += 1) N.push(this.getTextDimensions(d[p], {
+            fontSize: this.internal.__cell__.table_font_size,
+            scaleFactor: this.internal.scaleFactor
+          }).w);
+          w[g] = Math.max.apply(null, N) + P + P, N = [];
+        }
+        if (x) {
+          var I = {};
+          for (f = 0; f < m.length; f += 1) I[m[f]] = {}, I[m[f]].text = v[f], I[m[f]].align = b[f];
+          var C = c.call(this, I, w);
+          L = m.map(function (e) {
+            return new o(t, n, w[e], C, I[e].text, void 0, I[e].align);
+          }), this.setTableHeaderRow(L), this.printHeaderRow(1, !1);
+        }
+        var j = l.reduce(function (t, e) {
+          return t[e.name] = e.align, t;
+        }, {});
+        for (f = 0; f < u.length; f += 1) {
+          "rowStart" in h && h.rowStart instanceof Function && h.rowStart({
+            row: f,
+            data: u[f]
+          }, this);
+          var O = c.call(this, u[f], w);
+          for (p = 0; p < m.length; p += 1) {
+            var B = u[f][m[p]];
+            "cellStart" in h && h.cellStart instanceof Function && h.cellStart({
+              row: f,
+              col: p,
+              data: B
+            }, this), s.call(this, new o(t, n, w[m[p]], O, B, f + 2, j[m[p]]));
+          }
+        }
+        return this.internal.__cell__.table_x = t, this.internal.__cell__.table_y = n, this;
+      };
+      var c = function c(t, e) {
+        var r = this.internal.__cell__.padding,
+          n = this.internal.__cell__.table_font_size,
+          i = this.internal.scaleFactor;
+        return Object.keys(t).map(function (n) {
+          var i = t[n];
+          return this.splitTextToSize(i.hasOwnProperty("text") ? i.text : i, e[n] - r - r);
+        }, this).map(function (t) {
+          return this.getLineHeightFactor() * t.length * n / i + r + r;
+        }, this).reduce(function (t, e) {
+          return Math.max(t, e);
+        }, 0);
+      };
+      t.setTableHeaderRow = function (t) {
+        i.call(this), this.internal.__cell__.tableHeaderRow = t;
+      }, t.printHeaderRow = function (t, e) {
+        if (i.call(this), !this.internal.__cell__.tableHeaderRow) throw new Error("Property tableHeaderRow does not exist.");
+        var r;
+        if (n = !0, "function" == typeof this.internal.__cell__.headerFunction) {
+          var a = this.internal.__cell__.headerFunction(this, this.internal.__cell__.pages);
+          this.internal.__cell__.lastCell = new o(a[0], a[1], a[2], a[3], void 0, -1);
+        }
+        this.setFont(void 0, "bold");
+        for (var c = [], u = 0; u < this.internal.__cell__.tableHeaderRow.length; u += 1) {
+          r = this.internal.__cell__.tableHeaderRow[u].clone(), e && (r.y = this.internal.__cell__.margins.top || 0, c.push(r)), r.lineNumber = t;
+          var l = this.getTextColor();
+          this.setTextColor(this.internal.__cell__.headerTextColor), this.setFillColor(this.internal.__cell__.headerBackgroundColor), s.call(this, r), this.setTextColor(l);
+        }
+        c.length > 0 && this.setTableHeaderRow(c), this.setFont(void 0, "normal"), n = !1;
+      };
+    }(M.API);
+    var _t = {
+        italic: ["italic", "oblique", "normal"],
+        oblique: ["oblique", "italic", "normal"],
+        normal: ["normal", "oblique", "italic"]
+      },
+      Pt = ["ultra-condensed", "extra-condensed", "condensed", "semi-condensed", "normal", "semi-expanded", "expanded", "extra-expanded", "ultra-expanded"],
+      kt = St(Pt),
+      Ft = [100, 200, 300, 400, 500, 600, 700, 800, 900],
+      It = St(Ft);
+    function Ct(t) {
+      var e = t.family.replace(/"|'/g, "").toLowerCase(),
+        r = function (t) {
+          return _t[t = t || "normal"] ? t : "normal";
+        }(t.style),
+        n = function (t) {
+          if (!t) return 400;
+          if ("number" == typeof t) return t >= 100 && t <= 900 && t % 100 == 0 ? t : 400;
+          if (/^\d00$/.test(t)) return parseInt(t);
+          switch (t) {
+            case "bold":
+              return 700;
+            case "normal":
+            default:
+              return 400;
+          }
+        }(t.weight),
+        i = function (t) {
+          return "number" == typeof kt[t = t || "normal"] ? t : "normal";
+        }(t.stretch);
+      return {
+        family: e,
+        style: r,
+        weight: n,
+        stretch: i,
+        src: t.src || [],
+        ref: t.ref || {
+          name: e,
+          style: [i, r, n].join(" ")
+        }
+      };
+    }
+    function jt(t, e, r, n) {
+      var i;
+      for (i = r; i >= 0 && i < e.length; i += n) if (t[e[i]]) return t[e[i]];
+      for (i = r; i >= 0 && i < e.length; i -= n) if (t[e[i]]) return t[e[i]];
+    }
+    var Ot = {
+        "sans-serif": "helvetica",
+        fixed: "courier",
+        monospace: "courier",
+        terminal: "courier",
+        cursive: "times",
+        fantasy: "times",
+        serif: "times"
+      },
+      Bt = {
+        caption: "times",
+        icon: "times",
+        menu: "times",
+        "message-box": "times",
+        "small-caption": "times",
+        "status-bar": "times"
+      };
+    function Mt(t) {
+      return [t.stretch, t.style, t.weight, t.family].join(" ");
+    }
+    function Et(t, e, r) {
+      for (var n = (r = r || {}).defaultFontFamily || "times", i = Object.assign({}, Ot, r.genericFontFamilies || {}), a = null, o = null, s = 0; s < e.length; ++s) if (i[(a = Ct(e[s])).family] && (a.family = i[a.family]), t.hasOwnProperty(a.family)) {
+        o = t[a.family];
+        break;
+      }
+      if (!(o = o || t[n])) throw new Error("Could not find a font-family for the rule '" + Mt(a) + "' and default family '" + n + "'.");
+      if (o = function (t, e) {
+        if (e[t]) return e[t];
+        var r = kt[t],
+          n = r <= kt.normal ? -1 : 1,
+          i = jt(e, Pt, r, n);
+        if (!i) throw new Error("Could not find a matching font-stretch value for " + t);
+        return i;
+      }(a.stretch, o), o = function (t, e) {
+        if (e[t]) return e[t];
+        for (var r = _t[t], n = 0; n < r.length; ++n) if (e[r[n]]) return e[r[n]];
+        throw new Error("Could not find a matching font-style for " + t);
+      }(a.style, o), !(o = function (t, e) {
+        if (e[t]) return e[t];
+        if (400 === t && e[500]) return e[500];
+        if (500 === t && e[400]) return e[400];
+        var r = It[t],
+          n = jt(e, Ft, r, t < 400 ? -1 : 1);
+        if (!n) throw new Error("Could not find a matching font-weight for value " + t);
+        return n;
+      }(a.weight, o))) throw new Error("Failed to resolve a font for the rule '" + Mt(a) + "'.");
+      return o;
+    }
+    function qt(t) {
+      return t.trimLeft();
+    }
+    function Dt(t, e) {
+      for (var r = 0; r < t.length;) {
+        if (t.charAt(r) === e) return [t.substring(0, r), t.substring(r + 1)];
+        r += 1;
+      }
+      return null;
+    }
+    function Rt(t) {
+      var e = t.match(/^(-[a-z_]|[a-z_])[a-z0-9_-]*/i);
+      return null === e ? null : [e[0], t.substring(e[0].length)];
+    }
+    var Tt = ["times"];
+    !function (t) {
+      var r,
+        n,
+        a,
+        o,
+        s,
+        c,
+        u,
+        l,
+        f,
+        d = function d(t) {
+          return t = t || {}, this.isStrokeTransparent = t.isStrokeTransparent || !1, this.strokeOpacity = t.strokeOpacity || 1, this.strokeStyle = t.strokeStyle || "#000000", this.fillStyle = t.fillStyle || "#000000", this.isFillTransparent = t.isFillTransparent || !1, this.fillOpacity = t.fillOpacity || 1, this.font = t.font || "10px sans-serif", this.textBaseline = t.textBaseline || "alphabetic", this.textAlign = t.textAlign || "left", this.lineWidth = t.lineWidth || 1, this.lineJoin = t.lineJoin || "miter", this.lineCap = t.lineCap || "butt", this.path = t.path || [], this.transform = void 0 !== t.transform ? t.transform.clone() : new l(), this.globalCompositeOperation = t.globalCompositeOperation || "normal", this.globalAlpha = t.globalAlpha || 1, this.clip_path = t.clip_path || [], this.currentPoint = t.currentPoint || new c(), this.miterLimit = t.miterLimit || 10, this.lastPoint = t.lastPoint || new c(), this.lineDashOffset = t.lineDashOffset || 0, this.lineDash = t.lineDash || [], this.margin = t.margin || [0, 0, 0, 0], this.prevPageLastElemOffset = t.prevPageLastElemOffset || 0, this.ignoreClearRect = "boolean" != typeof t.ignoreClearRect || t.ignoreClearRect, this;
+        };
+      t.events.push(["initialized", function () {
+        this.context2d = new p(this), r = this.internal.f2, n = this.internal.getCoordinateString, a = this.internal.getVerticalCoordinateString, o = this.internal.getHorizontalCoordinate, s = this.internal.getVerticalCoordinate, c = this.internal.Point, u = this.internal.Rectangle, l = this.internal.Matrix, f = new d();
+      }]);
+      var p = function p(t) {
+        Object.defineProperty(this, "canvas", {
+          get: function get() {
+            return {
+              parentNode: !1,
+              style: !1
+            };
+          }
+        });
+        var e = t;
+        Object.defineProperty(this, "pdf", {
+          get: function get() {
+            return e;
+          }
+        });
+        var r = !1;
+        Object.defineProperty(this, "pageWrapXEnabled", {
+          get: function get() {
+            return r;
+          },
+          set: function set(t) {
+            r = Boolean(t);
+          }
+        });
+        var n = !1;
+        Object.defineProperty(this, "pageWrapYEnabled", {
+          get: function get() {
+            return n;
+          },
+          set: function set(t) {
+            n = Boolean(t);
+          }
+        });
+        var i = 0;
+        Object.defineProperty(this, "posX", {
+          get: function get() {
+            return i;
+          },
+          set: function set(t) {
+            isNaN(t) || (i = t);
+          }
+        });
+        var a = 0;
+        Object.defineProperty(this, "posY", {
+          get: function get() {
+            return a;
+          },
+          set: function set(t) {
+            isNaN(t) || (a = t);
+          }
+        }), Object.defineProperty(this, "margin", {
+          get: function get() {
+            return f.margin;
+          },
+          set: function set(t) {
+            var e;
+            "number" == typeof t ? e = [t, t, t, t] : ((e = new Array(4))[0] = t[0], e[1] = t.length >= 2 ? t[1] : e[0], e[2] = t.length >= 3 ? t[2] : e[0], e[3] = t.length >= 4 ? t[3] : e[1]), f.margin = e;
+          }
+        });
+        var o = !1;
+        Object.defineProperty(this, "autoPaging", {
+          get: function get() {
+            return o;
+          },
+          set: function set(t) {
+            o = t;
+          }
+        });
+        var s = 0;
+        Object.defineProperty(this, "lastBreak", {
+          get: function get() {
+            return s;
+          },
+          set: function set(t) {
+            s = t;
+          }
+        });
+        var c = [];
+        Object.defineProperty(this, "pageBreaks", {
+          get: function get() {
+            return c;
+          },
+          set: function set(t) {
+            c = t;
+          }
+        }), Object.defineProperty(this, "ctx", {
+          get: function get() {
+            return f;
+          },
+          set: function set(t) {
+            t instanceof d && (f = t);
+          }
+        }), Object.defineProperty(this, "path", {
+          get: function get() {
+            return f.path;
+          },
+          set: function set(t) {
+            f.path = t;
+          }
+        });
+        var u = [];
+        Object.defineProperty(this, "ctxStack", {
+          get: function get() {
+            return u;
+          },
+          set: function set(t) {
+            u = t;
+          }
+        }), Object.defineProperty(this, "fillStyle", {
+          get: function get() {
+            return this.ctx.fillStyle;
+          },
+          set: function set(t) {
+            var e;
+            e = g(t), this.ctx.fillStyle = e.style, this.ctx.isFillTransparent = 0 === e.a, this.ctx.fillOpacity = e.a, this.pdf.setFillColor(e.r, e.g, e.b, {
+              a: e.a
+            }), this.pdf.setTextColor(e.r, e.g, e.b, {
+              a: e.a
+            });
+          }
+        }), Object.defineProperty(this, "strokeStyle", {
+          get: function get() {
+            return this.ctx.strokeStyle;
+          },
+          set: function set(t) {
+            var e = g(t);
+            this.ctx.strokeStyle = e.style, this.ctx.isStrokeTransparent = 0 === e.a, this.ctx.strokeOpacity = e.a, 0 === e.a ? this.pdf.setDrawColor(255, 255, 255) : (e.a, this.pdf.setDrawColor(e.r, e.g, e.b));
+          }
+        }), Object.defineProperty(this, "lineCap", {
+          get: function get() {
+            return this.ctx.lineCap;
+          },
+          set: function set(t) {
+            -1 !== ["butt", "round", "square"].indexOf(t) && (this.ctx.lineCap = t, this.pdf.setLineCap(t));
+          }
+        }), Object.defineProperty(this, "lineWidth", {
+          get: function get() {
+            return this.ctx.lineWidth;
+          },
+          set: function set(t) {
+            isNaN(t) || (this.ctx.lineWidth = t, this.pdf.setLineWidth(t));
+          }
+        }), Object.defineProperty(this, "lineJoin", {
+          get: function get() {
+            return this.ctx.lineJoin;
+          },
+          set: function set(t) {
+            -1 !== ["bevel", "round", "miter"].indexOf(t) && (this.ctx.lineJoin = t, this.pdf.setLineJoin(t));
+          }
+        }), Object.defineProperty(this, "miterLimit", {
+          get: function get() {
+            return this.ctx.miterLimit;
+          },
+          set: function set(t) {
+            isNaN(t) || (this.ctx.miterLimit = t, this.pdf.setMiterLimit(t));
+          }
+        }), Object.defineProperty(this, "textBaseline", {
+          get: function get() {
+            return this.ctx.textBaseline;
+          },
+          set: function set(t) {
+            this.ctx.textBaseline = t;
+          }
+        }), Object.defineProperty(this, "textAlign", {
+          get: function get() {
+            return this.ctx.textAlign;
+          },
+          set: function set(t) {
+            -1 !== ["right", "end", "center", "left", "start"].indexOf(t) && (this.ctx.textAlign = t);
+          }
+        });
+        var l = null;
+        function h(t, e) {
+          if (null === l) {
+            var r = function (t) {
+              var e = [];
+              return Object.keys(t).forEach(function (r) {
+                t[r].forEach(function (t) {
+                  var n = null;
+                  switch (t) {
+                    case "bold":
+                      n = {
+                        family: r,
+                        weight: "bold"
+                      };
+                      break;
+                    case "italic":
+                      n = {
+                        family: r,
+                        style: "italic"
+                      };
+                      break;
+                    case "bolditalic":
+                      n = {
+                        family: r,
+                        weight: "bold",
+                        style: "italic"
+                      };
+                      break;
+                    case "":
+                    case "normal":
+                      n = {
+                        family: r
+                      };
+                  }
+                  null !== n && (n.ref = {
+                    name: r,
+                    style: t
+                  }, e.push(n));
+                });
+              }), e;
+            }(t.getFontList());
+            l = function (t) {
+              for (var e = {}, r = 0; r < t.length; ++r) {
+                var n = Ct(t[r]),
+                  i = n.family,
+                  a = n.stretch,
+                  o = n.style,
+                  s = n.weight;
+                e[i] = e[i] || {}, e[i][a] = e[i][a] || {}, e[i][a][o] = e[i][a][o] || {}, e[i][a][o][s] = n;
+              }
+              return e;
+            }(r.concat(e));
+          }
+          return l;
+        }
+        var p = null;
+        Object.defineProperty(this, "fontFaces", {
+          get: function get() {
+            return p;
+          },
+          set: function set(t) {
+            l = null, p = t;
+          }
+        }), Object.defineProperty(this, "font", {
+          get: function get() {
+            return this.ctx.font;
+          },
+          set: function set(t) {
+            var e;
+            if (this.ctx.font = t, null !== (e = /^\s*(?=(?:(?:[-a-z]+\s*){0,2}(italic|oblique))?)(?=(?:(?:[-a-z]+\s*){0,2}(small-caps))?)(?=(?:(?:[-a-z]+\s*){0,2}(bold(?:er)?|lighter|[1-9]00))?)(?:(?:normal|\1|\2|\3)\s*){0,3}((?:xx?-)?(?:small|large)|medium|smaller|larger|[.\d]+(?:\%|in|[cem]m|ex|p[ctx]))(?:\s*\/\s*(normal|[.\d]+(?:\%|in|[cem]m|ex|p[ctx])))?\s*([-_,\"\'\sa-z]+?)\s*$/i.exec(t))) {
+              var r = e[1],
+                n = (e[2], e[3]),
+                i = e[4],
+                a = (e[5], e[6]),
+                o = /^([.\d]+)((?:%|in|[cem]m|ex|p[ctx]))$/i.exec(i)[2];
+              i = "px" === o ? Math.floor(parseFloat(i) * this.pdf.internal.scaleFactor) : "em" === o ? Math.floor(parseFloat(i) * this.pdf.getFontSize()) : Math.floor(parseFloat(i) * this.pdf.internal.scaleFactor), this.pdf.setFontSize(i);
+              var s = function (t) {
+                var e,
+                  r,
+                  n = [],
+                  i = t.trim();
+                if ("" === i) return Tt;
+                if (i in Bt) return [Bt[i]];
+                for (; "" !== i;) {
+                  switch (r = null, e = (i = qt(i)).charAt(0)) {
+                    case '"':
+                    case "'":
+                      r = Dt(i.substring(1), e);
+                      break;
+                    default:
+                      r = Rt(i);
+                  }
+                  if (null === r) return Tt;
+                  if (n.push(r[0]), "" !== (i = qt(r[1])) && "," !== i.charAt(0)) return Tt;
+                  i = i.replace(/^,/, "");
+                }
+                return n;
+              }(a);
+              if (this.fontFaces) {
+                var c = Et(h(this.pdf, this.fontFaces), s.map(function (t) {
+                  return {
+                    family: t,
+                    stretch: "normal",
+                    weight: n,
+                    style: r
+                  };
+                }));
+                this.pdf.setFont(c.ref.name, c.ref.style);
+              } else {
+                var u = "";
+                ("bold" === n || parseInt(n, 10) >= 700 || "bold" === r) && (u = "bold"), "italic" === r && (u += "italic"), 0 === u.length && (u = "normal");
+                for (var l = "", f = {
+                    arial: "Helvetica",
+                    Arial: "Helvetica",
+                    verdana: "Helvetica",
+                    Verdana: "Helvetica",
+                    helvetica: "Helvetica",
+                    Helvetica: "Helvetica",
+                    "sans-serif": "Helvetica",
+                    fixed: "Courier",
+                    monospace: "Courier",
+                    terminal: "Courier",
+                    cursive: "Times",
+                    fantasy: "Times",
+                    serif: "Times"
+                  }, d = 0; d < s.length; d++) {
+                  if (void 0 !== this.pdf.internal.getFont(s[d], u, {
+                    noFallback: !0,
+                    disableWarning: !0
+                  })) {
+                    l = s[d];
+                    break;
+                  }
+                  if ("bolditalic" === u && void 0 !== this.pdf.internal.getFont(s[d], "bold", {
+                    noFallback: !0,
+                    disableWarning: !0
+                  })) l = s[d], u = "bold";else if (void 0 !== this.pdf.internal.getFont(s[d], "normal", {
+                    noFallback: !0,
+                    disableWarning: !0
+                  })) {
+                    l = s[d], u = "normal";
+                    break;
+                  }
+                }
+                if ("" === l) for (var p = 0; p < s.length; p++) if (f[s[p]]) {
+                  l = f[s[p]];
+                  break;
+                }
+                l = "" === l ? "Times" : l, this.pdf.setFont(l, u);
+              }
+            }
+          }
+        }), Object.defineProperty(this, "globalCompositeOperation", {
+          get: function get() {
+            return this.ctx.globalCompositeOperation;
+          },
+          set: function set(t) {
+            this.ctx.globalCompositeOperation = t;
+          }
+        }), Object.defineProperty(this, "globalAlpha", {
+          get: function get() {
+            return this.ctx.globalAlpha;
+          },
+          set: function set(t) {
+            this.ctx.globalAlpha = t;
+          }
+        }), Object.defineProperty(this, "lineDashOffset", {
+          get: function get() {
+            return this.ctx.lineDashOffset;
+          },
+          set: function set(t) {
+            this.ctx.lineDashOffset = t, T.call(this);
+          }
+        }), Object.defineProperty(this, "lineDash", {
+          get: function get() {
+            return this.ctx.lineDash;
+          },
+          set: function set(t) {
+            this.ctx.lineDash = t, T.call(this);
+          }
+        }), Object.defineProperty(this, "ignoreClearRect", {
+          get: function get() {
+            return this.ctx.ignoreClearRect;
+          },
+          set: function set(t) {
+            this.ctx.ignoreClearRect = Boolean(t);
+          }
+        });
+      };
+      p.prototype.setLineDash = function (t) {
+        this.lineDash = t;
+      }, p.prototype.getLineDash = function () {
+        return this.lineDash.length % 2 ? this.lineDash.concat(this.lineDash) : this.lineDash.slice();
+      }, p.prototype.fill = function () {
+        A.call(this, "fill", !1);
+      }, p.prototype.stroke = function () {
+        A.call(this, "stroke", !1);
+      }, p.prototype.beginPath = function () {
+        this.path = [{
+          type: "begin"
+        }];
+      }, p.prototype.moveTo = function (t, e) {
+        if (isNaN(t) || isNaN(e)) throw i.error("jsPDF.context2d.moveTo: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.moveTo");
+        var r = this.ctx.transform.applyToPoint(new c(t, e));
+        this.path.push({
+          type: "mt",
+          x: r.x,
+          y: r.y
+        }), this.ctx.lastPoint = new c(t, e);
+      }, p.prototype.closePath = function () {
+        var t = new c(0, 0),
+          r = 0;
+        for (r = this.path.length - 1; -1 !== r; r--) if ("begin" === this.path[r].type && "object" === e(this.path[r + 1]) && "number" == typeof this.path[r + 1].x) {
+          t = new c(this.path[r + 1].x, this.path[r + 1].y);
+          break;
+        }
+        this.path.push({
+          type: "close"
+        }), this.ctx.lastPoint = new c(t.x, t.y);
+      }, p.prototype.lineTo = function (t, e) {
+        if (isNaN(t) || isNaN(e)) throw i.error("jsPDF.context2d.lineTo: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.lineTo");
+        var r = this.ctx.transform.applyToPoint(new c(t, e));
+        this.path.push({
+          type: "lt",
+          x: r.x,
+          y: r.y
+        }), this.ctx.lastPoint = new c(r.x, r.y);
+      }, p.prototype.clip = function () {
+        this.ctx.clip_path = JSON.parse(JSON.stringify(this.path)), A.call(this, null, !0);
+      }, p.prototype.quadraticCurveTo = function (t, e, r, n) {
+        if (isNaN(r) || isNaN(n) || isNaN(t) || isNaN(e)) throw i.error("jsPDF.context2d.quadraticCurveTo: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.quadraticCurveTo");
+        var a = this.ctx.transform.applyToPoint(new c(r, n)),
+          o = this.ctx.transform.applyToPoint(new c(t, e));
+        this.path.push({
+          type: "qct",
+          x1: o.x,
+          y1: o.y,
+          x: a.x,
+          y: a.y
+        }), this.ctx.lastPoint = new c(a.x, a.y);
+      }, p.prototype.bezierCurveTo = function (t, e, r, n, a, o) {
+        if (isNaN(a) || isNaN(o) || isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n)) throw i.error("jsPDF.context2d.bezierCurveTo: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.bezierCurveTo");
+        var s = this.ctx.transform.applyToPoint(new c(a, o)),
+          u = this.ctx.transform.applyToPoint(new c(t, e)),
+          l = this.ctx.transform.applyToPoint(new c(r, n));
+        this.path.push({
+          type: "bct",
+          x1: u.x,
+          y1: u.y,
+          x2: l.x,
+          y2: l.y,
+          x: s.x,
+          y: s.y
+        }), this.ctx.lastPoint = new c(s.x, s.y);
+      }, p.prototype.arc = function (t, e, r, n, a, o) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n) || isNaN(a)) throw i.error("jsPDF.context2d.arc: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.arc");
+        if (o = Boolean(o), !this.ctx.transform.isIdentity) {
+          var s = this.ctx.transform.applyToPoint(new c(t, e));
+          t = s.x, e = s.y;
+          var u = this.ctx.transform.applyToPoint(new c(0, r)),
+            l = this.ctx.transform.applyToPoint(new c(0, 0));
+          r = Math.sqrt(Math.pow(u.x - l.x, 2) + Math.pow(u.y - l.y, 2));
+        }
+        Math.abs(a - n) >= 2 * Math.PI && (n = 0, a = 2 * Math.PI), this.path.push({
+          type: "arc",
+          x: t,
+          y: e,
+          radius: r,
+          startAngle: n,
+          endAngle: a,
+          counterclockwise: o
+        });
+      }, p.prototype.arcTo = function (t, e, r, n, i) {
+        throw new Error("arcTo not implemented.");
+      }, p.prototype.rect = function (t, e, r, n) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n)) throw i.error("jsPDF.context2d.rect: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.rect");
+        this.moveTo(t, e), this.lineTo(t + r, e), this.lineTo(t + r, e + n), this.lineTo(t, e + n), this.lineTo(t, e), this.lineTo(t + r, e), this.lineTo(t, e);
+      }, p.prototype.fillRect = function (t, e, r, n) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n)) throw i.error("jsPDF.context2d.fillRect: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.fillRect");
+        if (!m.call(this)) {
+          var a = {};
+          "butt" !== this.lineCap && (a.lineCap = this.lineCap, this.lineCap = "butt"), "miter" !== this.lineJoin && (a.lineJoin = this.lineJoin, this.lineJoin = "miter"), this.beginPath(), this.rect(t, e, r, n), this.fill(), a.hasOwnProperty("lineCap") && (this.lineCap = a.lineCap), a.hasOwnProperty("lineJoin") && (this.lineJoin = a.lineJoin);
+        }
+      }, p.prototype.strokeRect = function (t, e, r, n) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n)) throw i.error("jsPDF.context2d.strokeRect: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.strokeRect");
+        v.call(this) || (this.beginPath(), this.rect(t, e, r, n), this.stroke());
+      }, p.prototype.clearRect = function (t, e, r, n) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n)) throw i.error("jsPDF.context2d.clearRect: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.clearRect");
+        this.ignoreClearRect || (this.fillStyle = "#ffffff", this.fillRect(t, e, r, n));
+      }, p.prototype.save = function (t) {
+        t = "boolean" != typeof t || t;
+        for (var e = this.pdf.internal.getCurrentPageInfo().pageNumber, r = 0; r < this.pdf.internal.getNumberOfPages(); r++) this.pdf.setPage(r + 1), this.pdf.internal.out("q");
+        if (this.pdf.setPage(e), t) {
+          this.ctx.fontSize = this.pdf.internal.getFontSize();
+          var n = new d(this.ctx);
+          this.ctxStack.push(this.ctx), this.ctx = n;
+        }
+      }, p.prototype.restore = function (t) {
+        t = "boolean" != typeof t || t;
+        for (var e = this.pdf.internal.getCurrentPageInfo().pageNumber, r = 0; r < this.pdf.internal.getNumberOfPages(); r++) this.pdf.setPage(r + 1), this.pdf.internal.out("Q");
+        this.pdf.setPage(e), t && 0 !== this.ctxStack.length && (this.ctx = this.ctxStack.pop(), this.fillStyle = this.ctx.fillStyle, this.strokeStyle = this.ctx.strokeStyle, this.font = this.ctx.font, this.lineCap = this.ctx.lineCap, this.lineWidth = this.ctx.lineWidth, this.lineJoin = this.ctx.lineJoin, this.lineDash = this.ctx.lineDash, this.lineDashOffset = this.ctx.lineDashOffset);
+      }, p.prototype.toDataURL = function () {
+        throw new Error("toDataUrl not implemented.");
+      };
+      var g = function g(t) {
+          var e, r, n, i;
+          if (!0 === t.isCanvasGradient && (t = t.getColor()), !t) return {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 0,
+            style: t
+          };
+          if (/transparent|rgba\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*0+\s*\)/.test(t)) e = 0, r = 0, n = 0, i = 0;else {
+            var a = /rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/.exec(t);
+            if (null !== a) e = parseInt(a[1]), r = parseInt(a[2]), n = parseInt(a[3]), i = 1;else if (null !== (a = /rgba\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\s*\)/.exec(t))) e = parseInt(a[1]), r = parseInt(a[2]), n = parseInt(a[3]), i = parseFloat(a[4]);else {
+              if (i = 1, "string" == typeof t && "#" !== t.charAt(0)) {
+                var o = new h(t);
+                t = o.ok ? o.toHex() : "#000000";
+              }
+              4 === t.length ? (e = t.substring(1, 2), e += e, r = t.substring(2, 3), r += r, n = t.substring(3, 4), n += n) : (e = t.substring(1, 3), r = t.substring(3, 5), n = t.substring(5, 7)), e = parseInt(e, 16), r = parseInt(r, 16), n = parseInt(n, 16);
+            }
+          }
+          return {
+            r: e,
+            g: r,
+            b: n,
+            a: i,
+            style: t
+          };
+        },
+        m = function m() {
+          return this.ctx.isFillTransparent || 0 == this.globalAlpha;
+        },
+        v = function v() {
+          return Boolean(this.ctx.isStrokeTransparent || 0 == this.globalAlpha);
+        };
+      p.prototype.fillText = function (t, e, r, n) {
+        if (isNaN(e) || isNaN(r) || "string" != typeof t) throw i.error("jsPDF.context2d.fillText: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.fillText");
+        if (n = isNaN(n) ? void 0 : n, !m.call(this)) {
+          var a = q(this.ctx.transform.rotation),
+            o = this.ctx.transform.scaleX;
+          C.call(this, {
+            text: t,
+            x: e,
+            y: r,
+            scale: o,
+            angle: a,
+            align: this.textAlign,
+            maxWidth: n
+          });
+        }
+      }, p.prototype.strokeText = function (t, e, r, n) {
+        if (isNaN(e) || isNaN(r) || "string" != typeof t) throw i.error("jsPDF.context2d.strokeText: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.strokeText");
+        if (!v.call(this)) {
+          n = isNaN(n) ? void 0 : n;
+          var a = q(this.ctx.transform.rotation),
+            o = this.ctx.transform.scaleX;
+          C.call(this, {
+            text: t,
+            x: e,
+            y: r,
+            scale: o,
+            renderingMode: "stroke",
+            angle: a,
+            align: this.textAlign,
+            maxWidth: n
+          });
+        }
+      }, p.prototype.measureText = function (t) {
+        if ("string" != typeof t) throw i.error("jsPDF.context2d.measureText: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.measureText");
+        var e = this.pdf,
+          r = this.pdf.internal.scaleFactor,
+          n = e.internal.getFontSize(),
+          a = e.getStringUnitWidth(t) * n / e.internal.scaleFactor,
+          o = function o(t) {
+            var e = (t = t || {}).width || 0;
+            return Object.defineProperty(this, "width", {
+              get: function get() {
+                return e;
+              }
+            }), this;
+          };
+        return new o({
+          width: a *= Math.round(96 * r / 72 * 1e4) / 1e4
+        });
+      }, p.prototype.scale = function (t, e) {
+        if (isNaN(t) || isNaN(e)) throw i.error("jsPDF.context2d.scale: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.scale");
+        var r = new l(t, 0, 0, e, 0, 0);
+        this.ctx.transform = this.ctx.transform.multiply(r);
+      }, p.prototype.rotate = function (t) {
+        if (isNaN(t)) throw i.error("jsPDF.context2d.rotate: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.rotate");
+        var e = new l(Math.cos(t), Math.sin(t), -Math.sin(t), Math.cos(t), 0, 0);
+        this.ctx.transform = this.ctx.transform.multiply(e);
+      }, p.prototype.translate = function (t, e) {
+        if (isNaN(t) || isNaN(e)) throw i.error("jsPDF.context2d.translate: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.translate");
+        var r = new l(1, 0, 0, 1, t, e);
+        this.ctx.transform = this.ctx.transform.multiply(r);
+      }, p.prototype.transform = function (t, e, r, n, a, o) {
+        if (isNaN(t) || isNaN(e) || isNaN(r) || isNaN(n) || isNaN(a) || isNaN(o)) throw i.error("jsPDF.context2d.transform: Invalid arguments", arguments), new Error("Invalid arguments passed to jsPDF.context2d.transform");
+        var s = new l(t, e, r, n, a, o);
+        this.ctx.transform = this.ctx.transform.multiply(s);
+      }, p.prototype.setTransform = function (t, e, r, n, i, a) {
+        t = isNaN(t) ? 1 : t, e = isNaN(e) ? 0 : e, r = isNaN(r) ? 0 : r, n = isNaN(n) ? 1 : n, i = isNaN(i) ? 0 : i, a = isNaN(a) ? 0 : a, this.ctx.transform = new l(t, e, r, n, i, a);
+      };
+      var b = function b() {
+        return this.margin[0] > 0 || this.margin[1] > 0 || this.margin[2] > 0 || this.margin[3] > 0;
+      };
+      p.prototype.drawImage = function (t, e, r, n, i, a, o, s, c) {
+        var h = this.pdf.getImageProperties(t),
+          f = 1,
+          d = 1,
+          p = 1,
+          g = 1;
+        void 0 !== n && void 0 !== s && (p = s / n, g = c / i, f = h.width / n * s / n, d = h.height / i * c / i), void 0 === a && (a = e, o = r, e = 0, r = 0), void 0 !== n && void 0 === s && (s = n, c = i), void 0 === n && void 0 === s && (s = h.width, c = h.height);
+        for (var m, v = this.ctx.transform.decompose(), w = q(v.rotate.shx), A = new l(), S = (A = (A = (A = A.multiply(v.translate)).multiply(v.skew)).multiply(v.scale)).applyToRectangle(new u(a - e * p, o - r * g, n * f, i * d)), _ = y.call(this, S), P = [], k = 0; k < _.length; k += 1) -1 === P.indexOf(_[k]) && P.push(_[k]);
+        if (L(P), this.autoPaging) for (var F = P[0], I = P[P.length - 1], C = F; C < I + 1; C++) {
+          this.pdf.setPage(C);
+          var j = this.pdf.internal.pageSize.width - this.margin[3] - this.margin[1],
+            O = 1 === C ? this.posY + this.margin[0] : this.margin[0],
+            B = this.pdf.internal.pageSize.height - this.posY - this.margin[0] - this.margin[2],
+            M = this.pdf.internal.pageSize.height - this.margin[0] - this.margin[2],
+            E = 1 === C ? 0 : B + (C - 2) * M;
+          if (0 !== this.ctx.clip_path.length) {
+            var D = this.path;
+            m = JSON.parse(JSON.stringify(this.ctx.clip_path)), this.path = N(m, this.posX + this.margin[3], -E + O + this.ctx.prevPageLastElemOffset), x.call(this, "fill", !0), this.path = D;
+          }
+          var R = JSON.parse(JSON.stringify(S));
+          R = N([R], this.posX + this.margin[3], -E + O + this.ctx.prevPageLastElemOffset)[0];
+          var T = (C > F || C < I) && b.call(this);
+          T && (this.pdf.saveGraphicsState(), this.pdf.rect(this.margin[3], this.margin[0], j, M, null).clip().discardPath()), this.pdf.addImage(t, "JPEG", R.x, R.y, R.w, R.h, null, null, w), T && this.pdf.restoreGraphicsState();
+        } else this.pdf.addImage(t, "JPEG", S.x, S.y, S.w, S.h, null, null, w);
+      };
+      var y = function y(t, e, r) {
+          var n = [];
+          e = e || this.pdf.internal.pageSize.width, r = r || this.pdf.internal.pageSize.height - this.margin[0] - this.margin[2];
+          var i = this.posY + this.ctx.prevPageLastElemOffset;
+          switch (t.type) {
+            default:
+            case "mt":
+            case "lt":
+              n.push(Math.floor((t.y + i) / r) + 1);
+              break;
+            case "arc":
+              n.push(Math.floor((t.y + i - t.radius) / r) + 1), n.push(Math.floor((t.y + i + t.radius) / r) + 1);
+              break;
+            case "qct":
+              var a = D(this.ctx.lastPoint.x, this.ctx.lastPoint.y, t.x1, t.y1, t.x, t.y);
+              n.push(Math.floor((a.y + i) / r) + 1), n.push(Math.floor((a.y + a.h + i) / r) + 1);
+              break;
+            case "bct":
+              var o = R(this.ctx.lastPoint.x, this.ctx.lastPoint.y, t.x1, t.y1, t.x2, t.y2, t.x, t.y);
+              n.push(Math.floor((o.y + i) / r) + 1), n.push(Math.floor((o.y + o.h + i) / r) + 1);
+              break;
+            case "rect":
+              n.push(Math.floor((t.y + i) / r) + 1), n.push(Math.floor((t.y + t.h + i) / r) + 1);
+          }
+          for (var s = 0; s < n.length; s += 1) for (; this.pdf.internal.getNumberOfPages() < n[s];) w.call(this);
+          return n;
+        },
+        w = function w() {
+          var t = this.fillStyle,
+            e = this.strokeStyle,
+            r = this.font,
+            n = this.lineCap,
+            i = this.lineWidth,
+            a = this.lineJoin;
+          this.pdf.addPage(), this.fillStyle = t, this.strokeStyle = e, this.font = r, this.lineCap = n, this.lineWidth = i, this.lineJoin = a;
+        },
+        N = function N(t, e, r) {
+          for (var n = 0; n < t.length; n++) switch (t[n].type) {
+            case "bct":
+              t[n].x2 += e, t[n].y2 += r;
+            case "qct":
+              t[n].x1 += e, t[n].y1 += r;
+            case "mt":
+            case "lt":
+            case "arc":
+            default:
+              t[n].x += e, t[n].y += r;
+          }
+          return t;
+        },
+        L = function L(t) {
+          return t.sort(function (t, e) {
+            return t - e;
+          });
+        },
+        A = function A(t, e) {
+          for (var r, n, i = this.fillStyle, a = this.strokeStyle, o = this.lineCap, s = this.lineWidth, c = Math.abs(s * this.ctx.transform.scaleX), u = this.lineJoin, l = JSON.parse(JSON.stringify(this.path)), h = JSON.parse(JSON.stringify(this.path)), f = [], d = 0; d < h.length; d++) if (void 0 !== h[d].x) for (var p = y.call(this, h[d]), g = 0; g < p.length; g += 1) -1 === f.indexOf(p[g]) && f.push(p[g]);
+          for (var m = 0; m < f.length; m++) for (; this.pdf.internal.getNumberOfPages() < f[m];) w.call(this);
+          if (L(f), this.autoPaging) for (var v = f[0], A = f[f.length - 1], S = v; S < A + 1; S++) {
+            this.pdf.setPage(S), this.fillStyle = i, this.strokeStyle = a, this.lineCap = o, this.lineWidth = c, this.lineJoin = u;
+            var _ = this.pdf.internal.pageSize.width - this.margin[3] - this.margin[1],
+              P = 1 === S ? this.posY + this.margin[0] : this.margin[0],
+              k = this.pdf.internal.pageSize.height - this.posY - this.margin[0] - this.margin[2],
+              F = this.pdf.internal.pageSize.height - this.margin[0] - this.margin[2],
+              I = 1 === S ? 0 : k + (S - 2) * F;
+            if (0 !== this.ctx.clip_path.length) {
+              var C = this.path;
+              r = JSON.parse(JSON.stringify(this.ctx.clip_path)), this.path = N(r, this.posX + this.margin[3], -I + P + this.ctx.prevPageLastElemOffset), x.call(this, t, !0), this.path = C;
+            }
+            if (n = JSON.parse(JSON.stringify(l)), this.path = N(n, this.posX + this.margin[3], -I + P + this.ctx.prevPageLastElemOffset), !1 === e || 0 === S) {
+              var j = (S > v || S < A) && b.call(this);
+              j && (this.pdf.saveGraphicsState(), this.pdf.rect(this.margin[3], this.margin[0], _, F, null).clip().discardPath()), x.call(this, t, e), j && this.pdf.restoreGraphicsState();
+            }
+            this.lineWidth = s;
+          } else this.lineWidth = c, x.call(this, t, e), this.lineWidth = s;
+          this.path = l;
+        },
+        x = function x(t, e) {
+          if (("stroke" !== t || e || !v.call(this)) && ("stroke" === t || e || !m.call(this))) {
+            for (var r, n, i = [], a = this.path, o = 0; o < a.length; o++) {
+              var s = a[o];
+              switch (s.type) {
+                case "begin":
+                  i.push({
+                    begin: !0
+                  });
+                  break;
+                case "close":
+                  i.push({
+                    close: !0
+                  });
+                  break;
+                case "mt":
+                  i.push({
+                    start: s,
+                    deltas: [],
+                    abs: []
+                  });
+                  break;
+                case "lt":
+                  var c = i.length;
+                  if (a[o - 1] && !isNaN(a[o - 1].x) && (r = [s.x - a[o - 1].x, s.y - a[o - 1].y], c > 0)) for (; c >= 0; c--) if (!0 !== i[c - 1].close && !0 !== i[c - 1].begin) {
+                    i[c - 1].deltas.push(r), i[c - 1].abs.push(s);
+                    break;
+                  }
+                  break;
+                case "bct":
+                  r = [s.x1 - a[o - 1].x, s.y1 - a[o - 1].y, s.x2 - a[o - 1].x, s.y2 - a[o - 1].y, s.x - a[o - 1].x, s.y - a[o - 1].y], i[i.length - 1].deltas.push(r);
+                  break;
+                case "qct":
+                  var u = a[o - 1].x + 2 / 3 * (s.x1 - a[o - 1].x),
+                    l = a[o - 1].y + 2 / 3 * (s.y1 - a[o - 1].y),
+                    h = s.x + 2 / 3 * (s.x1 - s.x),
+                    f = s.y + 2 / 3 * (s.y1 - s.y),
+                    d = s.x,
+                    p = s.y;
+                  r = [u - a[o - 1].x, l - a[o - 1].y, h - a[o - 1].x, f - a[o - 1].y, d - a[o - 1].x, p - a[o - 1].y], i[i.length - 1].deltas.push(r);
+                  break;
+                case "arc":
+                  i.push({
+                    deltas: [],
+                    abs: [],
+                    arc: !0
+                  }), Array.isArray(i[i.length - 1].abs) && i[i.length - 1].abs.push(s);
+              }
+            }
+            n = e ? null : "stroke" === t ? "stroke" : "fill";
+            for (var g = !1, b = 0; b < i.length; b++) if (i[b].arc) for (var y = i[b].abs, w = 0; w < y.length; w++) {
+              var N = y[w];
+              "arc" === N.type ? P.call(this, N.x, N.y, N.radius, N.startAngle, N.endAngle, N.counterclockwise, void 0, e, !g) : j.call(this, N.x, N.y), g = !0;
+            } else if (!0 === i[b].close) this.pdf.internal.out("h"), g = !1;else if (!0 !== i[b].begin) {
+              var L = i[b].start.x,
+                A = i[b].start.y;
+              O.call(this, i[b].deltas, L, A), g = !0;
+            }
+            n && k.call(this, n), e && F.call(this);
+          }
+        },
+        S = function S(t) {
+          var e = this.pdf.internal.getFontSize() / this.pdf.internal.scaleFactor,
+            r = e * (this.pdf.internal.getLineHeightFactor() - 1);
+          switch (this.ctx.textBaseline) {
+            case "bottom":
+              return t - r;
+            case "top":
+              return t + e - r;
+            case "hanging":
+              return t + e - 2 * r;
+            case "middle":
+              return t + e / 2 - r;
+            case "ideographic":
+              return t;
+            case "alphabetic":
+            default:
+              return t;
+          }
+        },
+        _ = function _(t) {
+          return t + this.pdf.internal.getFontSize() / this.pdf.internal.scaleFactor * (this.pdf.internal.getLineHeightFactor() - 1);
+        };
+      p.prototype.createLinearGradient = function () {
+        var t = function t() {};
+        return t.colorStops = [], t.addColorStop = function (t, e) {
+          this.colorStops.push([t, e]);
+        }, t.getColor = function () {
+          return 0 === this.colorStops.length ? "#000000" : this.colorStops[0][1];
+        }, t.isCanvasGradient = !0, t;
+      }, p.prototype.createPattern = function () {
+        return this.createLinearGradient();
+      }, p.prototype.createRadialGradient = function () {
+        return this.createLinearGradient();
+      };
+      var P = function P(t, e, r, n, i, a, o, s, c) {
+          for (var u = M.call(this, r, n, i, a), l = 0; l < u.length; l++) {
+            var h = u[l];
+            0 === l && (c ? I.call(this, h.x1 + t, h.y1 + e) : j.call(this, h.x1 + t, h.y1 + e)), B.call(this, t, e, h.x2, h.y2, h.x3, h.y3, h.x4, h.y4);
+          }
+          s ? F.call(this) : k.call(this, o);
+        },
+        k = function k(t) {
+          switch (t) {
+            case "stroke":
+              this.pdf.internal.out("S");
+              break;
+            case "fill":
+              this.pdf.internal.out("f");
+          }
+        },
+        F = function F() {
+          this.pdf.clip(), this.pdf.discardPath();
+        },
+        I = function I(t, e) {
+          this.pdf.internal.out(n(t) + " " + a(e) + " m");
+        },
+        C = function C(t) {
+          var e;
+          switch (t.align) {
+            case "right":
+            case "end":
+              e = "right";
+              break;
+            case "center":
+              e = "center";
+              break;
+            case "left":
+            case "start":
+            default:
+              e = "left";
+          }
+          var r = this.pdf.getTextDimensions(t.text),
+            n = S.call(this, t.y),
+            i = _.call(this, n) - r.h,
+            a = this.ctx.transform.applyToPoint(new c(t.x, n)),
+            o = this.ctx.transform.decompose(),
+            s = new l();
+          s = (s = (s = s.multiply(o.translate)).multiply(o.skew)).multiply(o.scale);
+          for (var h, f, d, p = this.ctx.transform.applyToRectangle(new u(t.x, n, r.w, r.h)), g = s.applyToRectangle(new u(t.x, i, r.w, r.h)), m = y.call(this, g), v = [], w = 0; w < m.length; w += 1) -1 === v.indexOf(m[w]) && v.push(m[w]);
+          if (L(v), this.autoPaging) for (var A = v[0], P = v[v.length - 1], k = A; k < P + 1; k++) {
+            this.pdf.setPage(k);
+            var F = 1 === k ? this.posY + this.margin[0] : this.margin[0],
+              I = this.pdf.internal.pageSize.height - this.posY - this.margin[0] - this.margin[2],
+              C = this.pdf.internal.pageSize.height - this.margin[2],
+              j = C - this.margin[0],
+              O = this.pdf.internal.pageSize.width - this.margin[1],
+              B = O - this.margin[3],
+              M = 1 === k ? 0 : I + (k - 2) * j;
+            if (0 !== this.ctx.clip_path.length) {
+              var E = this.path;
+              h = JSON.parse(JSON.stringify(this.ctx.clip_path)), this.path = N(h, this.posX + this.margin[3], -1 * M + F), x.call(this, "fill", !0), this.path = E;
+            }
+            var q = N([JSON.parse(JSON.stringify(g))], this.posX + this.margin[3], -M + F + this.ctx.prevPageLastElemOffset)[0];
+            t.scale >= .01 && (f = this.pdf.internal.getFontSize(), this.pdf.setFontSize(f * t.scale), d = this.lineWidth, this.lineWidth = d * t.scale);
+            var D = "text" !== this.autoPaging;
+            if (D || q.y + q.h <= C) {
+              if (D || q.y >= F && q.x <= O) {
+                var R = D ? t.text : this.pdf.splitTextToSize(t.text, t.maxWidth || O - q.x)[0],
+                  T = N([JSON.parse(JSON.stringify(p))], this.posX + this.margin[3], -M + F + this.ctx.prevPageLastElemOffset)[0],
+                  U = D && (k > A || k < P) && b.call(this);
+                U && (this.pdf.saveGraphicsState(), this.pdf.rect(this.margin[3], this.margin[0], B, j, null).clip().discardPath()), this.pdf.text(R, T.x, T.y, {
+                  angle: t.angle,
+                  align: e,
+                  renderingMode: t.renderingMode
+                }), U && this.pdf.restoreGraphicsState();
+              }
+            } else q.y < C && (this.ctx.prevPageLastElemOffset += C - q.y);
+            t.scale >= .01 && (this.pdf.setFontSize(f), this.lineWidth = d);
+          } else t.scale >= .01 && (f = this.pdf.internal.getFontSize(), this.pdf.setFontSize(f * t.scale), d = this.lineWidth, this.lineWidth = d * t.scale), this.pdf.text(t.text, a.x + this.posX, a.y + this.posY, {
+            angle: t.angle,
+            align: e,
+            renderingMode: t.renderingMode,
+            maxWidth: t.maxWidth
+          }), t.scale >= .01 && (this.pdf.setFontSize(f), this.lineWidth = d);
+        },
+        j = function j(t, e, r, i) {
+          r = r || 0, i = i || 0, this.pdf.internal.out(n(t + r) + " " + a(e + i) + " l");
+        },
+        O = function O(t, e, r) {
+          return this.pdf.lines(t, e, r, null, null);
+        },
+        B = function B(t, e, n, i, a, c, u, l) {
+          this.pdf.internal.out([r(o(n + t)), r(s(i + e)), r(o(a + t)), r(s(c + e)), r(o(u + t)), r(s(l + e)), "c"].join(" "));
+        },
+        M = function M(t, e, r, n) {
+          for (var i = 2 * Math.PI, a = Math.PI / 2; e > r;) e -= i;
+          var o = Math.abs(r - e);
+          o < i && n && (o = i - o);
+          for (var s = [], c = n ? -1 : 1, u = e; o > 1e-5;) {
+            var l = u + c * Math.min(o, a);
+            s.push(E.call(this, t, u, l)), o -= Math.abs(l - u), u = l;
+          }
+          return s;
+        },
+        E = function E(t, e, r) {
+          var n = (r - e) / 2,
+            i = t * Math.cos(n),
+            a = t * Math.sin(n),
+            o = i,
+            s = -a,
+            c = o * o + s * s,
+            u = c + o * i + s * a,
+            l = 4 / 3 * (Math.sqrt(2 * c * u) - u) / (o * a - s * i),
+            h = o - l * s,
+            f = s + l * o,
+            d = h,
+            p = -f,
+            g = n + e,
+            m = Math.cos(g),
+            v = Math.sin(g);
+          return {
+            x1: t * Math.cos(e),
+            y1: t * Math.sin(e),
+            x2: h * m - f * v,
+            y2: h * v + f * m,
+            x3: d * m - p * v,
+            y3: d * v + p * m,
+            x4: t * Math.cos(r),
+            y4: t * Math.sin(r)
+          };
+        },
+        q = function q(t) {
+          return 180 * t / Math.PI;
+        },
+        D = function D(t, e, r, n, i, a) {
+          var o = t + .5 * (r - t),
+            s = e + .5 * (n - e),
+            c = i + .5 * (r - i),
+            l = a + .5 * (n - a),
+            h = Math.min(t, i, o, c),
+            f = Math.max(t, i, o, c),
+            d = Math.min(e, a, s, l),
+            p = Math.max(e, a, s, l);
+          return new u(h, d, f - h, p - d);
+        },
+        R = function R(t, e, r, n, i, a, o, s) {
+          var c,
+            l,
+            h,
+            f,
+            d,
+            p,
+            g,
+            m,
+            v,
+            b,
+            y,
+            w,
+            N,
+            L,
+            A = r - t,
+            x = n - e,
+            S = i - r,
+            _ = a - n,
+            P = o - i,
+            k = s - a;
+          for (l = 0; l < 41; l++) v = (g = (h = t + (c = l / 40) * A) + c * ((d = r + c * S) - h)) + c * (d + c * (i + c * P - d) - g), b = (m = (f = e + c * x) + c * ((p = n + c * _) - f)) + c * (p + c * (a + c * k - p) - m), 0 == l ? (y = v, w = b, N = v, L = b) : (y = Math.min(y, v), w = Math.min(w, b), N = Math.max(N, v), L = Math.max(L, b));
+          return new u(Math.round(y), Math.round(w), Math.round(N - y), Math.round(L - w));
+        },
+        T = function T() {
+          if (this.prevLineDash || this.ctx.lineDash.length || this.ctx.lineDashOffset) {
+            var t,
+              e,
+              r = (t = this.ctx.lineDash, e = this.ctx.lineDashOffset, JSON.stringify({
+                lineDash: t,
+                lineDashOffset: e
+              }));
+            this.prevLineDash !== r && (this.pdf.setLineDash(this.ctx.lineDash, this.ctx.lineDashOffset), this.prevLineDash = r);
+          }
+        };
+    }(M.API);
+    var Ut = Uint8Array,
+      zt = Uint16Array,
+      Ht = Int32Array,
+      Wt = new Ut([0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0, 0, 0, 0]),
+      Vt = new Ut([0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 0, 0]),
+      Gt = new Ut([16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15]),
+      Yt = function Yt(t, e) {
+        for (var r = new zt(31), n = 0; n < 31; ++n) r[n] = e += 1 << t[n - 1];
+        var i = new Ht(r[30]);
+        for (n = 1; n < 30; ++n) for (var a = r[n]; a < r[n + 1]; ++a) i[a] = a - r[n] << 5 | n;
+        return {
+          b: r,
+          r: i
+        };
+      },
+      Jt = Yt(Wt, 2),
+      Xt = Jt.b,
+      Kt = Jt.r;
+    Xt[28] = 258, Kt[258] = 28;
+    for (var Zt = Yt(Vt, 0), $t = Zt.b, Qt = Zt.r, te = new zt(32768), ee = 0; ee < 32768; ++ee) {
+      var re = (43690 & ee) >> 1 | (21845 & ee) << 1;
+      re = (61680 & (re = (52428 & re) >> 2 | (13107 & re) << 2)) >> 4 | (3855 & re) << 4, te[ee] = ((65280 & re) >> 8 | (255 & re) << 8) >> 1;
+    }
+    var ne = function ne(t, e, r) {
+        for (var n = t.length, i = 0, a = new zt(e); i < n; ++i) t[i] && ++a[t[i] - 1];
+        var o,
+          s = new zt(e);
+        for (i = 1; i < e; ++i) s[i] = s[i - 1] + a[i - 1] << 1;
+        if (r) {
+          o = new zt(1 << e);
+          var c = 15 - e;
+          for (i = 0; i < n; ++i) if (t[i]) for (var u = i << 4 | t[i], l = e - t[i], h = s[t[i] - 1]++ << l, f = h | (1 << l) - 1; h <= f; ++h) o[te[h] >> c] = u;
+        } else for (o = new zt(n), i = 0; i < n; ++i) t[i] && (o[i] = te[s[t[i] - 1]++] >> 15 - t[i]);
+        return o;
+      },
+      ie = new Ut(288);
+    for (ee = 0; ee < 144; ++ee) ie[ee] = 8;
+    for (ee = 144; ee < 256; ++ee) ie[ee] = 9;
+    for (ee = 256; ee < 280; ++ee) ie[ee] = 7;
+    for (ee = 280; ee < 288; ++ee) ie[ee] = 8;
+    var ae = new Ut(32);
+    for (ee = 0; ee < 32; ++ee) ae[ee] = 5;
+    var oe = ne(ie, 9, 0),
+      se = ne(ie, 9, 1),
+      ce = ne(ae, 5, 0),
+      ue = ne(ae, 5, 1),
+      le = function le(t) {
+        for (var e = t[0], r = 1; r < t.length; ++r) t[r] > e && (e = t[r]);
+        return e;
+      },
+      he = function he(t, e, r) {
+        var n = e / 8 | 0;
+        return (t[n] | t[n + 1] << 8) >> (7 & e) & r;
+      },
+      fe = function fe(t, e) {
+        var r = e / 8 | 0;
+        return (t[r] | t[r + 1] << 8 | t[r + 2] << 16) >> (7 & e);
+      },
+      de = function de(t) {
+        return (t + 7) / 8 | 0;
+      },
+      pe = function pe(t, e, r) {
+        return (null == e || e < 0) && (e = 0), (null == r || r > t.length) && (r = t.length), new Ut(t.subarray(e, r));
+      },
+      ge = ["unexpected EOF", "invalid block type", "invalid length/literal", "invalid distance", "stream finished", "no stream handler",, "no callback", "invalid UTF-8 data", "extra field too long", "date not in range 1980-2099", "filename too long", "stream finishing", "invalid zip data"],
+      _me = function me(t, e, r) {
+        var n = new Error(e || ge[t]);
+        if (n.code = t, Error.captureStackTrace && Error.captureStackTrace(n, _me), !r) throw n;
+        return n;
+      },
+      ve = function ve(t, e, r) {
+        r <<= 7 & e;
+        var n = e / 8 | 0;
+        t[n] |= r, t[n + 1] |= r >> 8;
+      },
+      be = function be(t, e, r) {
+        r <<= 7 & e;
+        var n = e / 8 | 0;
+        t[n] |= r, t[n + 1] |= r >> 8, t[n + 2] |= r >> 16;
+      },
+      ye = function ye(t, e) {
+        for (var r = [], n = 0; n < t.length; ++n) t[n] && r.push({
+          s: n,
+          f: t[n]
+        });
+        var i = r.length,
+          a = r.slice();
+        if (!i) return {
+          t: _e,
+          l: 0
+        };
+        if (1 == i) {
+          var o = new Ut(r[0].s + 1);
+          return o[r[0].s] = 1, {
+            t: o,
+            l: 1
+          };
+        }
+        r.sort(function (t, e) {
+          return t.f - e.f;
+        }), r.push({
+          s: -1,
+          f: 25001
+        });
+        var s = r[0],
+          c = r[1],
+          u = 0,
+          l = 1,
+          h = 2;
+        for (r[0] = {
+          s: -1,
+          f: s.f + c.f,
+          l: s,
+          r: c
+        }; l != i - 1;) s = r[r[u].f < r[h].f ? u++ : h++], c = r[u != l && r[u].f < r[h].f ? u++ : h++], r[l++] = {
+          s: -1,
+          f: s.f + c.f,
+          l: s,
+          r: c
+        };
+        var f = a[0].s;
+        for (n = 1; n < i; ++n) a[n].s > f && (f = a[n].s);
+        var d = new zt(f + 1),
+          p = _we(r[l - 1], d, 0);
+        if (p > e) {
+          n = 0;
+          var g = 0,
+            m = p - e,
+            v = 1 << m;
+          for (a.sort(function (t, e) {
+            return d[e.s] - d[t.s] || t.f - e.f;
+          }); n < i; ++n) {
+            var b = a[n].s;
+            if (!(d[b] > e)) break;
+            g += v - (1 << p - d[b]), d[b] = e;
+          }
+          for (g >>= m; g > 0;) {
+            var y = a[n].s;
+            d[y] < e ? g -= 1 << e - d[y]++ - 1 : ++n;
+          }
+          for (; n >= 0 && g; --n) {
+            var w = a[n].s;
+            d[w] == e && (--d[w], ++g);
+          }
+          p = e;
+        }
+        return {
+          t: new Ut(d),
+          l: p
+        };
+      },
+      _we = function we(t, e, r) {
+        return -1 == t.s ? Math.max(_we(t.l, e, r + 1), _we(t.r, e, r + 1)) : e[t.s] = r;
+      },
+      Ne = function Ne(t) {
+        for (var e = t.length; e && !t[--e];);
+        for (var r = new zt(++e), n = 0, i = t[0], a = 1, o = function o(t) {
+            r[n++] = t;
+          }, s = 1; s <= e; ++s) if (t[s] == i && s != e) ++a;else {
+          if (!i && a > 2) {
+            for (; a > 138; a -= 138) o(32754);
+            a > 2 && (o(a > 10 ? a - 11 << 5 | 28690 : a - 3 << 5 | 12305), a = 0);
+          } else if (a > 3) {
+            for (o(i), --a; a > 6; a -= 6) o(8304);
+            a > 2 && (o(a - 3 << 5 | 8208), a = 0);
+          }
+          for (; a--;) o(i);
+          a = 1, i = t[s];
+        }
+        return {
+          c: r.subarray(0, n),
+          n: e
+        };
+      },
+      Le = function Le(t, e) {
+        for (var r = 0, n = 0; n < e.length; ++n) r += t[n] * e[n];
+        return r;
+      },
+      Ae = function Ae(t, e, r) {
+        var n = r.length,
+          i = de(e + 2);
+        t[i] = 255 & n, t[i + 1] = n >> 8, t[i + 2] = 255 ^ t[i], t[i + 3] = 255 ^ t[i + 1];
+        for (var a = 0; a < n; ++a) t[i + a + 4] = r[a];
+        return 8 * (i + 4 + n);
+      },
+      xe = function xe(t, e, r, n, i, a, o, s, c, u, l) {
+        ve(e, l++, r), ++i[256];
+        for (var h = ye(i, 15), f = h.t, d = h.l, p = ye(a, 15), g = p.t, m = p.l, v = Ne(f), b = v.c, y = v.n, w = Ne(g), N = w.c, L = w.n, A = new zt(19), x = 0; x < b.length; ++x) ++A[31 & b[x]];
+        for (x = 0; x < N.length; ++x) ++A[31 & N[x]];
+        for (var S = ye(A, 7), _ = S.t, P = S.l, k = 19; k > 4 && !_[Gt[k - 1]]; --k);
+        var F,
+          I,
+          C,
+          j,
+          O = u + 5 << 3,
+          B = Le(i, ie) + Le(a, ae) + o,
+          M = Le(i, f) + Le(a, g) + o + 14 + 3 * k + Le(A, _) + 2 * A[16] + 3 * A[17] + 7 * A[18];
+        if (c >= 0 && O <= B && O <= M) return Ae(e, l, t.subarray(c, c + u));
+        if (ve(e, l, 1 + (M < B)), l += 2, M < B) {
+          F = ne(f, d, 0), I = f, C = ne(g, m, 0), j = g;
+          var E = ne(_, P, 0);
+          ve(e, l, y - 257), ve(e, l + 5, L - 1), ve(e, l + 10, k - 4), l += 14;
+          for (x = 0; x < k; ++x) ve(e, l + 3 * x, _[Gt[x]]);
+          l += 3 * k;
+          for (var q = [b, N], D = 0; D < 2; ++D) {
+            var R = q[D];
+            for (x = 0; x < R.length; ++x) {
+              var T = 31 & R[x];
+              ve(e, l, E[T]), l += _[T], T > 15 && (ve(e, l, R[x] >> 5 & 127), l += R[x] >> 12);
+            }
+          }
+        } else F = oe, I = ie, C = ce, j = ae;
+        for (x = 0; x < s; ++x) {
+          var U = n[x];
+          if (U > 255) {
+            be(e, l, F[(T = U >> 18 & 31) + 257]), l += I[T + 257], T > 7 && (ve(e, l, U >> 23 & 31), l += Wt[T]);
+            var z = 31 & U;
+            be(e, l, C[z]), l += j[z], z > 3 && (be(e, l, U >> 5 & 8191), l += Vt[z]);
+          } else be(e, l, F[U]), l += I[U];
+        }
+        return be(e, l, F[256]), l + I[256];
+      },
+      Se = new Ht([65540, 131080, 131088, 131104, 262176, 1048704, 1048832, 2114560, 2117632]),
+      _e = new Ut(0),
+      Pe = function Pe() {
+        var t = 1,
+          e = 0;
+        return {
+          p: function p(r) {
+            for (var n = t, i = e, a = 0 | r.length, o = 0; o != a;) {
+              for (var s = Math.min(o + 2655, a); o < s; ++o) i += n += r[o];
+              n = (65535 & n) + 15 * (n >> 16), i = (65535 & i) + 15 * (i >> 16);
+            }
+            t = n, e = i;
+          },
+          d: function d() {
+            return (255 & (t %= 65521)) << 24 | (65280 & t) << 8 | (255 & (e %= 65521)) << 8 | e >> 8;
+          }
+        };
+      },
+      ke = function ke(t, e, r, n, i) {
+        if (!i && (i = {
+          l: 1
+        }, e.dictionary)) {
+          var a = e.dictionary.subarray(-32768),
+            o = new Ut(a.length + t.length);
+          o.set(a), o.set(t, a.length), t = o, i.w = a.length;
+        }
+        return function (t, e, r, n, i, a) {
+          var o = a.z || t.length,
+            s = new Ut(n + o + 5 * (1 + Math.ceil(o / 7e3)) + i),
+            c = s.subarray(n, s.length - i),
+            u = a.l,
+            l = 7 & (a.r || 0);
+          if (e) {
+            l && (c[0] = a.r >> 3);
+            for (var h = Se[e - 1], f = h >> 13, d = 8191 & h, p = (1 << r) - 1, g = a.p || new zt(32768), m = a.h || new zt(p + 1), v = Math.ceil(r / 3), b = 2 * v, y = function y(e) {
+                return (t[e] ^ t[e + 1] << v ^ t[e + 2] << b) & p;
+              }, w = new Ht(25e3), N = new zt(288), L = new zt(32), A = 0, x = 0, S = a.i || 0, _ = 0, P = a.w || 0, k = 0; S + 2 < o; ++S) {
+              var F = y(S),
+                I = 32767 & S,
+                C = m[F];
+              if (g[I] = C, m[F] = I, P <= S) {
+                var j = o - S;
+                if ((A > 7e3 || _ > 24576) && (j > 423 || !u)) {
+                  l = xe(t, c, 0, w, N, L, x, _, k, S - k, l), _ = A = x = 0, k = S;
+                  for (var O = 0; O < 286; ++O) N[O] = 0;
+                  for (O = 0; O < 30; ++O) L[O] = 0;
+                }
+                var B = 2,
+                  M = 0,
+                  E = d,
+                  q = I - C & 32767;
+                if (j > 2 && F == y(S - q)) for (var D = Math.min(f, j) - 1, R = Math.min(32767, S), T = Math.min(258, j); q <= R && --E && I != C;) {
+                  if (t[S + B] == t[S + B - q]) {
+                    for (var U = 0; U < T && t[S + U] == t[S + U - q]; ++U);
+                    if (U > B) {
+                      if (B = U, M = q, U > D) break;
+                      var z = Math.min(q, U - 2),
+                        H = 0;
+                      for (O = 0; O < z; ++O) {
+                        var W = S - q + O & 32767,
+                          V = W - g[W] & 32767;
+                        V > H && (H = V, C = W);
+                      }
+                    }
+                  }
+                  q += (I = C) - (C = g[I]) & 32767;
+                }
+                if (M) {
+                  w[_++] = 268435456 | Kt[B] << 18 | Qt[M];
+                  var G = 31 & Kt[B],
+                    Y = 31 & Qt[M];
+                  x += Wt[G] + Vt[Y], ++N[257 + G], ++L[Y], P = S + B, ++A;
+                } else w[_++] = t[S], ++N[t[S]];
+              }
+            }
+            for (S = Math.max(S, P); S < o; ++S) w[_++] = t[S], ++N[t[S]];
+            l = xe(t, c, u, w, N, L, x, _, k, S - k, l), u || (a.r = 7 & l | c[l / 8 | 0] << 3, l -= 7, a.h = m, a.p = g, a.i = S, a.w = P);
+          } else {
+            for (S = a.w || 0; S < o + u; S += 65535) {
+              var J = S + 65535;
+              J >= o && (c[l / 8 | 0] = u, J = o), l = Ae(c, l + 1, t.subarray(S, J));
+            }
+            a.i = o;
+          }
+          return pe(s, 0, n + de(l) + i);
+        }(t, null == e.level ? 6 : e.level, null == e.mem ? Math.ceil(1.5 * Math.max(8, Math.min(13, Math.log(t.length)))) : 12 + e.mem, r, n, i);
+      },
+      Fe = function Fe(t, e, r) {
+        for (; r; ++e) t[e] = r, r >>>= 8;
+      };
+    function Ie(t, e) {
+      e || (e = {});
+      var r = Pe();
+      r.p(t);
+      var n = ke(t, e, e.dictionary ? 6 : 2, 4);
+      return function (t, e) {
+        var r = e.level,
+          n = 0 == r ? 0 : r < 6 ? 1 : 9 == r ? 3 : 2;
+        if (t[0] = 120, t[1] = n << 6 | (e.dictionary && 32), t[1] |= 31 - (t[0] << 8 | t[1]) % 31, e.dictionary) {
+          var i = Pe();
+          i.p(e.dictionary), Fe(t, 2, i.d());
+        }
+      }(n, e), Fe(n, n.length - 4, r.d()), n;
+    }
+    function Ce(t, e) {
+      return function (t, e, r, n) {
+        var i = t.length,
+          a = n ? n.length : 0;
+        if (!i || e.f && !e.l) return r || new Ut(0);
+        var o = !r,
+          s = o || 2 != e.i,
+          c = e.i;
+        o && (r = new Ut(3 * i));
+        var u = function u(t) {
+            var e = r.length;
+            if (t > e) {
+              var n = new Ut(Math.max(2 * e, t));
+              n.set(r), r = n;
+            }
+          },
+          l = e.f || 0,
+          h = e.p || 0,
+          f = e.b || 0,
+          d = e.l,
+          p = e.d,
+          g = e.m,
+          m = e.n,
+          v = 8 * i;
+        do {
+          if (!d) {
+            l = he(t, h, 1);
+            var b = he(t, h + 1, 3);
+            if (h += 3, !b) {
+              var y = t[(I = de(h) + 4) - 4] | t[I - 3] << 8,
+                w = I + y;
+              if (w > i) {
+                c && _me(0);
+                break;
+              }
+              s && u(f + y), r.set(t.subarray(I, w), f), e.b = f += y, e.p = h = 8 * w, e.f = l;
+              continue;
+            }
+            if (1 == b) d = se, p = ue, g = 9, m = 5;else if (2 == b) {
+              var N = he(t, h, 31) + 257,
+                L = he(t, h + 10, 15) + 4,
+                A = N + he(t, h + 5, 31) + 1;
+              h += 14;
+              for (var x = new Ut(A), S = new Ut(19), _ = 0; _ < L; ++_) S[Gt[_]] = he(t, h + 3 * _, 7);
+              h += 3 * L;
+              var P = le(S),
+                k = (1 << P) - 1,
+                F = ne(S, P, 1);
+              for (_ = 0; _ < A;) {
+                var I,
+                  C = F[he(t, h, k)];
+                if (h += 15 & C, (I = C >> 4) < 16) x[_++] = I;else {
+                  var j = 0,
+                    O = 0;
+                  for (16 == I ? (O = 3 + he(t, h, 3), h += 2, j = x[_ - 1]) : 17 == I ? (O = 3 + he(t, h, 7), h += 3) : 18 == I && (O = 11 + he(t, h, 127), h += 7); O--;) x[_++] = j;
+                }
+              }
+              var B = x.subarray(0, N),
+                M = x.subarray(N);
+              g = le(B), m = le(M), d = ne(B, g, 1), p = ne(M, m, 1);
+            } else _me(1);
+            if (h > v) {
+              c && _me(0);
+              break;
+            }
+          }
+          s && u(f + 131072);
+          for (var E = (1 << g) - 1, q = (1 << m) - 1, D = h;; D = h) {
+            var R = (j = d[fe(t, h) & E]) >> 4;
+            if ((h += 15 & j) > v) {
+              c && _me(0);
+              break;
+            }
+            if (j || _me(2), R < 256) r[f++] = R;else {
+              if (256 == R) {
+                D = h, d = null;
+                break;
+              }
+              var T = R - 254;
+              if (R > 264) {
+                var U = Wt[_ = R - 257];
+                T = he(t, h, (1 << U) - 1) + Xt[_], h += U;
+              }
+              var z = p[fe(t, h) & q],
+                H = z >> 4;
+              z || _me(3), h += 15 & z;
+              M = $t[H];
+              if (H > 3) {
+                U = Vt[H];
+                M += fe(t, h) & (1 << U) - 1, h += U;
+              }
+              if (h > v) {
+                c && _me(0);
+                break;
+              }
+              s && u(f + 131072);
+              var W = f + T;
+              if (f < M) {
+                var V = a - M,
+                  G = Math.min(M, W);
+                for (V + f < 0 && _me(3); f < G; ++f) r[f] = n[V + f];
+              }
+              for (; f < W; ++f) r[f] = r[f - M];
+            }
+          }
+          e.l = d, e.p = D, e.b = f, e.f = l, d && (l = 1, e.m = g, e.d = p, e.n = m);
+        } while (!l);
+        return f != r.length && o ? pe(r, 0, f) : r.subarray(0, f);
+      }(t.subarray((r = t, n = e && e.dictionary, (8 != (15 & r[0]) || r[0] >> 4 > 7 || (r[0] << 8 | r[1]) % 31) && _me(6, "invalid zlib data"), (r[1] >> 5 & 1) == +!n && _me(6, "invalid zlib data: " + (32 & r[1] ? "need" : "unexpected") + " dictionary"), 2 + (r[1] >> 3 & 4)), -4), {
+        i: 2
+      }, e && e.out, e && e.dictionary);
+      var r, n;
+    }
+    var je = "undefined" != typeof TextDecoder && new TextDecoder();
+    try {
+      je.decode(_e, {
+        stream: !0
+      }), 1;
+    } catch (t) {}
+    /**
+       * @license
+       * jsPDF filters PlugIn
+       * Copyright (c) 2014 Aras Abbasi
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    !function (t) {
+      var e = function e(t) {
+          var e, r, n, i, a, o, s, c, u, l;
+          for (/[^\x00-\xFF]/.test(t), r = [], n = 0, i = (t += e = "\0\0\0\0".slice(t.length % 4 || 4)).length; i > n; n += 4) 0 !== (a = (t.charCodeAt(n) << 24) + (t.charCodeAt(n + 1) << 16) + (t.charCodeAt(n + 2) << 8) + t.charCodeAt(n + 3)) ? (o = (a = ((a = ((a = ((a = (a - (l = a % 85)) / 85) - (u = a % 85)) / 85) - (c = a % 85)) / 85) - (s = a % 85)) / 85) % 85, r.push(o + 33, s + 33, c + 33, u + 33, l + 33)) : r.push(122);
+          return function (t, e) {
+            for (var r = e; r > 0; r--) t.pop();
+          }(r, e.length), String.fromCharCode.apply(String, r) + "~>";
+        },
+        r = function r(t) {
+          var e,
+            r,
+            n,
+            i,
+            a,
+            o = String,
+            s = "length",
+            c = 255,
+            u = "charCodeAt",
+            l = "slice",
+            h = "replace";
+          for (t[l](-2), t = t[l](0, -2)[h](/\s/g, "")[h]("z", "!!!!!"), n = [], i = 0, a = (t += e = "uuuuu"[l](t[s] % 5 || 5))[s]; a > i; i += 5) r = 52200625 * (t[u](i) - 33) + 614125 * (t[u](i + 1) - 33) + 7225 * (t[u](i + 2) - 33) + 85 * (t[u](i + 3) - 33) + (t[u](i + 4) - 33), n.push(c & r >> 24, c & r >> 16, c & r >> 8, c & r);
+          return function (t, e) {
+            for (var r = e; r > 0; r--) t.pop();
+          }(n, e[s]), o.fromCharCode.apply(o, n);
+        },
+        n = function n(t) {
+          var e = new RegExp(/^([0-9A-Fa-f]{2})+$/);
+          if (-1 !== (t = t.replace(/\s/g, "")).indexOf(">") && (t = t.substr(0, t.indexOf(">"))), t.length % 2 && (t += "0"), !1 === e.test(t)) return "";
+          for (var r = "", n = 0; n < t.length; n += 2) r += String.fromCharCode("0x" + (t[n] + t[n + 1]));
+          return r;
+        },
+        i = function i(t) {
+          for (var e = new Uint8Array(t.length), r = t.length; r--;) e[r] = t.charCodeAt(r);
+          return t = (e = Ie(e)).reduce(function (t, e) {
+            return t + String.fromCharCode(e);
+          }, "");
+        };
+      t.processDataByFilters = function (t, a) {
+        var o = 0,
+          s = t || "",
+          c = [];
+        for ("string" == typeof (a = a || []) && (a = [a]), o = 0; o < a.length; o += 1) switch (a[o]) {
+          case "ASCII85Decode":
+          case "/ASCII85Decode":
+            s = r(s), c.push("/ASCII85Encode");
+            break;
+          case "ASCII85Encode":
+          case "/ASCII85Encode":
+            s = e(s), c.push("/ASCII85Decode");
+            break;
+          case "ASCIIHexDecode":
+          case "/ASCIIHexDecode":
+            s = n(s), c.push("/ASCIIHexEncode");
+            break;
+          case "ASCIIHexEncode":
+          case "/ASCIIHexEncode":
+            s = s.split("").map(function (t) {
+              return ("0" + t.charCodeAt().toString(16)).slice(-2);
+            }).join("") + ">", c.push("/ASCIIHexDecode");
+            break;
+          case "FlateEncode":
+          case "/FlateEncode":
+            s = i(s), c.push("/FlateDecode");
+            break;
+          default:
+            throw new Error('The filter: "' + a[o] + '" is not implemented');
+        }
+        return {
+          data: s,
+          reverseChain: c.reverse().join(" ")
+        };
+      };
+    }(M.API),
+    /**
+       * @license
+       * jsPDF fileloading PlugIn
+       * Copyright (c) 2018 Aras Abbasi (aras.abbasi@gmail.com)
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      t.loadFile = function (t, e, r) {
+        return function (t, e, r) {
+          e = !1 !== e, r = "function" == typeof r ? r : function () {};
+          var n = void 0;
+          try {
+            n = function (t, e, r) {
+              var n = new XMLHttpRequest(),
+                i = 0,
+                a = function a(t) {
+                  var e = t.length,
+                    r = [],
+                    n = String.fromCharCode;
+                  for (i = 0; i < e; i += 1) r.push(n(255 & t.charCodeAt(i)));
+                  return r.join("");
+                };
+              if (n.open("GET", t, !e), n.overrideMimeType("text/plain; charset=x-user-defined"), !1 === e && (n.onload = function () {
+                200 === n.status ? r(a(this.responseText)) : r(void 0);
+              }), n.send(null), e && 200 === n.status) return a(n.responseText);
+            }(t, e, r);
+          } catch (t) {}
+          return n;
+        }(t, e, r);
+      }, t.loadImageFile = t.loadFile;
+    }(M.API), function (n) {
+      function i() {
+        return (r.html2canvas ? Promise.resolve(r.html2canvas) : "object" === (void 0 === t ? "undefined" : e(t)) && "undefined" != typeof module ? new Promise(function (t, e) {
+          try {
+            t(require("html2canvas"));
+          } catch (t) {
+            e(t);
+          }
+        }) : "function" == typeof define && define.amd ? new Promise(function (t, e) {
+          try {
+            require(["html2canvas"], t);
+          } catch (t) {
+            e(t);
+          }
+        }) : Promise.reject(new Error("Could not load html2canvas"))).catch(function (t) {
+          return Promise.reject(new Error("Could not load html2canvas: " + t));
+        }).then(function (t) {
+          return t.default ? t.default : t;
+        });
+      }
+      function a() {
+        return (r.DOMPurify ? Promise.resolve(r.DOMPurify) : "object" === (void 0 === t ? "undefined" : e(t)) && "undefined" != typeof module ? new Promise(function (t, e) {
+          try {
+            t(require("dompurify"));
+          } catch (t) {
+            e(t);
+          }
+        }) : "function" == typeof define && define.amd ? new Promise(function (t, e) {
+          try {
+            require(["dompurify"], t);
+          } catch (t) {
+            e(t);
+          }
+        }) : Promise.reject(new Error("Could not load dompurify"))).catch(function (t) {
+          return Promise.reject(new Error("Could not load dompurify: " + t));
+        }).then(function (t) {
+          return t.default ? t.default : t;
+        });
+      }
+      var o = function o(t) {
+          var r = e(t);
+          return "undefined" === r ? "undefined" : "string" === r || t instanceof String ? "string" : "number" === r || t instanceof Number ? "number" : "function" === r || t instanceof Function ? "function" : t && t.constructor === Array ? "array" : t && 1 === t.nodeType ? "element" : "object" === r ? "object" : "unknown";
+        },
+        s = function s(t, e) {
+          var r = document.createElement(t);
+          for (var n in e.className && (r.className = e.className), e.innerHTML && e.dompurify && (r.innerHTML = e.dompurify.sanitize(e.innerHTML)), e.style) r.style[n] = e.style[n];
+          return r;
+        },
+        c = function t(e) {
+          var r = Object.assign(t.convert(Promise.resolve()), JSON.parse(JSON.stringify(t.template))),
+            n = t.convert(Promise.resolve(), r);
+          return n = (n = n.setProgress(1, t, 1, [t])).set(e);
+        };
+      (c.prototype = Object.create(Promise.prototype)).constructor = c, c.convert = function (t, e) {
+        return t.__proto__ = e || c.prototype, t;
+      }, c.template = {
+        prop: {
+          src: null,
+          container: null,
+          overlay: null,
+          canvas: null,
+          img: null,
+          pdf: null,
+          pageSize: null,
+          callback: function callback() {}
+        },
+        progress: {
+          val: 0,
+          state: null,
+          n: 0,
+          stack: []
+        },
+        opt: {
+          filename: "file.pdf",
+          margin: [0, 0, 0, 0],
+          enableLinks: !0,
+          x: 0,
+          y: 0,
+          html2canvas: {},
+          jsPDF: {},
+          backgroundColor: "transparent"
+        }
+      }, c.prototype.from = function (t, e) {
+        return this.then(function () {
+          switch (e = e || function (t) {
+            switch (o(t)) {
+              case "string":
+                return "string";
+              case "element":
+                return "canvas" === t.nodeName.toLowerCase() ? "canvas" : "element";
+              default:
+                return "unknown";
+            }
+          }(t)) {
+            case "string":
+              return this.then(a).then(function (e) {
+                return this.set({
+                  src: s("div", {
+                    innerHTML: t,
+                    dompurify: e
+                  })
+                });
+              });
+            case "element":
+              return this.set({
+                src: t
+              });
+            case "canvas":
+              return this.set({
+                canvas: t
+              });
+            case "img":
+              return this.set({
+                img: t
+              });
+            default:
+              return this.error("Unknown source type.");
+          }
+        });
+      }, c.prototype.to = function (t) {
+        switch (t) {
+          case "container":
+            return this.toContainer();
+          case "canvas":
+            return this.toCanvas();
+          case "img":
+            return this.toImg();
+          case "pdf":
+            return this.toPdf();
+          default:
+            return this.error("Invalid target.");
+        }
+      }, c.prototype.toContainer = function () {
+        return this.thenList([function () {
+          return this.prop.src || this.error("Cannot duplicate - no source HTML.");
+        }, function () {
+          return this.prop.pageSize || this.setPageSize();
+        }]).then(function () {
+          var t = {
+              position: "relative",
+              display: "inline-block",
+              width: ("number" != typeof this.opt.width || isNaN(this.opt.width) || "number" != typeof this.opt.windowWidth || isNaN(this.opt.windowWidth) ? Math.max(this.prop.src.clientWidth, this.prop.src.scrollWidth, this.prop.src.offsetWidth) : this.opt.windowWidth) + "px",
+              left: 0,
+              right: 0,
+              top: 0,
+              margin: "auto",
+              backgroundColor: this.opt.backgroundColor
+            },
+            e = function t(e, r) {
+              for (var n = 3 === e.nodeType ? document.createTextNode(e.nodeValue) : e.cloneNode(!1), i = e.firstChild; i; i = i.nextSibling) !0 !== r && 1 === i.nodeType && "SCRIPT" === i.nodeName || n.appendChild(t(i, r));
+              return 1 === e.nodeType && ("CANVAS" === e.nodeName ? (n.width = e.width, n.height = e.height, n.getContext("2d").drawImage(e, 0, 0)) : "TEXTAREA" !== e.nodeName && "SELECT" !== e.nodeName || (n.value = e.value), n.addEventListener("load", function () {
+                n.scrollTop = e.scrollTop, n.scrollLeft = e.scrollLeft;
+              }, !0)), n;
+            }(this.prop.src, this.opt.html2canvas.javascriptEnabled);
+          "BODY" === e.tagName && (t.height = Math.max(document.body.scrollHeight, document.body.offsetHeight, document.documentElement.clientHeight, document.documentElement.scrollHeight, document.documentElement.offsetHeight) + "px"), this.prop.overlay = s("div", {
+            className: "html2pdf__overlay",
+            style: {
+              position: "fixed",
+              overflow: "hidden",
+              zIndex: 1e3,
+              left: "-100000px",
+              right: 0,
+              bottom: 0,
+              top: 0
+            }
+          }), this.prop.container = s("div", {
+            className: "html2pdf__container",
+            style: t
+          }), this.prop.container.appendChild(e), this.prop.container.firstChild.appendChild(s("div", {
+            style: {
+              clear: "both",
+              border: "0 none transparent",
+              margin: 0,
+              padding: 0,
+              height: 0
+            }
+          })), this.prop.container.style.float = "none", this.prop.overlay.appendChild(this.prop.container), document.body.appendChild(this.prop.overlay), this.prop.container.firstChild.style.position = "relative", this.prop.container.height = Math.max(this.prop.container.firstChild.clientHeight, this.prop.container.firstChild.scrollHeight, this.prop.container.firstChild.offsetHeight) + "px";
+        });
+      }, c.prototype.toCanvas = function () {
+        var t = [function () {
+          return document.body.contains(this.prop.container) || this.toContainer();
+        }];
+        return this.thenList(t).then(i).then(function (t) {
+          var e = Object.assign({}, this.opt.html2canvas);
+          return delete e.onrendered, t(this.prop.container, e);
+        }).then(function (t) {
+          (this.opt.html2canvas.onrendered || function () {})(t), this.prop.canvas = t, document.body.removeChild(this.prop.overlay);
+        });
+      }, c.prototype.toContext2d = function () {
+        var t = [function () {
+          return document.body.contains(this.prop.container) || this.toContainer();
+        }];
+        return this.thenList(t).then(i).then(function (t) {
+          var e = this.opt.jsPDF,
+            r = this.opt.fontFaces,
+            n = "number" != typeof this.opt.width || isNaN(this.opt.width) || "number" != typeof this.opt.windowWidth || isNaN(this.opt.windowWidth) ? 1 : this.opt.width / this.opt.windowWidth,
+            i = Object.assign({
+              async: !0,
+              allowTaint: !0,
+              scale: n,
+              scrollX: this.opt.scrollX || 0,
+              scrollY: this.opt.scrollY || 0,
+              backgroundColor: "#ffffff",
+              imageTimeout: 15e3,
+              logging: !0,
+              proxy: null,
+              removeContainer: !0,
+              foreignObjectRendering: !1,
+              useCORS: !1
+            }, this.opt.html2canvas);
+          if (delete i.onrendered, e.context2d.autoPaging = void 0 === this.opt.autoPaging || this.opt.autoPaging, e.context2d.posX = this.opt.x, e.context2d.posY = this.opt.y, e.context2d.margin = this.opt.margin, e.context2d.fontFaces = r, r) for (var a = 0; a < r.length; ++a) {
+            var o = r[a],
+              s = o.src.find(function (t) {
+                return "truetype" === t.format;
+              });
+            s && e.addFont(s.url, o.ref.name, o.ref.style);
+          }
+          return i.windowHeight = i.windowHeight || 0, i.windowHeight = 0 == i.windowHeight ? Math.max(this.prop.container.clientHeight, this.prop.container.scrollHeight, this.prop.container.offsetHeight) : i.windowHeight, e.context2d.save(!0), t(this.prop.container, i);
+        }).then(function (t) {
+          this.opt.jsPDF.context2d.restore(!0), (this.opt.html2canvas.onrendered || function () {})(t), this.prop.canvas = t, document.body.removeChild(this.prop.overlay);
+        });
+      }, c.prototype.toImg = function () {
+        return this.thenList([function () {
+          return this.prop.canvas || this.toCanvas();
+        }]).then(function () {
+          var t = this.prop.canvas.toDataURL("image/" + this.opt.image.type, this.opt.image.quality);
+          this.prop.img = document.createElement("img"), this.prop.img.src = t;
+        });
+      }, c.prototype.toPdf = function () {
+        return this.thenList([function () {
+          return this.toContext2d();
+        }]).then(function () {
+          this.prop.pdf = this.prop.pdf || this.opt.jsPDF;
+        });
+      }, c.prototype.output = function (t, e, r) {
+        return "img" === (r = r || "pdf").toLowerCase() || "image" === r.toLowerCase() ? this.outputImg(t, e) : this.outputPdf(t, e);
+      }, c.prototype.outputPdf = function (t, e) {
+        return this.thenList([function () {
+          return this.prop.pdf || this.toPdf();
+        }]).then(function () {
+          return this.prop.pdf.output(t, e);
+        });
+      }, c.prototype.outputImg = function (t) {
+        return this.thenList([function () {
+          return this.prop.img || this.toImg();
+        }]).then(function () {
+          switch (t) {
+            case void 0:
+            case "img":
+              return this.prop.img;
+            case "datauristring":
+            case "dataurlstring":
+              return this.prop.img.src;
+            case "datauri":
+            case "dataurl":
+              return document.location.href = this.prop.img.src;
+            default:
+              throw 'Image output type "' + t + '" is not supported.';
+          }
+        });
+      }, c.prototype.save = function (t) {
+        return this.thenList([function () {
+          return this.prop.pdf || this.toPdf();
+        }]).set(t ? {
+          filename: t
+        } : null).then(function () {
+          this.prop.pdf.save(this.opt.filename);
+        });
+      }, c.prototype.doCallback = function () {
+        return this.thenList([function () {
+          return this.prop.pdf || this.toPdf();
+        }]).then(function () {
+          this.prop.callback(this.prop.pdf);
+        });
+      }, c.prototype.set = function (t) {
+        if ("object" !== o(t)) return this;
+        var e = Object.keys(t || {}).map(function (e) {
+          if (e in c.template.prop) return function () {
+            this.prop[e] = t[e];
+          };
+          switch (e) {
+            case "margin":
+              return this.setMargin.bind(this, t.margin);
+            case "jsPDF":
+              return function () {
+                return this.opt.jsPDF = t.jsPDF, this.setPageSize();
+              };
+            case "pageSize":
+              return this.setPageSize.bind(this, t.pageSize);
+            default:
+              return function () {
+                this.opt[e] = t[e];
+              };
+          }
+        }, this);
+        return this.then(function () {
+          return this.thenList(e);
+        });
+      }, c.prototype.get = function (t, e) {
+        return this.then(function () {
+          var r = t in c.template.prop ? this.prop[t] : this.opt[t];
+          return e ? e(r) : r;
+        });
+      }, c.prototype.setMargin = function (t) {
+        return this.then(function () {
+          switch (o(t)) {
+            case "number":
+              t = [t, t, t, t];
+            case "array":
+              if (2 === t.length && (t = [t[0], t[1], t[0], t[1]]), 4 === t.length) break;
+            default:
+              return this.error("Invalid margin array.");
+          }
+          this.opt.margin = t;
+        }).then(this.setPageSize);
+      }, c.prototype.setPageSize = function (t) {
+        function e(t, e) {
+          return Math.floor(t * e / 72 * 96);
+        }
+        return this.then(function () {
+          (t = t || M.getPageSize(this.opt.jsPDF)).hasOwnProperty("inner") || (t.inner = {
+            width: t.width - this.opt.margin[1] - this.opt.margin[3],
+            height: t.height - this.opt.margin[0] - this.opt.margin[2]
+          }, t.inner.px = {
+            width: e(t.inner.width, t.k),
+            height: e(t.inner.height, t.k)
+          }, t.inner.ratio = t.inner.height / t.inner.width), this.prop.pageSize = t;
+        });
+      }, c.prototype.setProgress = function (t, e, r, n) {
+        return null != t && (this.progress.val = t), null != e && (this.progress.state = e), null != r && (this.progress.n = r), null != n && (this.progress.stack = n), this.progress.ratio = this.progress.val / this.progress.state, this;
+      }, c.prototype.updateProgress = function (t, e, r, n) {
+        return this.setProgress(t ? this.progress.val + t : null, e || null, r ? this.progress.n + r : null, n ? this.progress.stack.concat(n) : null);
+      }, c.prototype.then = function (t, e) {
+        var r = this;
+        return this.thenCore(t, e, function (t, e) {
+          return r.updateProgress(null, null, 1, [t]), Promise.prototype.then.call(this, function (e) {
+            return r.updateProgress(null, t), e;
+          }).then(t, e).then(function (t) {
+            return r.updateProgress(1), t;
+          });
+        });
+      }, c.prototype.thenCore = function (t, e, r) {
+        r = r || Promise.prototype.then;
+        t && (t = t.bind(this)), e && (e = e.bind(this));
+        var n = -1 !== Promise.toString().indexOf("[native code]") && "Promise" === Promise.name ? this : c.convert(Object.assign({}, this), Promise.prototype),
+          i = r.call(n, t, e);
+        return c.convert(i, this.__proto__);
+      }, c.prototype.thenExternal = function (t, e) {
+        return Promise.prototype.then.call(this, t, e);
+      }, c.prototype.thenList = function (t) {
+        var e = this;
+        return t.forEach(function (t) {
+          e = e.thenCore(t);
+        }), e;
+      }, c.prototype.catch = function (t) {
+        t && (t = t.bind(this));
+        var e = Promise.prototype.catch.call(this, t);
+        return c.convert(e, this);
+      }, c.prototype.catchExternal = function (t) {
+        return Promise.prototype.catch.call(this, t);
+      }, c.prototype.error = function (t) {
+        return this.then(function () {
+          throw new Error(t);
+        });
+      }, c.prototype.using = c.prototype.set, c.prototype.saveAs = c.prototype.save, c.prototype.export = c.prototype.output, c.prototype.run = c.prototype.then, M.getPageSize = function (t, r, n) {
+        if ("object" === e(t)) {
+          var i = t;
+          t = i.orientation, r = i.unit || r, n = i.format || n;
+        }
+        r = r || "mm", n = n || "a4", t = ("" + (t || "P")).toLowerCase();
+        var a,
+          o = ("" + n).toLowerCase(),
+          s = {
+            a0: [2383.94, 3370.39],
+            a1: [1683.78, 2383.94],
+            a2: [1190.55, 1683.78],
+            a3: [841.89, 1190.55],
+            a4: [595.28, 841.89],
+            a5: [419.53, 595.28],
+            a6: [297.64, 419.53],
+            a7: [209.76, 297.64],
+            a8: [147.4, 209.76],
+            a9: [104.88, 147.4],
+            a10: [73.7, 104.88],
+            b0: [2834.65, 4008.19],
+            b1: [2004.09, 2834.65],
+            b2: [1417.32, 2004.09],
+            b3: [1000.63, 1417.32],
+            b4: [708.66, 1000.63],
+            b5: [498.9, 708.66],
+            b6: [354.33, 498.9],
+            b7: [249.45, 354.33],
+            b8: [175.75, 249.45],
+            b9: [124.72, 175.75],
+            b10: [87.87, 124.72],
+            c0: [2599.37, 3676.54],
+            c1: [1836.85, 2599.37],
+            c2: [1298.27, 1836.85],
+            c3: [918.43, 1298.27],
+            c4: [649.13, 918.43],
+            c5: [459.21, 649.13],
+            c6: [323.15, 459.21],
+            c7: [229.61, 323.15],
+            c8: [161.57, 229.61],
+            c9: [113.39, 161.57],
+            c10: [79.37, 113.39],
+            dl: [311.81, 623.62],
+            letter: [612, 792],
+            "government-letter": [576, 756],
+            legal: [612, 1008],
+            "junior-legal": [576, 360],
+            ledger: [1224, 792],
+            tabloid: [792, 1224],
+            "credit-card": [153, 243]
+          };
+        switch (r) {
+          case "pt":
+            a = 1;
+            break;
+          case "mm":
+            a = 72 / 25.4;
+            break;
+          case "cm":
+            a = 72 / 2.54;
+            break;
+          case "in":
+            a = 72;
+            break;
+          case "px":
+            a = .75;
+            break;
+          case "pc":
+          case "em":
+            a = 12;
+            break;
+          case "ex":
+            a = 6;
+            break;
+          default:
+            throw "Invalid unit: " + r;
+        }
+        var c,
+          u = 0,
+          l = 0;
+        if (s.hasOwnProperty(o)) u = s[o][1] / a, l = s[o][0] / a;else try {
+          u = n[1], l = n[0];
+        } catch (t) {
+          throw new Error("Invalid format: " + n);
+        }
+        if ("p" === t || "portrait" === t) t = "p", l > u && (c = l, l = u, u = c);else {
+          if ("l" !== t && "landscape" !== t) throw "Invalid orientation: " + t;
+          t = "l", u > l && (c = l, l = u, u = c);
+        }
+        return {
+          width: l,
+          height: u,
+          unit: r,
+          k: a,
+          orientation: t
+        };
+      }, n.html = function (t, e) {
+        (e = e || {}).callback = e.callback || function () {}, e.html2canvas = e.html2canvas || {}, e.html2canvas.canvas = e.html2canvas.canvas || this.canvas, e.jsPDF = e.jsPDF || this, e.fontFaces = e.fontFaces ? e.fontFaces.map(Ct) : null;
+        var r = new c(e);
+        return e.worker ? r : r.from(t).doCallback();
+      };
+    }(M.API),
+    /**
+       * @license
+       * ====================================================================
+       * Copyright (c) 2013 Youssef Beddad, youssef.beddad@gmail.com
+       *
+       * Permission is hereby granted, free of charge, to any person obtaining
+       * a copy of this software and associated documentation files (the
+       * "Software"), to deal in the Software without restriction, including
+       * without limitation the rights to use, copy, modify, merge, publish,
+       * distribute, sublicense, and/or sell copies of the Software, and to
+       * permit persons to whom the Software is furnished to do so, subject to
+       * the following conditions:
+       *
+       * The above copyright notice and this permission notice shall be
+       * included in all copies or substantial portions of the Software.
+       *
+       * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+       * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+       * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+       * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+       * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+       * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+       * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+       * ====================================================================
+       */
+    function (t) {
+      var e, r, n;
+      t.addJS = function (t) {
+        return n = t, this.internal.events.subscribe("postPutResources", function () {
+          e = this.internal.newObject(), this.internal.out("<<"), this.internal.out("/Names [(EmbeddedJS) " + (e + 1) + " 0 R]"), this.internal.out(">>"), this.internal.out("endobj"), r = this.internal.newObject(), this.internal.out("<<"), this.internal.out("/S /JavaScript"), this.internal.out("/JS (" + n + ")"), this.internal.out(">>"), this.internal.out("endobj");
+        }), this.internal.events.subscribe("putCatalog", function () {
+          void 0 !== e && void 0 !== r && this.internal.out("/Names <</JavaScript " + e + " 0 R>>");
+        }), this;
+      };
+    }(M.API),
+    /**
+       * @license
+       * Copyright (c) 2014 Steven Spungin (TwelveTone LLC)  steven@twelvetone.tv
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      var e;
+      t.events.push(["postPutResources", function () {
+        var t = this,
+          r = /^(\d+) 0 obj$/;
+        if (this.outline.root.children.length > 0) for (var n = t.outline.render().split(/\r\n/), i = 0; i < n.length; i++) {
+          var a = n[i],
+            o = r.exec(a);
+          if (null != o) {
+            var s = o[1];
+            t.internal.newObjectDeferredBegin(s, !1);
+          }
+          t.internal.write(a);
+        }
+        if (this.outline.createNamedDestinations) {
+          var c = this.internal.pages.length,
+            u = [];
+          for (i = 0; i < c; i++) {
+            var l = t.internal.newObject();
+            u.push(l);
+            var h = t.internal.getPageInfo(i + 1);
+            t.internal.write("<< /D[" + h.objId + " 0 R /XYZ null null null]>> endobj");
+          }
+          var f = t.internal.newObject();
+          t.internal.write("<< /Names [ ");
+          for (i = 0; i < u.length; i++) t.internal.write("(page_" + (i + 1) + ")" + u[i] + " 0 R");
+          t.internal.write(" ] >>", "endobj"), e = t.internal.newObject(), t.internal.write("<< /Dests " + f + " 0 R"), t.internal.write(">>", "endobj");
+        }
+      }]), t.events.push(["putCatalog", function () {
+        this.outline.root.children.length > 0 && (this.internal.write("/Outlines", this.outline.makeRef(this.outline.root)), this.outline.createNamedDestinations && this.internal.write("/Names " + e + " 0 R"));
+      }]), t.events.push(["initialized", function () {
+        var t = this;
+        t.outline = {
+          createNamedDestinations: !1,
+          root: {
+            children: []
+          }
+        }, t.outline.add = function (t, e, r) {
+          var n = {
+            title: e,
+            options: r,
+            children: []
+          };
+          return null == t && (t = this.root), t.children.push(n), n;
+        }, t.outline.render = function () {
+          return this.ctx = {}, this.ctx.val = "", this.ctx.pdf = t, this.genIds_r(this.root), this.renderRoot(this.root), this.renderItems(this.root), this.ctx.val;
+        }, t.outline.genIds_r = function (e) {
+          e.id = t.internal.newObjectDeferred();
+          for (var r = 0; r < e.children.length; r++) this.genIds_r(e.children[r]);
+        }, t.outline.renderRoot = function (t) {
+          this.objStart(t), this.line("/Type /Outlines"), t.children.length > 0 && (this.line("/First " + this.makeRef(t.children[0])), this.line("/Last " + this.makeRef(t.children[t.children.length - 1]))), this.line("/Count " + this.count_r({
+            count: 0
+          }, t)), this.objEnd();
+        }, t.outline.renderItems = function (e) {
+          for (var r = this.ctx.pdf.internal.getVerticalCoordinateString, n = 0; n < e.children.length; n++) {
+            var i = e.children[n];
+            this.objStart(i), this.line("/Title " + this.makeString(i.title)), this.line("/Parent " + this.makeRef(e)), n > 0 && this.line("/Prev " + this.makeRef(e.children[n - 1])), n < e.children.length - 1 && this.line("/Next " + this.makeRef(e.children[n + 1])), i.children.length > 0 && (this.line("/First " + this.makeRef(i.children[0])), this.line("/Last " + this.makeRef(i.children[i.children.length - 1])));
+            var a = this.count = this.count_r({
+              count: 0
+            }, i);
+            if (a > 0 && this.line("/Count " + a), i.options && i.options.pageNumber) {
+              var o = t.internal.getPageInfo(i.options.pageNumber);
+              this.line("/Dest [" + o.objId + " 0 R /XYZ 0 " + r(0) + " 0]");
+            }
+            this.objEnd();
+          }
+          for (var s = 0; s < e.children.length; s++) this.renderItems(e.children[s]);
+        }, t.outline.line = function (t) {
+          this.ctx.val += t + "\r\n";
+        }, t.outline.makeRef = function (t) {
+          return t.id + " 0 R";
+        }, t.outline.makeString = function (e) {
+          return "(" + t.internal.pdfEscape(e) + ")";
+        }, t.outline.objStart = function (t) {
+          this.ctx.val += "\r\n" + t.id + " 0 obj\r\n<<\r\n";
+        }, t.outline.objEnd = function () {
+          this.ctx.val += ">> \r\nendobj\r\n";
+        }, t.outline.count_r = function (t, e) {
+          for (var r = 0; r < e.children.length; r++) t.count++, this.count_r(t, e.children[r]);
+          return t.count;
+        };
+      }]);
+    }(M.API),
+    /**
+       * @license
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      var e = [192, 193, 194, 195, 196, 197, 198, 199];
+      t.processJPEG = function (t, r, n, i, a, o) {
+        var s,
+          c = this.decode.DCT_DECODE,
+          u = null;
+        if ("string" == typeof t || this.__addimage__.isArrayBuffer(t) || this.__addimage__.isArrayBufferView(t)) {
+          switch (t = a || t, t = this.__addimage__.isArrayBuffer(t) ? new Uint8Array(t) : t, (s = function (t) {
+            for (var r, n = 256 * t.charCodeAt(4) + t.charCodeAt(5), i = t.length, a = {
+                width: 0,
+                height: 0,
+                numcomponents: 1
+              }, o = 4; o < i; o += 2) {
+              if (o += n, -1 !== e.indexOf(t.charCodeAt(o + 1))) {
+                r = 256 * t.charCodeAt(o + 5) + t.charCodeAt(o + 6), a = {
+                  width: 256 * t.charCodeAt(o + 7) + t.charCodeAt(o + 8),
+                  height: r,
+                  numcomponents: t.charCodeAt(o + 9)
+                };
+                break;
+              }
+              n = 256 * t.charCodeAt(o + 2) + t.charCodeAt(o + 3);
+            }
+            return a;
+          }(t = this.__addimage__.isArrayBufferView(t) ? this.__addimage__.arrayBufferToBinaryString(t) : t)).numcomponents) {
+            case 1:
+              o = this.color_spaces.DEVICE_GRAY;
+              break;
+            case 4:
+              o = this.color_spaces.DEVICE_CMYK;
+              break;
+            case 3:
+              o = this.color_spaces.DEVICE_RGB;
+          }
+          u = {
+            data: t,
+            width: s.width,
+            height: s.height,
+            colorSpace: o,
+            bitsPerComponent: 8,
+            filter: c,
+            index: r,
+            alias: n
+          };
+        }
+        return u;
+      };
+    }(M.API);
+    var Oe,
+      Be,
+      Me,
+      Ee,
+      qe,
+      De = function () {
+        var t, e, n;
+        function i(t) {
+          var e, r, n, i, a, o, s, c, u, l, h, f, d, p;
+          for (this.data = t, this.pos = 8, this.palette = [], this.imgData = [], this.transparency = {}, this.animation = null, this.text = {}, o = null;;) {
+            switch (e = this.readUInt32(), u = function () {
+              var t, e;
+              for (e = [], t = 0; t < 4; ++t) e.push(String.fromCharCode(this.data[this.pos++]));
+              return e;
+            }.call(this).join("")) {
+              case "IHDR":
+                this.width = this.readUInt32(), this.height = this.readUInt32(), this.bits = this.data[this.pos++], this.colorType = this.data[this.pos++], this.compressionMethod = this.data[this.pos++], this.filterMethod = this.data[this.pos++], this.interlaceMethod = this.data[this.pos++];
+                break;
+              case "acTL":
+                this.animation = {
+                  numFrames: this.readUInt32(),
+                  numPlays: this.readUInt32() || 1 / 0,
+                  frames: []
+                };
+                break;
+              case "PLTE":
+                this.palette = this.read(e);
+                break;
+              case "fcTL":
+                o && this.animation.frames.push(o), this.pos += 4, o = {
+                  width: this.readUInt32(),
+                  height: this.readUInt32(),
+                  xOffset: this.readUInt32(),
+                  yOffset: this.readUInt32()
+                }, a = this.readUInt16(), i = this.readUInt16() || 100, o.delay = 1e3 * a / i, o.disposeOp = this.data[this.pos++], o.blendOp = this.data[this.pos++], o.data = [];
+                break;
+              case "IDAT":
+              case "fdAT":
+                for ("fdAT" === u && (this.pos += 4, e -= 4), t = (null != o ? o.data : void 0) || this.imgData, f = 0; 0 <= e ? f < e : f > e; 0 <= e ? ++f : --f) t.push(this.data[this.pos++]);
+                break;
+              case "tRNS":
+                switch (this.transparency = {}, this.colorType) {
+                  case 3:
+                    if (n = this.palette.length / 3, this.transparency.indexed = this.read(e), this.transparency.indexed.length > n) throw new Error("More transparent colors than palette size");
+                    if ((l = n - this.transparency.indexed.length) > 0) for (d = 0; 0 <= l ? d < l : d > l; 0 <= l ? ++d : --d) this.transparency.indexed.push(255);
+                    break;
+                  case 0:
+                    this.transparency.grayscale = this.read(e)[0];
+                    break;
+                  case 2:
+                    this.transparency.rgb = this.read(e);
+                }
+                break;
+              case "tEXt":
+                s = (h = this.read(e)).indexOf(0), c = String.fromCharCode.apply(String, h.slice(0, s)), this.text[c] = String.fromCharCode.apply(String, h.slice(s + 1));
+                break;
+              case "IEND":
+                return o && this.animation.frames.push(o), this.colors = function () {
+                  switch (this.colorType) {
+                    case 0:
+                    case 3:
+                    case 4:
+                      return 1;
+                    case 2:
+                    case 6:
+                      return 3;
+                  }
+                }.call(this), this.hasAlphaChannel = 4 === (p = this.colorType) || 6 === p, r = this.colors + (this.hasAlphaChannel ? 1 : 0), this.pixelBitlength = this.bits * r, this.colorSpace = function () {
+                  switch (this.colors) {
+                    case 1:
+                      return "DeviceGray";
+                    case 3:
+                      return "DeviceRGB";
+                  }
+                }.call(this), void (this.imgData = new Uint8Array(this.imgData));
+              default:
+                this.pos += e;
+            }
+            if (this.pos += 4, this.pos > this.data.length) throw new Error("Incomplete or corrupt PNG file");
+          }
+        }
+        i.prototype.read = function (t) {
+          var e, r;
+          for (r = [], e = 0; 0 <= t ? e < t : e > t; 0 <= t ? ++e : --e) r.push(this.data[this.pos++]);
+          return r;
+        }, i.prototype.readUInt32 = function () {
+          return this.data[this.pos++] << 24 | this.data[this.pos++] << 16 | this.data[this.pos++] << 8 | this.data[this.pos++];
+        }, i.prototype.readUInt16 = function () {
+          return this.data[this.pos++] << 8 | this.data[this.pos++];
+        }, i.prototype.decodePixels = function (t) {
+          var e = this.pixelBitlength / 8,
+            r = new Uint8Array(this.width * this.height * e),
+            n = 0,
+            i = this;
+          if (null == t && (t = this.imgData), 0 === t.length) return new Uint8Array(0);
+          function a(a, o, s, c) {
+            var u,
+              l,
+              h,
+              f,
+              d,
+              p,
+              g,
+              m,
+              v,
+              b,
+              y,
+              w,
+              N,
+              L,
+              A,
+              x,
+              S,
+              _,
+              P,
+              k,
+              F,
+              I = Math.ceil((i.width - a) / s),
+              C = Math.ceil((i.height - o) / c),
+              j = i.width == I && i.height == C;
+            for (L = e * I, w = j ? r : new Uint8Array(L * C), p = t.length, N = 0, l = 0; N < C && n < p;) {
+              switch (t[n++]) {
+                case 0:
+                  for (f = S = 0; S < L; f = S += 1) w[l++] = t[n++];
+                  break;
+                case 1:
+                  for (f = _ = 0; _ < L; f = _ += 1) u = t[n++], d = f < e ? 0 : w[l - e], w[l++] = (u + d) % 256;
+                  break;
+                case 2:
+                  for (f = P = 0; P < L; f = P += 1) u = t[n++], h = (f - f % e) / e, A = N && w[(N - 1) * L + h * e + f % e], w[l++] = (A + u) % 256;
+                  break;
+                case 3:
+                  for (f = k = 0; k < L; f = k += 1) u = t[n++], h = (f - f % e) / e, d = f < e ? 0 : w[l - e], A = N && w[(N - 1) * L + h * e + f % e], w[l++] = (u + Math.floor((d + A) / 2)) % 256;
+                  break;
+                case 4:
+                  for (f = F = 0; F < L; f = F += 1) u = t[n++], h = (f - f % e) / e, d = f < e ? 0 : w[l - e], 0 === N ? A = x = 0 : (A = w[(N - 1) * L + h * e + f % e], x = h && w[(N - 1) * L + (h - 1) * e + f % e]), g = d + A - x, m = Math.abs(g - d), b = Math.abs(g - A), y = Math.abs(g - x), v = m <= b && m <= y ? d : b <= y ? A : x, w[l++] = (u + v) % 256;
+                  break;
+                default:
+                  throw new Error("Invalid filter algorithm: " + t[n - 1]);
+              }
+              if (!j) {
+                var O = ((o + N * c) * i.width + a) * e,
+                  B = N * L;
+                for (f = 0; f < I; f += 1) {
+                  for (var M = 0; M < e; M += 1) r[O++] = w[B++];
+                  O += (s - 1) * e;
+                }
+              }
+              N++;
+            }
+          }
+          return t = Ce(t), 1 == i.interlaceMethod ? (a(0, 0, 8, 8), a(4, 0, 8, 8), a(0, 4, 4, 8), a(2, 0, 4, 4), a(0, 2, 2, 4), a(1, 0, 2, 2), a(0, 1, 1, 2)) : a(0, 0, 1, 1), r;
+        }, i.prototype.decodePalette = function () {
+          var t, e, r, n, i, a, o, s, c;
+          for (r = this.palette, a = this.transparency.indexed || [], i = new Uint8Array((a.length || 0) + r.length), n = 0, t = 0, e = o = 0, s = r.length; o < s; e = o += 3) i[n++] = r[e], i[n++] = r[e + 1], i[n++] = r[e + 2], i[n++] = null != (c = a[t++]) ? c : 255;
+          return i;
+        }, i.prototype.copyToImageData = function (t, e) {
+          var r, n, i, a, o, s, c, u, l, h, f;
+          if (n = this.colors, l = null, r = this.hasAlphaChannel, this.palette.length && (l = null != (f = this._decodedPalette) ? f : this._decodedPalette = this.decodePalette(), n = 4, r = !0), u = (i = t.data || t).length, o = l || e, a = s = 0, 1 === n) for (; a < u;) c = l ? 4 * e[a / 4] : s, h = o[c++], i[a++] = h, i[a++] = h, i[a++] = h, i[a++] = r ? o[c++] : 255, s = c;else for (; a < u;) c = l ? 4 * e[a / 4] : s, i[a++] = o[c++], i[a++] = o[c++], i[a++] = o[c++], i[a++] = r ? o[c++] : 255, s = c;
+        }, i.prototype.decode = function () {
+          var t;
+          return t = new Uint8Array(this.width * this.height * 4), this.copyToImageData(t, this.decodePixels()), t;
+        };
+        var a = function a() {
+          if ("[object Window]" === Object.prototype.toString.call(r)) {
+            try {
+              e = r.document.createElement("canvas"), n = e.getContext("2d");
+            } catch (t) {
+              return !1;
+            }
+            return !0;
+          }
+          return !1;
+        };
+        return a(), t = function t(_t4) {
+          var r;
+          if (!0 === a()) return n.width = _t4.width, n.height = _t4.height, n.clearRect(0, 0, _t4.width, _t4.height), n.putImageData(_t4, 0, 0), (r = new Image()).src = e.toDataURL(), r;
+          throw new Error("This method requires a Browser with Canvas-capability.");
+        }, i.prototype.decodeFrames = function (e) {
+          var r, n, i, a, o, s, c, u;
+          if (this.animation) {
+            for (u = [], n = o = 0, s = (c = this.animation.frames).length; o < s; n = ++o) r = c[n], i = e.createImageData(r.width, r.height), a = this.decodePixels(new Uint8Array(r.data)), this.copyToImageData(i, a), r.imageData = i, u.push(r.image = t(i));
+            return u;
+          }
+        }, i.prototype.renderFrame = function (t, e) {
+          var r, n, i;
+          return r = (n = this.animation.frames)[e], i = n[e - 1], 0 === e && t.clearRect(0, 0, this.width, this.height), 1 === (null != i ? i.disposeOp : void 0) ? t.clearRect(i.xOffset, i.yOffset, i.width, i.height) : 2 === (null != i ? i.disposeOp : void 0) && t.putImageData(i.imageData, i.xOffset, i.yOffset), 0 === r.blendOp && t.clearRect(r.xOffset, r.yOffset, r.width, r.height), t.drawImage(r.image, r.xOffset, r.yOffset);
+        }, i.prototype.animate = function (t) {
+          var _e2,
+            r,
+            n,
+            i,
+            a,
+            o,
+            s = this;
+          return r = 0, o = this.animation, i = o.numFrames, n = o.frames, a = o.numPlays, (_e2 = function e() {
+            var o, c;
+            if (o = r++ % i, c = n[o], s.renderFrame(t, o), i > 1 && r / i < a) return s.animation._timeout = setTimeout(_e2, c.delay);
+          })();
+        }, i.prototype.stopAnimation = function () {
+          var t;
+          return clearTimeout(null != (t = this.animation) ? t._timeout : void 0);
+        }, i.prototype.render = function (t) {
+          var e, r;
+          return t._png && t._png.stopAnimation(), t._png = this, t.width = this.width, t.height = this.height, e = t.getContext("2d"), this.animation ? (this.decodeFrames(e), this.animate(e)) : (r = e.createImageData(this.width, this.height), this.copyToImageData(r, this.decodePixels()), e.putImageData(r, 0, 0));
+        }, i;
+      }();
+    /**
+       * @license
+       *
+       * Copyright (c) 2014 James Robb, https://github.com/jamesbrobb
+       *
+       * Permission is hereby granted, free of charge, to any person obtaining
+       * a copy of this software and associated documentation files (the
+       * "Software"), to deal in the Software without restriction, including
+       * without limitation the rights to use, copy, modify, merge, publish,
+       * distribute, sublicense, and/or sell copies of the Software, and to
+       * permit persons to whom the Software is furnished to do so, subject to
+       * the following conditions:
+       *
+       * The above copyright notice and this permission notice shall be
+       * included in all copies or substantial portions of the Software.
+       *
+       * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+       * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+       * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+       * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+       * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+       * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+       * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+       * ====================================================================
+       */
+    /**
+       * @license
+       * (c) Dean McNamee <dean@gmail.com>, 2013.
+       *
+       * https://github.com/deanm/omggif
+       *
+       * Permission is hereby granted, free of charge, to any person obtaining a copy
+       * of this software and associated documentation files (the "Software"), to
+       * deal in the Software without restriction, including without limitation the
+       * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+       * sell copies of the Software, and to permit persons to whom the Software is
+       * furnished to do so, subject to the following conditions:
+       *
+       * The above copyright notice and this permission notice shall be included in
+       * all copies or substantial portions of the Software.
+       *
+       * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+       * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+       * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+       * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+       * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+       * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+       * IN THE SOFTWARE.
+       *
+       * omggif is a JavaScript implementation of a GIF 89a encoder and decoder,
+       * including animation and compression.  It does not rely on any specific
+       * underlying system, so should run in the browser, Node, or Plask.
+       */
+    function Re(t) {
+      var e = 0;
+      if (71 !== t[e++] || 73 !== t[e++] || 70 !== t[e++] || 56 !== t[e++] || 56 != (t[e++] + 1 & 253) || 97 !== t[e++]) throw new Error("Invalid GIF 87a/89a header.");
+      var r = t[e++] | t[e++] << 8,
+        n = t[e++] | t[e++] << 8,
+        i = t[e++],
+        a = i >> 7,
+        o = 1 << (7 & i) + 1;
+      t[e++];
+      t[e++];
+      var s = null,
+        c = null;
+      a && (s = e, c = o, e += 3 * o);
+      var u = !0,
+        l = [],
+        h = 0,
+        f = null,
+        d = 0,
+        p = null;
+      for (this.width = r, this.height = n; u && e < t.length;) switch (t[e++]) {
+        case 33:
+          switch (t[e++]) {
+            case 255:
+              if (11 !== t[e] || 78 == t[e + 1] && 69 == t[e + 2] && 84 == t[e + 3] && 83 == t[e + 4] && 67 == t[e + 5] && 65 == t[e + 6] && 80 == t[e + 7] && 69 == t[e + 8] && 50 == t[e + 9] && 46 == t[e + 10] && 48 == t[e + 11] && 3 == t[e + 12] && 1 == t[e + 13] && 0 == t[e + 16]) e += 14, p = t[e++] | t[e++] << 8, e++;else for (e += 12;;) {
+                if (!((P = t[e++]) >= 0)) throw Error("Invalid block size");
+                if (0 === P) break;
+                e += P;
+              }
+              break;
+            case 249:
+              if (4 !== t[e++] || 0 !== t[e + 4]) throw new Error("Invalid graphics extension block.");
+              var g = t[e++];
+              h = t[e++] | t[e++] << 8, f = t[e++], 0 == (1 & g) && (f = null), d = g >> 2 & 7, e++;
+              break;
+            case 254:
+              for (;;) {
+                if (!((P = t[e++]) >= 0)) throw Error("Invalid block size");
+                if (0 === P) break;
+                e += P;
+              }
+              break;
+            default:
+              throw new Error("Unknown graphic control label: 0x" + t[e - 1].toString(16));
+          }
+          break;
+        case 44:
+          var m = t[e++] | t[e++] << 8,
+            v = t[e++] | t[e++] << 8,
+            b = t[e++] | t[e++] << 8,
+            y = t[e++] | t[e++] << 8,
+            w = t[e++],
+            N = w >> 6 & 1,
+            L = 1 << (7 & w) + 1,
+            A = s,
+            x = c,
+            S = !1;
+          if (w >> 7) {
+            S = !0;
+            A = e, x = L, e += 3 * L;
+          }
+          var _ = e;
+          for (e++;;) {
+            var P;
+            if (!((P = t[e++]) >= 0)) throw Error("Invalid block size");
+            if (0 === P) break;
+            e += P;
+          }
+          l.push({
+            x: m,
+            y: v,
+            width: b,
+            height: y,
+            has_local_palette: S,
+            palette_offset: A,
+            palette_size: x,
+            data_offset: _,
+            data_length: e - _,
+            transparent_index: f,
+            interlaced: !!N,
+            delay: h,
+            disposal: d
+          });
+          break;
+        case 59:
+          u = !1;
+          break;
+        default:
+          throw new Error("Unknown gif block: 0x" + t[e - 1].toString(16));
+      }
+      this.numFrames = function () {
+        return l.length;
+      }, this.loopCount = function () {
+        return p;
+      }, this.frameInfo = function (t) {
+        if (t < 0 || t >= l.length) throw new Error("Frame index out of range.");
+        return l[t];
+      }, this.decodeAndBlitFrameBGRA = function (e, n) {
+        var i = this.frameInfo(e),
+          a = i.width * i.height,
+          o = new Uint8Array(a);
+        Te(t, i.data_offset, o, a);
+        var s = i.palette_offset,
+          c = i.transparent_index;
+        null === c && (c = 256);
+        var u = i.width,
+          l = r - u,
+          h = u,
+          f = 4 * (i.y * r + i.x),
+          d = 4 * ((i.y + i.height) * r + i.x),
+          p = f,
+          g = 4 * l;
+        !0 === i.interlaced && (g += 4 * r * 7);
+        for (var m = 8, v = 0, b = o.length; v < b; ++v) {
+          var y = o[v];
+          if (0 === h && (h = u, (p += g) >= d && (g = 4 * l + 4 * r * (m - 1), p = f + (u + l) * (m << 1), m >>= 1)), y === c) p += 4;else {
+            var w = t[s + 3 * y],
+              N = t[s + 3 * y + 1],
+              L = t[s + 3 * y + 2];
+            n[p++] = L, n[p++] = N, n[p++] = w, n[p++] = 255;
+          }
+          --h;
+        }
+      }, this.decodeAndBlitFrameRGBA = function (e, n) {
+        var i = this.frameInfo(e),
+          a = i.width * i.height,
+          o = new Uint8Array(a);
+        Te(t, i.data_offset, o, a);
+        var s = i.palette_offset,
+          c = i.transparent_index;
+        null === c && (c = 256);
+        var u = i.width,
+          l = r - u,
+          h = u,
+          f = 4 * (i.y * r + i.x),
+          d = 4 * ((i.y + i.height) * r + i.x),
+          p = f,
+          g = 4 * l;
+        !0 === i.interlaced && (g += 4 * r * 7);
+        for (var m = 8, v = 0, b = o.length; v < b; ++v) {
+          var y = o[v];
+          if (0 === h && (h = u, (p += g) >= d && (g = 4 * l + 4 * r * (m - 1), p = f + (u + l) * (m << 1), m >>= 1)), y === c) p += 4;else {
+            var w = t[s + 3 * y],
+              N = t[s + 3 * y + 1],
+              L = t[s + 3 * y + 2];
+            n[p++] = w, n[p++] = N, n[p++] = L, n[p++] = 255;
+          }
+          --h;
+        }
+      };
+    }
+    function Te(t, e, r, n) {
+      for (var a = t[e++], o = 1 << a, s = o + 1, c = s + 1, u = a + 1, l = (1 << u) - 1, h = 0, f = 0, d = 0, p = t[e++], g = new Int32Array(4096), m = null;;) {
+        for (; h < 16 && 0 !== p;) f |= t[e++] << h, h += 8, 1 === p ? p = t[e++] : --p;
+        if (h < u) break;
+        var v = f & l;
+        if (f >>= u, h -= u, v !== o) {
+          if (v === s) break;
+          for (var b = v < c ? v : m, y = 0, w = b; w > o;) w = g[w] >> 8, ++y;
+          var N = w;
+          if (d + y + (b !== v ? 1 : 0) > n) return void i.log("Warning, gif stream longer than expected.");
+          r[d++] = N;
+          var L = d += y;
+          for (b !== v && (r[d++] = N), w = b; y--;) w = g[w], r[--L] = 255 & w, w >>= 8;
+          null !== m && c < 4096 && (g[c++] = m << 8 | N, c >= l + 1 && u < 12 && (++u, l = l << 1 | 1)), m = v;
+        } else c = s + 1, l = (1 << (u = a + 1)) - 1, m = null;
+      }
+      return d !== n && i.log("Warning, gif stream shorter than expected."), r;
+    }
+    /**
+       * @license
+        Copyright (c) 2008, Adobe Systems Incorporated
+        All rights reserved.
+    
+        Redistribution and use in source and binary forms, with or without 
+        modification, are permitted provided that the following conditions are
+        met:
+    
+        * Redistributions of source code must retain the above copyright notice, 
+          this list of conditions and the following disclaimer.
+        
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the 
+          documentation and/or other materials provided with the distribution.
+        
+        * Neither the name of Adobe Systems Incorporated nor the names of its 
+          contributors may be used to endorse or promote products derived from 
+          this software without specific prior written permission.
+    
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+        IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+        THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+        CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+        EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+        PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+        PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+        LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+        NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      */
+    function Ue(t) {
+      var e,
+        r,
+        n,
+        i,
+        a,
+        o = Math.floor,
+        s = new Array(64),
+        c = new Array(64),
+        u = new Array(64),
+        l = new Array(64),
+        h = new Array(65535),
+        f = new Array(65535),
+        d = new Array(64),
+        p = new Array(64),
+        g = [],
+        m = 0,
+        v = 7,
+        b = new Array(64),
+        y = new Array(64),
+        w = new Array(64),
+        N = new Array(256),
+        L = new Array(2048),
+        A = [0, 1, 5, 6, 14, 15, 27, 28, 2, 4, 7, 13, 16, 26, 29, 42, 3, 8, 12, 17, 25, 30, 41, 43, 9, 11, 18, 24, 31, 40, 44, 53, 10, 19, 23, 32, 39, 45, 52, 54, 20, 22, 33, 38, 46, 51, 55, 60, 21, 34, 37, 47, 50, 56, 59, 61, 35, 36, 48, 49, 57, 58, 62, 63],
+        x = [0, 0, 1, 5, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+        S = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        _ = [0, 0, 2, 1, 3, 3, 2, 4, 3, 5, 5, 4, 4, 0, 0, 1, 125],
+        P = [1, 2, 3, 0, 4, 17, 5, 18, 33, 49, 65, 6, 19, 81, 97, 7, 34, 113, 20, 50, 129, 145, 161, 8, 35, 66, 177, 193, 21, 82, 209, 240, 36, 51, 98, 114, 130, 9, 10, 22, 23, 24, 25, 26, 37, 38, 39, 40, 41, 42, 52, 53, 54, 55, 56, 57, 58, 67, 68, 69, 70, 71, 72, 73, 74, 83, 84, 85, 86, 87, 88, 89, 90, 99, 100, 101, 102, 103, 104, 105, 106, 115, 116, 117, 118, 119, 120, 121, 122, 131, 132, 133, 134, 135, 136, 137, 138, 146, 147, 148, 149, 150, 151, 152, 153, 154, 162, 163, 164, 165, 166, 167, 168, 169, 170, 178, 179, 180, 181, 182, 183, 184, 185, 186, 194, 195, 196, 197, 198, 199, 200, 201, 202, 210, 211, 212, 213, 214, 215, 216, 217, 218, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250],
+        k = [0, 0, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+        F = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        I = [0, 0, 2, 1, 2, 4, 4, 3, 4, 7, 5, 4, 4, 0, 1, 2, 119],
+        C = [0, 1, 2, 3, 17, 4, 5, 33, 49, 6, 18, 65, 81, 7, 97, 113, 19, 34, 50, 129, 8, 20, 66, 145, 161, 177, 193, 9, 35, 51, 82, 240, 21, 98, 114, 209, 10, 22, 36, 52, 225, 37, 241, 23, 24, 25, 26, 38, 39, 40, 41, 42, 53, 54, 55, 56, 57, 58, 67, 68, 69, 70, 71, 72, 73, 74, 83, 84, 85, 86, 87, 88, 89, 90, 99, 100, 101, 102, 103, 104, 105, 106, 115, 116, 117, 118, 119, 120, 121, 122, 130, 131, 132, 133, 134, 135, 136, 137, 138, 146, 147, 148, 149, 150, 151, 152, 153, 154, 162, 163, 164, 165, 166, 167, 168, 169, 170, 178, 179, 180, 181, 182, 183, 184, 185, 186, 194, 195, 196, 197, 198, 199, 200, 201, 202, 210, 211, 212, 213, 214, 215, 216, 217, 218, 226, 227, 228, 229, 230, 231, 232, 233, 234, 242, 243, 244, 245, 246, 247, 248, 249, 250];
+      function j(t, e) {
+        for (var r = 0, n = 0, i = new Array(), a = 1; a <= 16; a++) {
+          for (var o = 1; o <= t[a]; o++) i[e[n]] = [], i[e[n]][0] = r, i[e[n]][1] = a, n++, r++;
+          r *= 2;
+        }
+        return i;
+      }
+      function O(t) {
+        for (var e = t[0], r = t[1] - 1; r >= 0;) e & 1 << r && (m |= 1 << v), r--, --v < 0 && (255 == m ? (B(255), B(0)) : B(m), v = 7, m = 0);
+      }
+      function B(t) {
+        g.push(t);
+      }
+      function M(t) {
+        B(t >> 8 & 255), B(255 & t);
+      }
+      function E(t, e, r, n, i) {
+        for (var a, o = i[0], s = i[240], c = function (t, e) {
+            var r,
+              n,
+              i,
+              a,
+              o,
+              s,
+              c,
+              u,
+              l,
+              h,
+              f = 0;
+            for (l = 0; l < 8; ++l) {
+              r = t[f], n = t[f + 1], i = t[f + 2], a = t[f + 3], o = t[f + 4], s = t[f + 5], c = t[f + 6];
+              var p = r + (u = t[f + 7]),
+                g = r - u,
+                m = n + c,
+                v = n - c,
+                b = i + s,
+                y = i - s,
+                w = a + o,
+                N = a - o,
+                L = p + w,
+                A = p - w,
+                x = m + b,
+                S = m - b;
+              t[f] = L + x, t[f + 4] = L - x;
+              var _ = .707106781 * (S + A);
+              t[f + 2] = A + _, t[f + 6] = A - _;
+              var P = .382683433 * ((L = N + y) - (S = v + g)),
+                k = .5411961 * L + P,
+                F = 1.306562965 * S + P,
+                I = .707106781 * (x = y + v),
+                C = g + I,
+                j = g - I;
+              t[f + 5] = j + k, t[f + 3] = j - k, t[f + 1] = C + F, t[f + 7] = C - F, f += 8;
+            }
+            for (f = 0, l = 0; l < 8; ++l) {
+              r = t[f], n = t[f + 8], i = t[f + 16], a = t[f + 24], o = t[f + 32], s = t[f + 40], c = t[f + 48];
+              var O = r + (u = t[f + 56]),
+                B = r - u,
+                M = n + c,
+                E = n - c,
+                q = i + s,
+                D = i - s,
+                R = a + o,
+                T = a - o,
+                U = O + R,
+                z = O - R,
+                H = M + q,
+                W = M - q;
+              t[f] = U + H, t[f + 32] = U - H;
+              var V = .707106781 * (W + z);
+              t[f + 16] = z + V, t[f + 48] = z - V;
+              var G = .382683433 * ((U = T + D) - (W = E + B)),
+                Y = .5411961 * U + G,
+                J = 1.306562965 * W + G,
+                X = .707106781 * (H = D + E),
+                K = B + X,
+                Z = B - X;
+              t[f + 40] = Z + Y, t[f + 24] = Z - Y, t[f + 8] = K + J, t[f + 56] = K - J, f++;
+            }
+            for (l = 0; l < 64; ++l) h = t[l] * e[l], d[l] = h > 0 ? h + .5 | 0 : h - .5 | 0;
+            return d;
+          }(t, e), u = 0; u < 64; ++u) p[A[u]] = c[u];
+        var l = p[0] - r;
+        r = p[0], 0 == l ? O(n[0]) : (O(n[f[a = 32767 + l]]), O(h[a]));
+        for (var g = 63; g > 0 && 0 == p[g];) g--;
+        if (0 == g) return O(o), r;
+        for (var m, v = 1; v <= g;) {
+          for (var b = v; 0 == p[v] && v <= g;) ++v;
+          var y = v - b;
+          if (y >= 16) {
+            m = y >> 4;
+            for (var w = 1; w <= m; ++w) O(s);
+            y &= 15;
+          }
+          a = 32767 + p[v], O(i[(y << 4) + f[a]]), O(h[a]), v++;
+        }
+        return 63 != g && O(o), r;
+      }
+      function q(t) {
+        (t = Math.min(Math.max(t, 1), 100), a != t) && (!function (t) {
+          for (var e = [16, 11, 10, 16, 24, 40, 51, 61, 12, 12, 14, 19, 26, 58, 60, 55, 14, 13, 16, 24, 40, 57, 69, 56, 14, 17, 22, 29, 51, 87, 80, 62, 18, 22, 37, 56, 68, 109, 103, 77, 24, 35, 55, 64, 81, 104, 113, 92, 49, 64, 78, 87, 103, 121, 120, 101, 72, 92, 95, 98, 112, 100, 103, 99], r = 0; r < 64; r++) {
+            var n = o((e[r] * t + 50) / 100);
+            n = Math.min(Math.max(n, 1), 255), s[A[r]] = n;
+          }
+          for (var i = [17, 18, 24, 47, 99, 99, 99, 99, 18, 21, 26, 66, 99, 99, 99, 99, 24, 26, 56, 99, 99, 99, 99, 99, 47, 66, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99], a = 0; a < 64; a++) {
+            var h = o((i[a] * t + 50) / 100);
+            h = Math.min(Math.max(h, 1), 255), c[A[a]] = h;
+          }
+          for (var f = [1, 1.387039845, 1.306562965, 1.175875602, 1, .785694958, .5411961, .275899379], d = 0, p = 0; p < 8; p++) for (var g = 0; g < 8; g++) u[d] = 1 / (s[A[d]] * f[p] * f[g] * 8), l[d] = 1 / (c[A[d]] * f[p] * f[g] * 8), d++;
+        }(t < 50 ? Math.floor(5e3 / t) : Math.floor(200 - 2 * t)), a = t);
+      }
+      this.encode = function (t, a) {
+        a && q(a), g = new Array(), m = 0, v = 7, M(65496), M(65504), M(16), B(74), B(70), B(73), B(70), B(0), B(1), B(1), B(0), M(1), M(1), B(0), B(0), function () {
+          M(65499), M(132), B(0);
+          for (var t = 0; t < 64; t++) B(s[t]);
+          B(1);
+          for (var e = 0; e < 64; e++) B(c[e]);
+        }(), function (t, e) {
+          M(65472), M(17), B(8), M(e), M(t), B(3), B(1), B(17), B(0), B(2), B(17), B(1), B(3), B(17), B(1);
+        }(t.width, t.height), function () {
+          M(65476), M(418), B(0);
+          for (var t = 0; t < 16; t++) B(x[t + 1]);
+          for (var e = 0; e <= 11; e++) B(S[e]);
+          B(16);
+          for (var r = 0; r < 16; r++) B(_[r + 1]);
+          for (var n = 0; n <= 161; n++) B(P[n]);
+          B(1);
+          for (var i = 0; i < 16; i++) B(k[i + 1]);
+          for (var a = 0; a <= 11; a++) B(F[a]);
+          B(17);
+          for (var o = 0; o < 16; o++) B(I[o + 1]);
+          for (var s = 0; s <= 161; s++) B(C[s]);
+        }(), M(65498), M(12), B(3), B(1), B(0), B(2), B(17), B(3), B(17), B(0), B(63), B(0);
+        var o = 0,
+          h = 0,
+          f = 0;
+        m = 0, v = 7, this.encode.displayName = "_encode_";
+        for (var d, p, N, A, j, D, R, T, U, z = t.data, H = t.width, W = t.height, V = 4 * H, G = 0; G < W;) {
+          for (d = 0; d < V;) {
+            for (j = V * G + d, R = -1, T = 0, U = 0; U < 64; U++) D = j + (T = U >> 3) * V + (R = 4 * (7 & U)), G + T >= W && (D -= V * (G + 1 + T - W)), d + R >= V && (D -= d + R - V + 4), p = z[D++], N = z[D++], A = z[D++], b[U] = (L[p] + L[N + 256 >> 0] + L[A + 512 >> 0] >> 16) - 128, y[U] = (L[p + 768 >> 0] + L[N + 1024 >> 0] + L[A + 1280 >> 0] >> 16) - 128, w[U] = (L[p + 1280 >> 0] + L[N + 1536 >> 0] + L[A + 1792 >> 0] >> 16) - 128;
+            o = E(b, u, o, e, n), h = E(y, l, h, r, i), f = E(w, l, f, r, i), d += 32;
+          }
+          G += 8;
+        }
+        if (v >= 0) {
+          var Y = [];
+          Y[1] = v + 1, Y[0] = (1 << v + 1) - 1, O(Y);
+        }
+        return M(65497), new Uint8Array(g);
+      }, t = t || 50, function () {
+        for (var t = String.fromCharCode, e = 0; e < 256; e++) N[e] = t(e);
+      }(), e = j(x, S), r = j(k, F), n = j(_, P), i = j(I, C), function () {
+        for (var t = 1, e = 2, r = 1; r <= 15; r++) {
+          for (var n = t; n < e; n++) f[32767 + n] = r, h[32767 + n] = [], h[32767 + n][1] = r, h[32767 + n][0] = n;
+          for (var i = -(e - 1); i <= -t; i++) f[32767 + i] = r, h[32767 + i] = [], h[32767 + i][1] = r, h[32767 + i][0] = e - 1 + i;
+          t <<= 1, e <<= 1;
+        }
+      }(), function () {
+        for (var t = 0; t < 256; t++) L[t] = 19595 * t, L[t + 256 >> 0] = 38470 * t, L[t + 512 >> 0] = 7471 * t + 32768, L[t + 768 >> 0] = -11059 * t, L[t + 1024 >> 0] = -21709 * t, L[t + 1280 >> 0] = 32768 * t + 8421375, L[t + 1536 >> 0] = -27439 * t, L[t + 1792 >> 0] = -5329 * t;
+      }(), q(t);
+    }
+    /**
+       * @license
+       * Copyright (c) 2017 Aras Abbasi
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function ze(t, e) {
+      if (this.pos = 0, this.buffer = t, this.datav = new DataView(t.buffer), this.is_with_alpha = !!e, this.bottom_up = !0, this.flag = String.fromCharCode(this.buffer[0]) + String.fromCharCode(this.buffer[1]), this.pos += 2, -1 === ["BM", "BA", "CI", "CP", "IC", "PT"].indexOf(this.flag)) throw new Error("Invalid BMP File");
+      this.parseHeader(), this.parseBGR();
+    }
+    function He(t) {
+      function e(t) {
+        if (!t) throw Error("assert :P");
+      }
+      function r(t, e, r) {
+        for (var n = 0; 4 > n; n++) if (t[e + n] != r.charCodeAt(n)) return !0;
+        return !1;
+      }
+      function n(t, e, r, n, i) {
+        for (var a = 0; a < i; a++) t[e + a] = r[n + a];
+      }
+      function i(t, e, r, n) {
+        for (var i = 0; i < n; i++) t[e + i] = r;
+      }
+      function a(t) {
+        return new Int32Array(t);
+      }
+      function o(t, e) {
+        for (var r = [], n = 0; n < t; n++) r.push(new e());
+        return r;
+      }
+      function s(t, e) {
+        var r = [];
+        return function t(r, n, i) {
+          for (var a = i[n], o = 0; o < a && (r.push(i.length > n + 1 ? [] : new e()), !(i.length < n + 1)); o++) t(r[o], n + 1, i);
+        }(r, 0, t), r;
+      }
+      var c = function c() {
+        var t = this;
+        function c(t, e) {
+          for (var r = 1 << e - 1 >>> 0; t & r;) r >>>= 1;
+          return r ? (t & r - 1) + r : t;
+        }
+        function u(t, r, n, i, a) {
+          e(!(i % n));
+          do {
+            t[r + (i -= n)] = a;
+          } while (0 < i);
+        }
+        function l(t, r, n, i, o) {
+          if (e(2328 >= o), 512 >= o) var s = a(512);else if (null == (s = a(o))) return 0;
+          return function (t, r, n, i, o, s) {
+            var l,
+              f,
+              d = r,
+              p = 1 << n,
+              g = a(16),
+              m = a(16);
+            for (e(0 != o), e(null != i), e(null != t), e(0 < n), f = 0; f < o; ++f) {
+              if (15 < i[f]) return 0;
+              ++g[i[f]];
+            }
+            if (g[0] == o) return 0;
+            for (m[1] = 0, l = 1; 15 > l; ++l) {
+              if (g[l] > 1 << l) return 0;
+              m[l + 1] = m[l] + g[l];
+            }
+            for (f = 0; f < o; ++f) l = i[f], 0 < i[f] && (s[m[l]++] = f);
+            if (1 == m[15]) return (i = new h()).g = 0, i.value = s[0], u(t, d, 1, p, i), p;
+            var v,
+              b = -1,
+              y = p - 1,
+              w = 0,
+              N = 1,
+              L = 1,
+              A = 1 << n;
+            for (f = 0, l = 1, o = 2; l <= n; ++l, o <<= 1) {
+              if (N += L <<= 1, 0 > (L -= g[l])) return 0;
+              for (; 0 < g[l]; --g[l]) (i = new h()).g = l, i.value = s[f++], u(t, d + w, o, A, i), w = c(w, l);
+            }
+            for (l = n + 1, o = 2; 15 >= l; ++l, o <<= 1) {
+              if (N += L <<= 1, 0 > (L -= g[l])) return 0;
+              for (; 0 < g[l]; --g[l]) {
+                if (i = new h(), (w & y) != b) {
+                  for (d += A, v = 1 << (b = l) - n; 15 > b && !(0 >= (v -= g[b]));) ++b, v <<= 1;
+                  p += A = 1 << (v = b - n), t[r + (b = w & y)].g = v + n, t[r + b].value = d - r - b;
+                }
+                i.g = l - n, i.value = s[f++], u(t, d + (w >> n), o, A, i), w = c(w, l);
+              }
+            }
+            return N != 2 * m[15] - 1 ? 0 : p;
+          }(t, r, n, i, o, s);
+        }
+        function h() {
+          this.value = this.g = 0;
+        }
+        function f() {
+          this.value = this.g = 0;
+        }
+        function d() {
+          this.G = o(5, h), this.H = a(5), this.jc = this.Qb = this.qb = this.nd = 0, this.pd = o(Dr, f);
+        }
+        function p(t, r, n, i) {
+          e(null != t), e(null != r), e(2147483648 > i), t.Ca = 254, t.I = 0, t.b = -8, t.Ka = 0, t.oa = r, t.pa = n, t.Jd = r, t.Yc = n + i, t.Zc = 4 <= i ? n + i - 4 + 1 : n, _(t);
+        }
+        function g(t, e) {
+          for (var r = 0; 0 < e--;) r |= k(t, 128) << e;
+          return r;
+        }
+        function m(t, e) {
+          var r = g(t, e);
+          return P(t) ? -r : r;
+        }
+        function v(t, r, n, i) {
+          var a,
+            o = 0;
+          for (e(null != t), e(null != r), e(4294967288 > i), t.Sb = i, t.Ra = 0, t.u = 0, t.h = 0, 4 < i && (i = 4), a = 0; a < i; ++a) o += r[n + a] << 8 * a;
+          t.Ra = o, t.bb = i, t.oa = r, t.pa = n;
+        }
+        function b(t) {
+          for (; 8 <= t.u && t.bb < t.Sb;) t.Ra >>>= 8, t.Ra += t.oa[t.pa + t.bb] << Ur - 8 >>> 0, ++t.bb, t.u -= 8;
+          A(t) && (t.h = 1, t.u = 0);
+        }
+        function y(t, r) {
+          if (e(0 <= r), !t.h && r <= Tr) {
+            var n = L(t) & Rr[r];
+            return t.u += r, b(t), n;
+          }
+          return t.h = 1, t.u = 0;
+        }
+        function w() {
+          this.b = this.Ca = this.I = 0, this.oa = [], this.pa = 0, this.Jd = [], this.Yc = 0, this.Zc = [], this.Ka = 0;
+        }
+        function N() {
+          this.Ra = 0, this.oa = [], this.h = this.u = this.bb = this.Sb = this.pa = 0;
+        }
+        function L(t) {
+          return t.Ra >>> (t.u & Ur - 1) >>> 0;
+        }
+        function A(t) {
+          return e(t.bb <= t.Sb), t.h || t.bb == t.Sb && t.u > Ur;
+        }
+        function x(t, e) {
+          t.u = e, t.h = A(t);
+        }
+        function S(t) {
+          t.u >= zr && (e(t.u >= zr), b(t));
+        }
+        function _(t) {
+          e(null != t && null != t.oa), t.pa < t.Zc ? (t.I = (t.oa[t.pa++] | t.I << 8) >>> 0, t.b += 8) : (e(null != t && null != t.oa), t.pa < t.Yc ? (t.b += 8, t.I = t.oa[t.pa++] | t.I << 8) : t.Ka ? t.b = 0 : (t.I <<= 8, t.b += 8, t.Ka = 1));
+        }
+        function P(t) {
+          return g(t, 1);
+        }
+        function k(t, e) {
+          var r = t.Ca;
+          0 > t.b && _(t);
+          var n = t.b,
+            i = r * e >>> 8,
+            a = (t.I >>> n > i) + 0;
+          for (a ? (r -= i, t.I -= i + 1 << n >>> 0) : r = i + 1, n = r, i = 0; 256 <= n;) i += 8, n >>= 8;
+          return n = 7 ^ i + Hr[n], t.b -= n, t.Ca = (r << n) - 1, a;
+        }
+        function F(t, e, r) {
+          t[e + 0] = r >> 24 & 255, t[e + 1] = r >> 16 & 255, t[e + 2] = r >> 8 & 255, t[e + 3] = r >> 0 & 255;
+        }
+        function I(t, e) {
+          return t[e + 0] << 0 | t[e + 1] << 8;
+        }
+        function C(t, e) {
+          return I(t, e) | t[e + 2] << 16;
+        }
+        function j(t, e) {
+          return I(t, e) | I(t, e + 2) << 16;
+        }
+        function O(t, r) {
+          var n = 1 << r;
+          return e(null != t), e(0 < r), t.X = a(n), null == t.X ? 0 : (t.Mb = 32 - r, t.Xa = r, 1);
+        }
+        function B(t, r) {
+          e(null != t), e(null != r), e(t.Xa == r.Xa), n(r.X, 0, t.X, 0, 1 << r.Xa);
+        }
+        function M() {
+          this.X = [], this.Xa = this.Mb = 0;
+        }
+        function E(t, r, n, i) {
+          e(null != n), e(null != i);
+          var a = n[0],
+            o = i[0];
+          return 0 == a && (a = (t * o + r / 2) / r), 0 == o && (o = (r * a + t / 2) / t), 0 >= a || 0 >= o ? 0 : (n[0] = a, i[0] = o, 1);
+        }
+        function q(t, e) {
+          return t + (1 << e) - 1 >>> e;
+        }
+        function D(t, e) {
+          return ((4278255360 & t) + (4278255360 & e) >>> 0 & 4278255360) + ((16711935 & t) + (16711935 & e) >>> 0 & 16711935) >>> 0;
+        }
+        function R(e, r) {
+          t[r] = function (r, n, i, a, o, s, c) {
+            var u;
+            for (u = 0; u < o; ++u) {
+              var l = t[e](s[c + u - 1], i, a + u);
+              s[c + u] = D(r[n + u], l);
+            }
+          };
+        }
+        function T() {
+          this.ud = this.hd = this.jd = 0;
+        }
+        function U(t, e) {
+          return ((4278124286 & (t ^ e)) >>> 1) + (t & e) >>> 0;
+        }
+        function z(t) {
+          return 0 <= t && 256 > t ? t : 0 > t ? 0 : 255 < t ? 255 : void 0;
+        }
+        function H(t, e) {
+          return z(t + (t - e + .5 >> 1));
+        }
+        function W(t, e, r) {
+          return Math.abs(e - r) - Math.abs(t - r);
+        }
+        function V(t, e, r, n, i, a, o) {
+          for (n = a[o - 1], r = 0; r < i; ++r) a[o + r] = n = D(t[e + r], n);
+        }
+        function G(t, e, r, n, i) {
+          var a;
+          for (a = 0; a < r; ++a) {
+            var o = t[e + a],
+              s = o >> 8 & 255,
+              c = 16711935 & (c = (c = 16711935 & o) + ((s << 16) + s));
+            n[i + a] = (4278255360 & o) + c >>> 0;
+          }
+        }
+        function Y(t, e) {
+          e.jd = t >> 0 & 255, e.hd = t >> 8 & 255, e.ud = t >> 16 & 255;
+        }
+        function J(t, e, r, n, i, a) {
+          var o;
+          for (o = 0; o < n; ++o) {
+            var s = e[r + o],
+              c = s >>> 8,
+              u = s,
+              l = 255 & (l = (l = s >>> 16) + ((t.jd << 24 >> 24) * (c << 24 >> 24) >>> 5));
+            u = 255 & (u = (u = u + ((t.hd << 24 >> 24) * (c << 24 >> 24) >>> 5)) + ((t.ud << 24 >> 24) * (l << 24 >> 24) >>> 5));
+            i[a + o] = (4278255360 & s) + (l << 16) + u;
+          }
+        }
+        function X(e, r, n, i, a) {
+          t[r] = function (t, e, r, n, o, s, c, u, l) {
+            for (n = c; n < u; ++n) for (c = 0; c < l; ++c) o[s++] = a(r[i(t[e++])]);
+          }, t[e] = function (e, r, o, s, c, u, l) {
+            var h = 8 >> e.b,
+              f = e.Ea,
+              d = e.K[0],
+              p = e.w;
+            if (8 > h) for (e = (1 << e.b) - 1, p = (1 << h) - 1; r < o; ++r) {
+              var g,
+                m = 0;
+              for (g = 0; g < f; ++g) g & e || (m = i(s[c++])), u[l++] = a(d[m & p]), m >>= h;
+            } else t["VP8LMapColor" + n](s, c, d, p, u, l, r, o, f);
+          };
+        }
+        function K(t, e, r, n, i) {
+          for (r = e + r; e < r;) {
+            var a = t[e++];
+            n[i++] = a >> 16 & 255, n[i++] = a >> 8 & 255, n[i++] = a >> 0 & 255;
+          }
+        }
+        function Z(t, e, r, n, i) {
+          for (r = e + r; e < r;) {
+            var a = t[e++];
+            n[i++] = a >> 16 & 255, n[i++] = a >> 8 & 255, n[i++] = a >> 0 & 255, n[i++] = a >> 24 & 255;
+          }
+        }
+        function $(t, e, r, n, i) {
+          for (r = e + r; e < r;) {
+            var a = (o = t[e++]) >> 16 & 240 | o >> 12 & 15,
+              o = o >> 0 & 240 | o >> 28 & 15;
+            n[i++] = a, n[i++] = o;
+          }
+        }
+        function Q(t, e, r, n, i) {
+          for (r = e + r; e < r;) {
+            var a = (o = t[e++]) >> 16 & 248 | o >> 13 & 7,
+              o = o >> 5 & 224 | o >> 3 & 31;
+            n[i++] = a, n[i++] = o;
+          }
+        }
+        function tt(t, e, r, n, i) {
+          for (r = e + r; e < r;) {
+            var a = t[e++];
+            n[i++] = a >> 0 & 255, n[i++] = a >> 8 & 255, n[i++] = a >> 16 & 255;
+          }
+        }
+        function et(t, e, r, i, a, o) {
+          if (0 == o) for (r = e + r; e < r;) F(i, ((o = t[e++])[0] >> 24 | o[1] >> 8 & 65280 | o[2] << 8 & 16711680 | o[3] << 24) >>> 0), a += 32;else n(i, a, t, e, r);
+        }
+        function rt(e, r) {
+          t[r][0] = t[e + "0"], t[r][1] = t[e + "1"], t[r][2] = t[e + "2"], t[r][3] = t[e + "3"], t[r][4] = t[e + "4"], t[r][5] = t[e + "5"], t[r][6] = t[e + "6"], t[r][7] = t[e + "7"], t[r][8] = t[e + "8"], t[r][9] = t[e + "9"], t[r][10] = t[e + "10"], t[r][11] = t[e + "11"], t[r][12] = t[e + "12"], t[r][13] = t[e + "13"], t[r][14] = t[e + "0"], t[r][15] = t[e + "0"];
+        }
+        function nt(t) {
+          return t == Hn || t == Wn || t == Vn || t == Gn;
+        }
+        function it() {
+          this.eb = [], this.size = this.A = this.fb = 0;
+        }
+        function at() {
+          this.y = [], this.f = [], this.ea = [], this.F = [], this.Tc = this.Ed = this.Cd = this.Fd = this.lb = this.Db = this.Ab = this.fa = this.J = this.W = this.N = this.O = 0;
+        }
+        function ot() {
+          this.Rd = this.height = this.width = this.S = 0, this.f = {}, this.f.RGBA = new it(), this.f.kb = new at(), this.sd = null;
+        }
+        function st() {
+          this.width = [0], this.height = [0], this.Pd = [0], this.Qd = [0], this.format = [0];
+        }
+        function ct() {
+          this.Id = this.fd = this.Md = this.hb = this.ib = this.da = this.bd = this.cd = this.j = this.v = this.Da = this.Sd = this.ob = 0;
+        }
+        function ut(t) {
+          return alert("todo:WebPSamplerProcessPlane"), t.T;
+        }
+        function lt(t, e) {
+          var r = t.T,
+            i = e.ba.f.RGBA,
+            a = i.eb,
+            o = i.fb + t.ka * i.A,
+            s = vi[e.ba.S],
+            c = t.y,
+            u = t.O,
+            l = t.f,
+            h = t.N,
+            f = t.ea,
+            d = t.W,
+            p = e.cc,
+            g = e.dc,
+            m = e.Mc,
+            v = e.Nc,
+            b = t.ka,
+            y = t.ka + t.T,
+            w = t.U,
+            N = w + 1 >> 1;
+          for (0 == b ? s(c, u, null, null, l, h, f, d, l, h, f, d, a, o, null, null, w) : (s(e.ec, e.fc, c, u, p, g, m, v, l, h, f, d, a, o - i.A, a, o, w), ++r); b + 2 < y; b += 2) p = l, g = h, m = f, v = d, h += t.Rc, d += t.Rc, o += 2 * i.A, s(c, (u += 2 * t.fa) - t.fa, c, u, p, g, m, v, l, h, f, d, a, o - i.A, a, o, w);
+          return u += t.fa, t.j + y < t.o ? (n(e.ec, e.fc, c, u, w), n(e.cc, e.dc, l, h, N), n(e.Mc, e.Nc, f, d, N), r--) : 1 & y || s(c, u, null, null, l, h, f, d, l, h, f, d, a, o + i.A, null, null, w), r;
+        }
+        function ht(t, r, n) {
+          var i = t.F,
+            a = [t.J];
+          if (null != i) {
+            var o = t.U,
+              s = r.ba.S,
+              c = s == Tn || s == Vn;
+            r = r.ba.f.RGBA;
+            var u = [0],
+              l = t.ka;
+            u[0] = t.T, t.Kb && (0 == l ? --u[0] : (--l, a[0] -= t.width), t.j + t.ka + t.T == t.o && (u[0] = t.o - t.j - l));
+            var h = r.eb;
+            l = r.fb + l * r.A;
+            t = Sn(i, a[0], t.width, o, u, h, l + (c ? 0 : 3), r.A), e(n == u), t && nt(s) && An(h, l, c, o, u, r.A);
+          }
+          return 0;
+        }
+        function ft(t) {
+          var e = t.ma,
+            r = e.ba.S,
+            n = 11 > r,
+            i = r == qn || r == Rn || r == Tn || r == Un || 12 == r || nt(r);
+          if (e.memory = null, e.Ib = null, e.Jb = null, e.Nd = null, !Mr(e.Oa, t, i ? 11 : 12)) return 0;
+          if (i && nt(r) && br(), t.da) alert("todo:use_scaling");else {
+            if (n) {
+              if (e.Ib = ut, t.Kb) {
+                if (r = t.U + 1 >> 1, e.memory = a(t.U + 2 * r), null == e.memory) return 0;
+                e.ec = e.memory, e.fc = 0, e.cc = e.ec, e.dc = e.fc + t.U, e.Mc = e.cc, e.Nc = e.dc + r, e.Ib = lt, br();
+              }
+            } else alert("todo:EmitYUV");
+            i && (e.Jb = ht, n && mr());
+          }
+          if (n && !Ci) {
+            for (t = 0; 256 > t; ++t) ji[t] = 89858 * (t - 128) + _i >> Si, Mi[t] = -22014 * (t - 128) + _i, Bi[t] = -45773 * (t - 128), Oi[t] = 113618 * (t - 128) + _i >> Si;
+            for (t = Pi; t < ki; ++t) e = 76283 * (t - 16) + _i >> Si, Ei[t - Pi] = Vt(e, 255), qi[t - Pi] = Vt(e + 8 >> 4, 15);
+            Ci = 1;
+          }
+          return 1;
+        }
+        function dt(t) {
+          var r = t.ma,
+            n = t.U,
+            i = t.T;
+          return e(!(1 & t.ka)), 0 >= n || 0 >= i ? 0 : (n = r.Ib(t, r), null != r.Jb && r.Jb(t, r, n), r.Dc += n, 1);
+        }
+        function pt(t) {
+          t.ma.memory = null;
+        }
+        function gt(t, e, r, n) {
+          return 47 != y(t, 8) ? 0 : (e[0] = y(t, 14) + 1, r[0] = y(t, 14) + 1, n[0] = y(t, 1), 0 != y(t, 3) ? 0 : !t.h);
+        }
+        function mt(t, e) {
+          if (4 > t) return t + 1;
+          var r = t - 2 >> 1;
+          return (2 + (1 & t) << r) + y(e, r) + 1;
+        }
+        function vt(t, e) {
+          return 120 < e ? e - 120 : 1 <= (r = ((r = $n[e - 1]) >> 4) * t + (8 - (15 & r))) ? r : 1;
+          var r;
+        }
+        function bt(t, e, r) {
+          var n = L(r),
+            i = t[e += 255 & n].g - 8;
+          return 0 < i && (x(r, r.u + 8), n = L(r), e += t[e].value, e += n & (1 << i) - 1), x(r, r.u + t[e].g), t[e].value;
+        }
+        function yt(t, r, n) {
+          return n.g += t.g, n.value += t.value << r >>> 0, e(8 >= n.g), t.g;
+        }
+        function wt(t, r, n) {
+          var i = t.xc;
+          return e((r = 0 == i ? 0 : t.vc[t.md * (n >> i) + (r >> i)]) < t.Wb), t.Ya[r];
+        }
+        function Nt(t, r, i, a) {
+          var o = t.ab,
+            s = t.c * r,
+            c = t.C;
+          r = c + r;
+          var u = i,
+            l = a;
+          for (a = t.Ta, i = t.Ua; 0 < o--;) {
+            var h = t.gc[o],
+              f = c,
+              d = r,
+              p = u,
+              g = l,
+              m = (l = a, u = i, h.Ea);
+            switch (e(f < d), e(d <= h.nc), h.hc) {
+              case 2:
+                Gr(p, g, (d - f) * m, l, u);
+                break;
+              case 0:
+                var v = f,
+                  b = d,
+                  y = l,
+                  w = u,
+                  N = (_ = h).Ea;
+                0 == v && (Wr(p, g, null, null, 1, y, w), V(p, g + 1, 0, 0, N - 1, y, w + 1), g += N, w += N, ++v);
+                for (var L = 1 << _.b, A = L - 1, x = q(N, _.b), S = _.K, _ = _.w + (v >> _.b) * x; v < b;) {
+                  var P = S,
+                    k = _,
+                    F = 1;
+                  for (Vr(p, g, y, w - N, 1, y, w); F < N;) {
+                    var I = (F & ~A) + L;
+                    I > N && (I = N), (0, Zr[P[k++] >> 8 & 15])(p, g + +F, y, w + F - N, I - F, y, w + F), F = I;
+                  }
+                  g += N, w += N, ++v & A || (_ += x);
+                }
+                d != h.nc && n(l, u - m, l, u + (d - f - 1) * m, m);
+                break;
+              case 1:
+                for (m = p, b = g, N = (p = h.Ea) - (w = p & ~(y = (g = 1 << h.b) - 1)), v = q(p, h.b), L = h.K, h = h.w + (f >> h.b) * v; f < d;) {
+                  for (A = L, x = h, S = new T(), _ = b + w, P = b + p; b < _;) Y(A[x++], S), $r(S, m, b, g, l, u), b += g, u += g;
+                  b < P && (Y(A[x++], S), $r(S, m, b, N, l, u), b += N, u += N), ++f & y || (h += v);
+                }
+                break;
+              case 3:
+                if (p == l && g == u && 0 < h.b) {
+                  for (b = l, p = m = u + (d - f) * m - (w = (d - f) * q(h.Ea, h.b)), g = l, y = u, v = [], w = (N = w) - 1; 0 <= w; --w) v[w] = g[y + w];
+                  for (w = N - 1; 0 <= w; --w) b[p + w] = v[w];
+                  Yr(h, f, d, l, m, l, u);
+                } else Yr(h, f, d, p, g, l, u);
+            }
+            u = a, l = i;
+          }
+          l != i && n(a, i, u, l, s);
+        }
+        function Lt(t, r) {
+          var n = t.V,
+            i = t.Ba + t.c * t.C,
+            a = r - t.C;
+          if (e(r <= t.l.o), e(16 >= a), 0 < a) {
+            var o = t.l,
+              s = t.Ta,
+              c = t.Ua,
+              u = o.width;
+            if (Nt(t, a, n, i), a = c = [c], e((n = t.C) < (i = r)), e(o.v < o.va), i > o.o && (i = o.o), n < o.j) {
+              var l = o.j - n;
+              n = o.j;
+              a[0] += l * u;
+            }
+            if (n >= i ? n = 0 : (a[0] += 4 * o.v, o.ka = n - o.j, o.U = o.va - o.v, o.T = i - n, n = 1), n) {
+              if (c = c[0], 11 > (n = t.ca).S) {
+                var h = n.f.RGBA,
+                  f = (i = n.S, a = o.U, o = o.T, l = h.eb, h.A),
+                  d = o;
+                for (h = h.fb + t.Ma * h.A; 0 < d--;) {
+                  var p = s,
+                    g = c,
+                    m = a,
+                    v = l,
+                    b = h;
+                  switch (i) {
+                    case En:
+                      Qr(p, g, m, v, b);
+                      break;
+                    case qn:
+                      tn(p, g, m, v, b);
+                      break;
+                    case Hn:
+                      tn(p, g, m, v, b), An(v, b, 0, m, 1, 0);
+                      break;
+                    case Dn:
+                      nn(p, g, m, v, b);
+                      break;
+                    case Rn:
+                      et(p, g, m, v, b, 1);
+                      break;
+                    case Wn:
+                      et(p, g, m, v, b, 1), An(v, b, 0, m, 1, 0);
+                      break;
+                    case Tn:
+                      et(p, g, m, v, b, 0);
+                      break;
+                    case Vn:
+                      et(p, g, m, v, b, 0), An(v, b, 1, m, 1, 0);
+                      break;
+                    case Un:
+                      en(p, g, m, v, b);
+                      break;
+                    case Gn:
+                      en(p, g, m, v, b), xn(v, b, m, 1, 0);
+                      break;
+                    case zn:
+                      rn(p, g, m, v, b);
+                      break;
+                    default:
+                      e(0);
+                  }
+                  c += u, h += f;
+                }
+                t.Ma += o;
+              } else alert("todo:EmitRescaledRowsYUVA");
+              e(t.Ma <= n.height);
+            }
+          }
+          t.C = r, e(t.C <= t.i);
+        }
+        function At(t) {
+          var e;
+          if (0 < t.ua) return 0;
+          for (e = 0; e < t.Wb; ++e) {
+            var r = t.Ya[e].G,
+              n = t.Ya[e].H;
+            if (0 < r[1][n[1] + 0].g || 0 < r[2][n[2] + 0].g || 0 < r[3][n[3] + 0].g) return 0;
+          }
+          return 1;
+        }
+        function xt(t, r, n, i, a, o) {
+          if (0 != t.Z) {
+            var s = t.qd,
+              c = t.rd;
+            for (e(null != mi[t.Z]); r < n; ++r) mi[t.Z](s, c, i, a, i, a, o), s = i, c = a, a += o;
+            t.qd = s, t.rd = c;
+          }
+        }
+        function St(t, r) {
+          var n = t.l.ma,
+            i = 0 == n.Z || 1 == n.Z ? t.l.j : t.C;
+          i = t.C < i ? i : t.C;
+          if (e(r <= t.l.o), r > i) {
+            var a = t.l.width,
+              o = n.ca,
+              s = n.tb + a * i,
+              c = t.V,
+              u = t.Ba + t.c * i,
+              l = t.gc;
+            e(1 == t.ab), e(3 == l[0].hc), Xr(l[0], i, r, c, u, o, s), xt(n, i, r, o, s, a);
+          }
+          t.C = t.Ma = r;
+        }
+        function _t(t, r, n, i, a, o, s) {
+          var c = t.$ / i,
+            u = t.$ % i,
+            l = t.m,
+            h = t.s,
+            f = n + t.$,
+            d = f;
+          a = n + i * a;
+          var p = n + i * o,
+            g = 280 + h.ua,
+            m = t.Pb ? c : 16777216,
+            v = 0 < h.ua ? h.Wa : null,
+            b = h.wc,
+            y = f < p ? wt(h, u, c) : null;
+          e(t.C < o), e(p <= a);
+          var w = !1;
+          t: for (;;) {
+            for (; w || f < p;) {
+              var N = 0;
+              if (c >= m) {
+                var _ = f - n;
+                e((m = t).Pb), m.wd = m.m, m.xd = _, 0 < m.s.ua && B(m.s.Wa, m.s.vb), m = c + ti;
+              }
+              if (u & b || (y = wt(h, u, c)), e(null != y), y.Qb && (r[f] = y.qb, w = !0), !w) if (S(l), y.jc) {
+                N = l, _ = r;
+                var P = f,
+                  k = y.pd[L(N) & Dr - 1];
+                e(y.jc), 256 > k.g ? (x(N, N.u + k.g), _[P] = k.value, N = 0) : (x(N, N.u + k.g - 256), e(256 <= k.value), N = k.value), 0 == N && (w = !0);
+              } else N = bt(y.G[0], y.H[0], l);
+              if (l.h) break;
+              if (w || 256 > N) {
+                if (!w) if (y.nd) r[f] = (y.qb | N << 8) >>> 0;else {
+                  if (S(l), w = bt(y.G[1], y.H[1], l), S(l), _ = bt(y.G[2], y.H[2], l), P = bt(y.G[3], y.H[3], l), l.h) break;
+                  r[f] = (P << 24 | w << 16 | N << 8 | _) >>> 0;
+                }
+                if (w = !1, ++f, ++u >= i && (u = 0, ++c, null != s && c <= o && !(c % 16) && s(t, c), null != v)) for (; d < f;) N = r[d++], v.X[(506832829 * N & 4294967295) >>> v.Mb] = N;
+              } else if (280 > N) {
+                if (N = mt(N - 256, l), _ = bt(y.G[4], y.H[4], l), S(l), _ = vt(i, _ = mt(_, l)), l.h) break;
+                if (f - n < _ || a - f < N) break t;
+                for (P = 0; P < N; ++P) r[f + P] = r[f + P - _];
+                for (f += N, u += N; u >= i;) u -= i, ++c, null != s && c <= o && !(c % 16) && s(t, c);
+                if (e(f <= a), u & b && (y = wt(h, u, c)), null != v) for (; d < f;) N = r[d++], v.X[(506832829 * N & 4294967295) >>> v.Mb] = N;
+              } else {
+                if (!(N < g)) break t;
+                for (w = N - 280, e(null != v); d < f;) N = r[d++], v.X[(506832829 * N & 4294967295) >>> v.Mb] = N;
+                N = f, e(!(w >>> (_ = v).Xa)), r[N] = _.X[w], w = !0;
+              }
+              w || e(l.h == A(l));
+            }
+            if (t.Pb && l.h && f < a) e(t.m.h), t.a = 5, t.m = t.wd, t.$ = t.xd, 0 < t.s.ua && B(t.s.vb, t.s.Wa);else {
+              if (l.h) break t;
+              null != s && s(t, c > o ? o : c), t.a = 0, t.$ = f - n;
+            }
+            return 1;
+          }
+          return t.a = 3, 0;
+        }
+        function Pt(t) {
+          e(null != t), t.vc = null, t.yc = null, t.Ya = null;
+          var r = t.Wa;
+          null != r && (r.X = null), t.vb = null, e(null != t);
+        }
+        function kt() {
+          var e = new or();
+          return null == e ? null : (e.a = 0, e.xb = gi, rt("Predictor", "VP8LPredictors"), rt("Predictor", "VP8LPredictors_C"), rt("PredictorAdd", "VP8LPredictorsAdd"), rt("PredictorAdd", "VP8LPredictorsAdd_C"), Gr = G, $r = J, Qr = K, tn = Z, en = $, rn = Q, nn = tt, t.VP8LMapColor32b = Jr, t.VP8LMapColor8b = Kr, e);
+        }
+        function Ft(t, r, n, s, c) {
+          var u = 1,
+            f = [t],
+            p = [r],
+            g = s.m,
+            m = s.s,
+            v = null,
+            b = 0;
+          t: for (;;) {
+            if (n) for (; u && y(g, 1);) {
+              var w = f,
+                N = p,
+                A = s,
+                _ = 1,
+                P = A.m,
+                k = A.gc[A.ab],
+                F = y(P, 2);
+              if (A.Oc & 1 << F) u = 0;else {
+                switch (A.Oc |= 1 << F, k.hc = F, k.Ea = w[0], k.nc = N[0], k.K = [null], ++A.ab, e(4 >= A.ab), F) {
+                  case 0:
+                  case 1:
+                    k.b = y(P, 3) + 2, _ = Ft(q(k.Ea, k.b), q(k.nc, k.b), 0, A, k.K), k.K = k.K[0];
+                    break;
+                  case 3:
+                    var I,
+                      C = y(P, 8) + 1,
+                      j = 16 < C ? 0 : 4 < C ? 1 : 2 < C ? 2 : 3;
+                    if (w[0] = q(k.Ea, j), k.b = j, I = _ = Ft(C, 1, 0, A, k.K)) {
+                      var B,
+                        M = C,
+                        E = k,
+                        R = 1 << (8 >> E.b),
+                        T = a(R);
+                      if (null == T) I = 0;else {
+                        var U = E.K[0],
+                          z = E.w;
+                        for (T[0] = E.K[0][0], B = 1; B < 1 * M; ++B) T[B] = D(U[z + B], T[B - 1]);
+                        for (; B < 4 * R; ++B) T[B] = 0;
+                        E.K[0] = null, E.K[0] = T, I = 1;
+                      }
+                    }
+                    _ = I;
+                    break;
+                  case 2:
+                    break;
+                  default:
+                    e(0);
+                }
+                u = _;
+              }
+            }
+            if (f = f[0], p = p[0], u && y(g, 1) && !(u = 1 <= (b = y(g, 4)) && 11 >= b)) {
+              s.a = 3;
+              break t;
+            }
+            var H;
+            if (H = u) e: {
+              var W,
+                V,
+                G,
+                Y = s,
+                J = f,
+                X = p,
+                K = b,
+                Z = n,
+                $ = Y.m,
+                Q = Y.s,
+                tt = [null],
+                et = 1,
+                rt = 0,
+                nt = Qn[K];
+              r: for (;;) {
+                if (Z && y($, 1)) {
+                  var it = y($, 3) + 2,
+                    at = q(J, it),
+                    ot = q(X, it),
+                    st = at * ot;
+                  if (!Ft(at, ot, 0, Y, tt)) break r;
+                  for (tt = tt[0], Q.xc = it, W = 0; W < st; ++W) {
+                    var ct = tt[W] >> 8 & 65535;
+                    tt[W] = ct, ct >= et && (et = ct + 1);
+                  }
+                }
+                if ($.h) break r;
+                for (V = 0; 5 > V; ++V) {
+                  var ut = Xn[V];
+                  !V && 0 < K && (ut += 1 << K), rt < ut && (rt = ut);
+                }
+                var lt = o(et * nt, h),
+                  ht = et,
+                  ft = o(ht, d);
+                if (null == ft) var dt = null;else e(65536 >= ht), dt = ft;
+                var pt = a(rt);
+                if (null == dt || null == pt || null == lt) {
+                  Y.a = 1;
+                  break r;
+                }
+                var gt = lt;
+                for (W = G = 0; W < et; ++W) {
+                  var mt = dt[W],
+                    vt = mt.G,
+                    bt = mt.H,
+                    wt = 0,
+                    Nt = 1,
+                    Lt = 0;
+                  for (V = 0; 5 > V; ++V) {
+                    ut = Xn[V], vt[V] = gt, bt[V] = G, !V && 0 < K && (ut += 1 << K);
+                    n: {
+                      var At,
+                        xt = ut,
+                        St = Y,
+                        kt = pt,
+                        It = gt,
+                        Ct = G,
+                        jt = 0,
+                        Ot = St.m,
+                        Bt = y(Ot, 1);
+                      if (i(kt, 0, 0, xt), Bt) {
+                        var Mt = y(Ot, 1) + 1,
+                          Et = y(Ot, 1),
+                          qt = y(Ot, 0 == Et ? 1 : 8);
+                        kt[qt] = 1, 2 == Mt && (kt[qt = y(Ot, 8)] = 1);
+                        var Dt = 1;
+                      } else {
+                        var Rt = a(19),
+                          Tt = y(Ot, 4) + 4;
+                        if (19 < Tt) {
+                          St.a = 3;
+                          var Ut = 0;
+                          break n;
+                        }
+                        for (At = 0; At < Tt; ++At) Rt[Zn[At]] = y(Ot, 3);
+                        var zt = void 0,
+                          Ht = void 0,
+                          Wt = St,
+                          Vt = Rt,
+                          Gt = xt,
+                          Yt = kt,
+                          Jt = 0,
+                          Xt = Wt.m,
+                          Kt = 8,
+                          Zt = o(128, h);
+                        i: for (; l(Zt, 0, 7, Vt, 19);) {
+                          if (y(Xt, 1)) {
+                            var $t = 2 + 2 * y(Xt, 3);
+                            if ((zt = 2 + y(Xt, $t)) > Gt) break i;
+                          } else zt = Gt;
+                          for (Ht = 0; Ht < Gt && zt--;) {
+                            S(Xt);
+                            var Qt = Zt[0 + (127 & L(Xt))];
+                            x(Xt, Xt.u + Qt.g);
+                            var te = Qt.value;
+                            if (16 > te) Yt[Ht++] = te, 0 != te && (Kt = te);else {
+                              var ee = 16 == te,
+                                re = te - 16,
+                                ne = Jn[re],
+                                ie = y(Xt, Yn[re]) + ne;
+                              if (Ht + ie > Gt) break i;
+                              for (var ae = ee ? Kt : 0; 0 < ie--;) Yt[Ht++] = ae;
+                            }
+                          }
+                          Jt = 1;
+                          break i;
+                        }
+                        Jt || (Wt.a = 3), Dt = Jt;
+                      }
+                      (Dt = Dt && !Ot.h) && (jt = l(It, Ct, 8, kt, xt)), Dt && 0 != jt ? Ut = jt : (St.a = 3, Ut = 0);
+                    }
+                    if (0 == Ut) break r;
+                    if (Nt && 1 == Kn[V] && (Nt = 0 == gt[G].g), wt += gt[G].g, G += Ut, 3 >= V) {
+                      var oe,
+                        se = pt[0];
+                      for (oe = 1; oe < ut; ++oe) pt[oe] > se && (se = pt[oe]);
+                      Lt += se;
+                    }
+                  }
+                  if (mt.nd = Nt, mt.Qb = 0, Nt && (mt.qb = (vt[3][bt[3] + 0].value << 24 | vt[1][bt[1] + 0].value << 16 | vt[2][bt[2] + 0].value) >>> 0, 0 == wt && 256 > vt[0][bt[0] + 0].value && (mt.Qb = 1, mt.qb += vt[0][bt[0] + 0].value << 8)), mt.jc = !mt.Qb && 6 > Lt, mt.jc) {
+                    var ce,
+                      ue = mt;
+                    for (ce = 0; ce < Dr; ++ce) {
+                      var le = ce,
+                        he = ue.pd[le],
+                        fe = ue.G[0][ue.H[0] + le];
+                      256 <= fe.value ? (he.g = fe.g + 256, he.value = fe.value) : (he.g = 0, he.value = 0, le >>= yt(fe, 8, he), le >>= yt(ue.G[1][ue.H[1] + le], 16, he), le >>= yt(ue.G[2][ue.H[2] + le], 0, he), yt(ue.G[3][ue.H[3] + le], 24, he));
+                    }
+                  }
+                }
+                Q.vc = tt, Q.Wb = et, Q.Ya = dt, Q.yc = lt, H = 1;
+                break e;
+              }
+              H = 0;
+            }
+            if (!(u = H)) {
+              s.a = 3;
+              break t;
+            }
+            if (0 < b) {
+              if (m.ua = 1 << b, !O(m.Wa, b)) {
+                s.a = 1, u = 0;
+                break t;
+              }
+            } else m.ua = 0;
+            var de = s,
+              pe = f,
+              ge = p,
+              me = de.s,
+              ve = me.xc;
+            if (de.c = pe, de.i = ge, me.md = q(pe, ve), me.wc = 0 == ve ? -1 : (1 << ve) - 1, n) {
+              s.xb = pi;
+              break t;
+            }
+            if (null == (v = a(f * p))) {
+              s.a = 1, u = 0;
+              break t;
+            }
+            u = (u = _t(s, v, 0, f, p, p, null)) && !g.h;
+            break t;
+          }
+          return u ? (null != c ? c[0] = v : (e(null == v), e(n)), s.$ = 0, n || Pt(m)) : Pt(m), u;
+        }
+        function It(t, r) {
+          var n = t.c * t.i,
+            i = n + r + 16 * r;
+          return e(t.c <= r), t.V = a(i), null == t.V ? (t.Ta = null, t.Ua = 0, t.a = 1, 0) : (t.Ta = t.V, t.Ua = t.Ba + n + r, 1);
+        }
+        function Ct(t, r) {
+          var n = t.C,
+            i = r - n,
+            a = t.V,
+            o = t.Ba + t.c * n;
+          for (e(r <= t.l.o); 0 < i;) {
+            var s = 16 < i ? 16 : i,
+              c = t.l.ma,
+              u = t.l.width,
+              l = u * s,
+              h = c.ca,
+              f = c.tb + u * n,
+              d = t.Ta,
+              p = t.Ua;
+            Nt(t, s, a, o), _n(d, p, h, f, l), xt(c, n, n + s, h, f, u), i -= s, a += s * t.c, n += s;
+          }
+          e(n == r), t.C = t.Ma = r;
+        }
+        function jt() {
+          this.ub = this.yd = this.td = this.Rb = 0;
+        }
+        function Ot() {
+          this.Kd = this.Ld = this.Ud = this.Td = this.i = this.c = 0;
+        }
+        function Bt() {
+          this.Fb = this.Bb = this.Cb = 0, this.Zb = a(4), this.Lb = a(4);
+        }
+        function Mt() {
+          this.Yb = function () {
+            var t = [];
+            return function t(e, r, n) {
+              for (var i = n[r], a = 0; a < i && (e.push(n.length > r + 1 ? [] : 0), !(n.length < r + 1)); a++) t(e[a], r + 1, n);
+            }(t, 0, [3, 11]), t;
+          }();
+        }
+        function Et() {
+          this.jb = a(3), this.Wc = s([4, 8], Mt), this.Xc = s([4, 17], Mt);
+        }
+        function qt() {
+          this.Pc = this.wb = this.Tb = this.zd = 0, this.vd = new a(4), this.od = new a(4);
+        }
+        function Dt() {
+          this.ld = this.La = this.dd = this.tc = 0;
+        }
+        function Rt() {
+          this.Na = this.la = 0;
+        }
+        function Tt() {
+          this.Sc = [0, 0], this.Eb = [0, 0], this.Qc = [0, 0], this.ia = this.lc = 0;
+        }
+        function Ut() {
+          this.ad = a(384), this.Za = 0, this.Ob = a(16), this.$b = this.Ad = this.ia = this.Gc = this.Hc = this.Dd = 0;
+        }
+        function zt() {
+          this.uc = this.M = this.Nb = 0, this.wa = Array(new Dt()), this.Y = 0, this.ya = Array(new Ut()), this.aa = 0, this.l = new Gt();
+        }
+        function Ht() {
+          this.y = a(16), this.f = a(8), this.ea = a(8);
+        }
+        function Wt() {
+          this.cb = this.a = 0, this.sc = "", this.m = new w(), this.Od = new jt(), this.Kc = new Ot(), this.ed = new qt(), this.Qa = new Bt(), this.Ic = this.$c = this.Aa = 0, this.D = new zt(), this.Xb = this.Va = this.Hb = this.zb = this.yb = this.Ub = this.za = 0, this.Jc = o(8, w), this.ia = 0, this.pb = o(4, Tt), this.Pa = new Et(), this.Bd = this.kc = 0, this.Ac = [], this.Bc = 0, this.zc = [0, 0, 0, 0], this.Gd = Array(new Ht()), this.Hd = 0, this.rb = Array(new Rt()), this.sb = 0, this.wa = Array(new Dt()), this.Y = 0, this.oc = [], this.pc = 0, this.sa = [], this.ta = 0, this.qa = [], this.ra = 0, this.Ha = [], this.B = this.R = this.Ia = 0, this.Ec = [], this.M = this.ja = this.Vb = this.Fc = 0, this.ya = Array(new Ut()), this.L = this.aa = 0, this.gd = s([4, 2], Dt), this.ga = null, this.Fa = [], this.Cc = this.qc = this.P = 0, this.Gb = [], this.Uc = 0, this.mb = [], this.nb = 0, this.rc = [], this.Ga = this.Vc = 0;
+        }
+        function Vt(t, e) {
+          return 0 > t ? 0 : t > e ? e : t;
+        }
+        function Gt() {
+          this.T = this.U = this.ka = this.height = this.width = 0, this.y = [], this.f = [], this.ea = [], this.Rc = this.fa = this.W = this.N = this.O = 0, this.ma = "void", this.put = "VP8IoPutHook", this.ac = "VP8IoSetupHook", this.bc = "VP8IoTeardownHook", this.ha = this.Kb = 0, this.data = [], this.hb = this.ib = this.da = this.o = this.j = this.va = this.v = this.Da = this.ob = this.w = 0, this.F = [], this.J = 0;
+        }
+        function Yt() {
+          var t = new Wt();
+          return null != t && (t.a = 0, t.sc = "OK", t.cb = 0, t.Xb = 0, ni || (ni = Zt)), t;
+        }
+        function Jt(t, e, r) {
+          return 0 == t.a && (t.a = e, t.sc = r, t.cb = 0), 0;
+        }
+        function Xt(t, e, r) {
+          return 3 <= r && 157 == t[e + 0] && 1 == t[e + 1] && 42 == t[e + 2];
+        }
+        function Kt(t, r) {
+          if (null == t) return 0;
+          if (t.a = 0, t.sc = "OK", null == r) return Jt(t, 2, "null VP8Io passed to VP8GetHeaders()");
+          var n = r.data,
+            a = r.w,
+            o = r.ha;
+          if (4 > o) return Jt(t, 7, "Truncated header.");
+          var s = n[a + 0] | n[a + 1] << 8 | n[a + 2] << 16,
+            c = t.Od;
+          if (c.Rb = !(1 & s), c.td = s >> 1 & 7, c.yd = s >> 4 & 1, c.ub = s >> 5, 3 < c.td) return Jt(t, 3, "Incorrect keyframe parameters.");
+          if (!c.yd) return Jt(t, 4, "Frame not displayable.");
+          a += 3, o -= 3;
+          var u = t.Kc;
+          if (c.Rb) {
+            if (7 > o) return Jt(t, 7, "cannot parse picture header");
+            if (!Xt(n, a, o)) return Jt(t, 3, "Bad code word");
+            u.c = 16383 & (n[a + 4] << 8 | n[a + 3]), u.Td = n[a + 4] >> 6, u.i = 16383 & (n[a + 6] << 8 | n[a + 5]), u.Ud = n[a + 6] >> 6, a += 7, o -= 7, t.za = u.c + 15 >> 4, t.Ub = u.i + 15 >> 4, r.width = u.c, r.height = u.i, r.Da = 0, r.j = 0, r.v = 0, r.va = r.width, r.o = r.height, r.da = 0, r.ib = r.width, r.hb = r.height, r.U = r.width, r.T = r.height, i((s = t.Pa).jb, 0, 255, s.jb.length), e(null != (s = t.Qa)), s.Cb = 0, s.Bb = 0, s.Fb = 1, i(s.Zb, 0, 0, s.Zb.length), i(s.Lb, 0, 0, s.Lb);
+          }
+          if (c.ub > o) return Jt(t, 7, "bad partition length");
+          p(s = t.m, n, a, c.ub), a += c.ub, o -= c.ub, c.Rb && (u.Ld = P(s), u.Kd = P(s)), u = t.Qa;
+          var l,
+            h = t.Pa;
+          if (e(null != s), e(null != u), u.Cb = P(s), u.Cb) {
+            if (u.Bb = P(s), P(s)) {
+              for (u.Fb = P(s), l = 0; 4 > l; ++l) u.Zb[l] = P(s) ? m(s, 7) : 0;
+              for (l = 0; 4 > l; ++l) u.Lb[l] = P(s) ? m(s, 6) : 0;
+            }
+            if (u.Bb) for (l = 0; 3 > l; ++l) h.jb[l] = P(s) ? g(s, 8) : 255;
+          } else u.Bb = 0;
+          if (s.Ka) return Jt(t, 3, "cannot parse segment header");
+          if ((u = t.ed).zd = P(s), u.Tb = g(s, 6), u.wb = g(s, 3), u.Pc = P(s), u.Pc && P(s)) {
+            for (h = 0; 4 > h; ++h) P(s) && (u.vd[h] = m(s, 6));
+            for (h = 0; 4 > h; ++h) P(s) && (u.od[h] = m(s, 6));
+          }
+          if (t.L = 0 == u.Tb ? 0 : u.zd ? 1 : 2, s.Ka) return Jt(t, 3, "cannot parse filter header");
+          var f = o;
+          if (o = l = a, a = l + f, u = f, t.Xb = (1 << g(t.m, 2)) - 1, f < 3 * (h = t.Xb)) n = 7;else {
+            for (l += 3 * h, u -= 3 * h, f = 0; f < h; ++f) {
+              var d = n[o + 0] | n[o + 1] << 8 | n[o + 2] << 16;
+              d > u && (d = u), p(t.Jc[+f], n, l, d), l += d, u -= d, o += 3;
+            }
+            p(t.Jc[+h], n, l, u), n = l < a ? 0 : 5;
+          }
+          if (0 != n) return Jt(t, n, "cannot parse partitions");
+          for (n = g(l = t.m, 7), o = P(l) ? m(l, 4) : 0, a = P(l) ? m(l, 4) : 0, u = P(l) ? m(l, 4) : 0, h = P(l) ? m(l, 4) : 0, l = P(l) ? m(l, 4) : 0, f = t.Qa, d = 0; 4 > d; ++d) {
+            if (f.Cb) {
+              var v = f.Zb[d];
+              f.Fb || (v += n);
+            } else {
+              if (0 < d) {
+                t.pb[d] = t.pb[0];
+                continue;
+              }
+              v = n;
+            }
+            var b = t.pb[d];
+            b.Sc[0] = ei[Vt(v + o, 127)], b.Sc[1] = ri[Vt(v + 0, 127)], b.Eb[0] = 2 * ei[Vt(v + a, 127)], b.Eb[1] = 101581 * ri[Vt(v + u, 127)] >> 16, 8 > b.Eb[1] && (b.Eb[1] = 8), b.Qc[0] = ei[Vt(v + h, 117)], b.Qc[1] = ri[Vt(v + l, 127)], b.lc = v + l;
+          }
+          if (!c.Rb) return Jt(t, 4, "Not a key frame.");
+          for (P(s), c = t.Pa, n = 0; 4 > n; ++n) {
+            for (o = 0; 8 > o; ++o) for (a = 0; 3 > a; ++a) for (u = 0; 11 > u; ++u) h = k(s, ui[n][o][a][u]) ? g(s, 8) : si[n][o][a][u], c.Wc[n][o].Yb[a][u] = h;
+            for (o = 0; 17 > o; ++o) c.Xc[n][o] = c.Wc[n][li[o]];
+          }
+          return t.kc = P(s), t.kc && (t.Bd = g(s, 8)), t.cb = 1;
+        }
+        function Zt(t, e, r, n, i, a, o) {
+          var s = e[i].Yb[r];
+          for (r = 0; 16 > i; ++i) {
+            if (!k(t, s[r + 0])) return i;
+            for (; !k(t, s[r + 1]);) if (s = e[++i].Yb[0], r = 0, 16 == i) return 16;
+            var c = e[i + 1].Yb;
+            if (k(t, s[r + 2])) {
+              var u = t,
+                l = 0;
+              if (k(u, (f = s)[(h = r) + 3])) {
+                if (k(u, f[h + 6])) {
+                  for (s = 0, h = 2 * (l = k(u, f[h + 8])) + (f = k(u, f[h + 9 + l])), l = 0, f = ii[h]; f[s]; ++s) l += l + k(u, f[s]);
+                  l += 3 + (8 << h);
+                } else k(u, f[h + 7]) ? (l = 7 + 2 * k(u, 165), l += k(u, 145)) : l = 5 + k(u, 159);
+              } else l = k(u, f[h + 4]) ? 3 + k(u, f[h + 5]) : 2;
+              s = c[2];
+            } else l = 1, s = c[1];
+            c = o + ai[i], 0 > (u = t).b && _(u);
+            var h,
+              f = u.b,
+              d = (h = u.Ca >> 1) - (u.I >> f) >> 31;
+            --u.b, u.Ca += d, u.Ca |= 1, u.I -= (h + 1 & d) << f, a[c] = ((l ^ d) - d) * n[(0 < i) + 0];
+          }
+          return 16;
+        }
+        function $t(t) {
+          var e = t.rb[t.sb - 1];
+          e.la = 0, e.Na = 0, i(t.zc, 0, 0, t.zc.length), t.ja = 0;
+        }
+        function Qt(t, r) {
+          if (null == t) return 0;
+          if (null == r) return Jt(t, 2, "NULL VP8Io parameter in VP8Decode().");
+          if (!t.cb && !Kt(t, r)) return 0;
+          if (e(t.cb), null == r.ac || r.ac(r)) {
+            r.ob && (t.L = 0);
+            var s = Ri[t.L];
+            if (2 == t.L ? (t.yb = 0, t.zb = 0) : (t.yb = r.v - s >> 4, t.zb = r.j - s >> 4, 0 > t.yb && (t.yb = 0), 0 > t.zb && (t.zb = 0)), t.Va = r.o + 15 + s >> 4, t.Hb = r.va + 15 + s >> 4, t.Hb > t.za && (t.Hb = t.za), t.Va > t.Ub && (t.Va = t.Ub), 0 < t.L) {
+              var c = t.ed;
+              for (s = 0; 4 > s; ++s) {
+                var u;
+                if (t.Qa.Cb) {
+                  var l = t.Qa.Lb[s];
+                  t.Qa.Fb || (l += c.Tb);
+                } else l = c.Tb;
+                for (u = 0; 1 >= u; ++u) {
+                  var h = t.gd[s][u],
+                    f = l;
+                  if (c.Pc && (f += c.vd[0], u && (f += c.od[0])), 0 < (f = 0 > f ? 0 : 63 < f ? 63 : f)) {
+                    var d = f;
+                    0 < c.wb && (d = 4 < c.wb ? d >> 2 : d >> 1) > 9 - c.wb && (d = 9 - c.wb), 1 > d && (d = 1), h.dd = d, h.tc = 2 * f + d, h.ld = 40 <= f ? 2 : 15 <= f ? 1 : 0;
+                  } else h.tc = 0;
+                  h.La = u;
+                }
+              }
+            }
+            s = 0;
+          } else Jt(t, 6, "Frame setup failed"), s = t.a;
+          if (s = 0 == s) {
+            if (s) {
+              t.$c = 0, 0 < t.Aa || (t.Ic = Ui);
+              t: {
+                s = t.Ic;
+                c = 4 * (d = t.za);
+                var p = 32 * d,
+                  g = d + 1,
+                  m = 0 < t.L ? d * (0 < t.Aa ? 2 : 1) : 0,
+                  v = (2 == t.Aa ? 2 : 1) * d;
+                if ((h = c + 832 + (u = 3 * (16 * s + Ri[t.L]) / 2 * p) + (l = null != t.Fa && 0 < t.Fa.length ? t.Kc.c * t.Kc.i : 0)) != h) s = 0;else {
+                  if (h > t.Vb) {
+                    if (t.Vb = 0, t.Ec = a(h), t.Fc = 0, null == t.Ec) {
+                      s = Jt(t, 1, "no memory during frame initialization.");
+                      break t;
+                    }
+                    t.Vb = h;
+                  }
+                  h = t.Ec, f = t.Fc, t.Ac = h, t.Bc = f, f += c, t.Gd = o(p, Ht), t.Hd = 0, t.rb = o(g + 1, Rt), t.sb = 1, t.wa = m ? o(m, Dt) : null, t.Y = 0, t.D.Nb = 0, t.D.wa = t.wa, t.D.Y = t.Y, 0 < t.Aa && (t.D.Y += d), e(!0), t.oc = h, t.pc = f, f += 832, t.ya = o(v, Ut), t.aa = 0, t.D.ya = t.ya, t.D.aa = t.aa, 2 == t.Aa && (t.D.aa += d), t.R = 16 * d, t.B = 8 * d, d = (p = Ri[t.L]) * t.R, p = p / 2 * t.B, t.sa = h, t.ta = f + d, t.qa = t.sa, t.ra = t.ta + 16 * s * t.R + p, t.Ha = t.qa, t.Ia = t.ra + 8 * s * t.B + p, t.$c = 0, f += u, t.mb = l ? h : null, t.nb = l ? f : null, e(f + l <= t.Fc + t.Vb), $t(t), i(t.Ac, t.Bc, 0, c), s = 1;
+                }
+              }
+              if (s) {
+                if (r.ka = 0, r.y = t.sa, r.O = t.ta, r.f = t.qa, r.N = t.ra, r.ea = t.Ha, r.Vd = t.Ia, r.fa = t.R, r.Rc = t.B, r.F = null, r.J = 0, !Cn) {
+                  for (s = -255; 255 >= s; ++s) Pn[255 + s] = 0 > s ? -s : s;
+                  for (s = -1020; 1020 >= s; ++s) kn[1020 + s] = -128 > s ? -128 : 127 < s ? 127 : s;
+                  for (s = -112; 112 >= s; ++s) Fn[112 + s] = -16 > s ? -16 : 15 < s ? 15 : s;
+                  for (s = -255; 510 >= s; ++s) In[255 + s] = 0 > s ? 0 : 255 < s ? 255 : s;
+                  Cn = 1;
+                }
+                an = ue, on = ae, cn = oe, un = se, ln = ce, sn = ie, hn = Je, fn = Xe, dn = $e, pn = Qe, gn = Ke, mn = Ze, vn = tr, bn = er, yn = ze, wn = He, Nn = We, Ln = Ve, fi[0] = xe, fi[1] = he, fi[2] = Le, fi[3] = Ae, fi[4] = Se, fi[5] = Pe, fi[6] = _e, fi[7] = ke, fi[8] = Ie, fi[9] = Fe, hi[0] = ve, hi[1] = de, hi[2] = pe, hi[3] = ge, hi[4] = be, hi[5] = ye, hi[6] = we, di[0] = Be, di[1] = fe, di[2] = Ce, di[3] = je, di[4] = Ee, di[5] = Me, di[6] = qe, s = 1;
+              } else s = 0;
+            }
+            s && (s = function (t, r) {
+              for (t.M = 0; t.M < t.Va; ++t.M) {
+                var o,
+                  s = t.Jc[t.M & t.Xb],
+                  c = t.m,
+                  u = t;
+                for (o = 0; o < u.za; ++o) {
+                  var l = c,
+                    h = u,
+                    f = h.Ac,
+                    d = h.Bc + 4 * o,
+                    p = h.zc,
+                    g = h.ya[h.aa + o];
+                  if (h.Qa.Bb ? g.$b = k(l, h.Pa.jb[0]) ? 2 + k(l, h.Pa.jb[2]) : k(l, h.Pa.jb[1]) : g.$b = 0, h.kc && (g.Ad = k(l, h.Bd)), g.Za = !k(l, 145) + 0, g.Za) {
+                    var m = g.Ob,
+                      v = 0;
+                    for (h = 0; 4 > h; ++h) {
+                      var b,
+                        y = p[0 + h];
+                      for (b = 0; 4 > b; ++b) {
+                        y = ci[f[d + b]][y];
+                        for (var w = oi[k(l, y[0])]; 0 < w;) w = oi[2 * w + k(l, y[w])];
+                        y = -w, f[d + b] = y;
+                      }
+                      n(m, v, f, d, 4), v += 4, p[0 + h] = y;
+                    }
+                  } else y = k(l, 156) ? k(l, 128) ? 1 : 3 : k(l, 163) ? 2 : 0, g.Ob[0] = y, i(f, d, y, 4), i(p, 0, y, 4);
+                  g.Dd = k(l, 142) ? k(l, 114) ? k(l, 183) ? 1 : 3 : 2 : 0;
+                }
+                if (u.m.Ka) return Jt(t, 7, "Premature end-of-partition0 encountered.");
+                for (; t.ja < t.za; ++t.ja) {
+                  if (u = s, l = (c = t).rb[c.sb - 1], f = c.rb[c.sb + c.ja], o = c.ya[c.aa + c.ja], d = c.kc ? o.Ad : 0) l.la = f.la = 0, o.Za || (l.Na = f.Na = 0), o.Hc = 0, o.Gc = 0, o.ia = 0;else {
+                    var N, L;
+                    l = f, f = u, d = c.Pa.Xc, p = c.ya[c.aa + c.ja], g = c.pb[p.$b];
+                    if (h = p.ad, m = 0, v = c.rb[c.sb - 1], y = b = 0, i(h, m, 0, 384), p.Za) var A = 0,
+                      x = d[3];else {
+                      w = a(16);
+                      var S = l.Na + v.Na;
+                      if (S = ni(f, d[1], S, g.Eb, 0, w, 0), l.Na = v.Na = (0 < S) + 0, 1 < S) an(w, 0, h, m);else {
+                        var _ = w[0] + 3 >> 3;
+                        for (w = 0; 256 > w; w += 16) h[m + w] = _;
+                      }
+                      A = 1, x = d[0];
+                    }
+                    var P = 15 & l.la,
+                      F = 15 & v.la;
+                    for (w = 0; 4 > w; ++w) {
+                      var I = 1 & F;
+                      for (_ = L = 0; 4 > _; ++_) P = P >> 1 | (I = (S = ni(f, x, S = I + (1 & P), g.Sc, A, h, m)) > A) << 7, L = L << 2 | (3 < S ? 3 : 1 < S ? 2 : 0 != h[m + 0]), m += 16;
+                      P >>= 4, F = F >> 1 | I << 7, b = (b << 8 | L) >>> 0;
+                    }
+                    for (x = P, A = F >> 4, N = 0; 4 > N; N += 2) {
+                      for (L = 0, P = l.la >> 4 + N, F = v.la >> 4 + N, w = 0; 2 > w; ++w) {
+                        for (I = 1 & F, _ = 0; 2 > _; ++_) S = I + (1 & P), P = P >> 1 | (I = 0 < (S = ni(f, d[2], S, g.Qc, 0, h, m))) << 3, L = L << 2 | (3 < S ? 3 : 1 < S ? 2 : 0 != h[m + 0]), m += 16;
+                        P >>= 2, F = F >> 1 | I << 5;
+                      }
+                      y |= L << 4 * N, x |= P << 4 << N, A |= (240 & F) << N;
+                    }
+                    l.la = x, v.la = A, p.Hc = b, p.Gc = y, p.ia = 43690 & y ? 0 : g.ia, d = !(b | y);
+                  }
+                  if (0 < c.L && (c.wa[c.Y + c.ja] = c.gd[o.$b][o.Za], c.wa[c.Y + c.ja].La |= !d), u.Ka) return Jt(t, 7, "Premature end-of-file encountered.");
+                }
+                if ($t(t), c = r, u = 1, o = (s = t).D, l = 0 < s.L && s.M >= s.zb && s.M <= s.Va, 0 == s.Aa) t: {
+                  if (o.M = s.M, o.uc = l, Or(s, o), u = 1, o = (L = s.D).Nb, l = (y = Ri[s.L]) * s.R, f = y / 2 * s.B, w = 16 * o * s.R, _ = 8 * o * s.B, d = s.sa, p = s.ta - l + w, g = s.qa, h = s.ra - f + _, m = s.Ha, v = s.Ia - f + _, F = 0 == (P = L.M), b = P >= s.Va - 1, 2 == s.Aa && Or(s, L), L.uc) for (I = (S = s).D.M, e(S.D.uc), L = S.yb; L < S.Hb; ++L) {
+                    A = L, x = I;
+                    var C = (j = (U = S).D).Nb;
+                    N = U.R;
+                    var j = j.wa[j.Y + A],
+                      O = U.sa,
+                      B = U.ta + 16 * C * N + 16 * A,
+                      M = j.dd,
+                      E = j.tc;
+                    if (0 != E) if (e(3 <= E), 1 == U.L) 0 < A && wn(O, B, N, E + 4), j.La && Ln(O, B, N, E), 0 < x && yn(O, B, N, E + 4), j.La && Nn(O, B, N, E);else {
+                      var q = U.B,
+                        D = U.qa,
+                        R = U.ra + 8 * C * q + 8 * A,
+                        T = U.Ha,
+                        U = U.Ia + 8 * C * q + 8 * A;
+                      C = j.ld;
+                      0 < A && (fn(O, B, N, E + 4, M, C), pn(D, R, T, U, q, E + 4, M, C)), j.La && (mn(O, B, N, E, M, C), bn(D, R, T, U, q, E, M, C)), 0 < x && (hn(O, B, N, E + 4, M, C), dn(D, R, T, U, q, E + 4, M, C)), j.La && (gn(O, B, N, E, M, C), vn(D, R, T, U, q, E, M, C));
+                    }
+                  }
+                  if (s.ia && alert("todo:DitherRow"), null != c.put) {
+                    if (L = 16 * P, P = 16 * (P + 1), F ? (c.y = s.sa, c.O = s.ta + w, c.f = s.qa, c.N = s.ra + _, c.ea = s.Ha, c.W = s.Ia + _) : (L -= y, c.y = d, c.O = p, c.f = g, c.N = h, c.ea = m, c.W = v), b || (P -= y), P > c.o && (P = c.o), c.F = null, c.J = null, null != s.Fa && 0 < s.Fa.length && L < P && (c.J = hr(s, c, L, P - L), c.F = s.mb, null == c.F && 0 == c.F.length)) {
+                      u = Jt(s, 3, "Could not decode alpha data.");
+                      break t;
+                    }
+                    L < c.j && (y = c.j - L, L = c.j, e(!(1 & y)), c.O += s.R * y, c.N += s.B * (y >> 1), c.W += s.B * (y >> 1), null != c.F && (c.J += c.width * y)), L < P && (c.O += c.v, c.N += c.v >> 1, c.W += c.v >> 1, null != c.F && (c.J += c.v), c.ka = L - c.j, c.U = c.va - c.v, c.T = P - L, u = c.put(c));
+                  }
+                  o + 1 != s.Ic || b || (n(s.sa, s.ta - l, d, p + 16 * s.R, l), n(s.qa, s.ra - f, g, h + 8 * s.B, f), n(s.Ha, s.Ia - f, m, v + 8 * s.B, f));
+                }
+                if (!u) return Jt(t, 6, "Output aborted.");
+              }
+              return 1;
+            }(t, r)), null != r.bc && r.bc(r), s &= 1;
+          }
+          return s ? (t.cb = 0, s) : 0;
+        }
+        function te(t, e, r, n, i) {
+          i = t[e + r + 32 * n] + (i >> 3), t[e + r + 32 * n] = -256 & i ? 0 > i ? 0 : 255 : i;
+        }
+        function ee(t, e, r, n, i, a) {
+          te(t, e, 0, r, n + i), te(t, e, 1, r, n + a), te(t, e, 2, r, n - a), te(t, e, 3, r, n - i);
+        }
+        function re(t) {
+          return (20091 * t >> 16) + t;
+        }
+        function ne(t, e, r, n) {
+          var i,
+            o = 0,
+            s = a(16);
+          for (i = 0; 4 > i; ++i) {
+            var c = t[e + 0] + t[e + 8],
+              u = t[e + 0] - t[e + 8],
+              l = (35468 * t[e + 4] >> 16) - re(t[e + 12]),
+              h = re(t[e + 4]) + (35468 * t[e + 12] >> 16);
+            s[o + 0] = c + h, s[o + 1] = u + l, s[o + 2] = u - l, s[o + 3] = c - h, o += 4, e++;
+          }
+          for (i = o = 0; 4 > i; ++i) c = (t = s[o + 0] + 4) + s[o + 8], u = t - s[o + 8], l = (35468 * s[o + 4] >> 16) - re(s[o + 12]), te(r, n, 0, 0, c + (h = re(s[o + 4]) + (35468 * s[o + 12] >> 16))), te(r, n, 1, 0, u + l), te(r, n, 2, 0, u - l), te(r, n, 3, 0, c - h), o++, n += 32;
+        }
+        function ie(t, e, r, n) {
+          var i = t[e + 0] + 4,
+            a = 35468 * t[e + 4] >> 16,
+            o = re(t[e + 4]),
+            s = 35468 * t[e + 1] >> 16;
+          ee(r, n, 0, i + o, t = re(t[e + 1]), s), ee(r, n, 1, i + a, t, s), ee(r, n, 2, i - a, t, s), ee(r, n, 3, i - o, t, s);
+        }
+        function ae(t, e, r, n, i) {
+          ne(t, e, r, n), i && ne(t, e + 16, r, n + 4);
+        }
+        function oe(t, e, r, n) {
+          on(t, e + 0, r, n, 1), on(t, e + 32, r, n + 128, 1);
+        }
+        function se(t, e, r, n) {
+          var i;
+          for (t = t[e + 0] + 4, i = 0; 4 > i; ++i) for (e = 0; 4 > e; ++e) te(r, n, e, i, t);
+        }
+        function ce(t, e, r, n) {
+          t[e + 0] && un(t, e + 0, r, n), t[e + 16] && un(t, e + 16, r, n + 4), t[e + 32] && un(t, e + 32, r, n + 128), t[e + 48] && un(t, e + 48, r, n + 128 + 4);
+        }
+        function ue(t, e, r, n) {
+          var i,
+            o = a(16);
+          for (i = 0; 4 > i; ++i) {
+            var s = t[e + 0 + i] + t[e + 12 + i],
+              c = t[e + 4 + i] + t[e + 8 + i],
+              u = t[e + 4 + i] - t[e + 8 + i],
+              l = t[e + 0 + i] - t[e + 12 + i];
+            o[0 + i] = s + c, o[8 + i] = s - c, o[4 + i] = l + u, o[12 + i] = l - u;
+          }
+          for (i = 0; 4 > i; ++i) s = (t = o[0 + 4 * i] + 3) + o[3 + 4 * i], c = o[1 + 4 * i] + o[2 + 4 * i], u = o[1 + 4 * i] - o[2 + 4 * i], l = t - o[3 + 4 * i], r[n + 0] = s + c >> 3, r[n + 16] = l + u >> 3, r[n + 32] = s - c >> 3, r[n + 48] = l - u >> 3, n += 64;
+        }
+        function le(t, e, r) {
+          var n,
+            i = e - 32,
+            a = Bn,
+            o = 255 - t[i - 1];
+          for (n = 0; n < r; ++n) {
+            var s,
+              c = a,
+              u = o + t[e - 1];
+            for (s = 0; s < r; ++s) t[e + s] = c[u + t[i + s]];
+            e += 32;
+          }
+        }
+        function he(t, e) {
+          le(t, e, 4);
+        }
+        function fe(t, e) {
+          le(t, e, 8);
+        }
+        function de(t, e) {
+          le(t, e, 16);
+        }
+        function pe(t, e) {
+          var r;
+          for (r = 0; 16 > r; ++r) n(t, e + 32 * r, t, e - 32, 16);
+        }
+        function ge(t, e) {
+          var r;
+          for (r = 16; 0 < r; --r) i(t, e, t[e - 1], 16), e += 32;
+        }
+        function me(t, e, r) {
+          var n;
+          for (n = 0; 16 > n; ++n) i(e, r + 32 * n, t, 16);
+        }
+        function ve(t, e) {
+          var r,
+            n = 16;
+          for (r = 0; 16 > r; ++r) n += t[e - 1 + 32 * r] + t[e + r - 32];
+          me(n >> 5, t, e);
+        }
+        function be(t, e) {
+          var r,
+            n = 8;
+          for (r = 0; 16 > r; ++r) n += t[e - 1 + 32 * r];
+          me(n >> 4, t, e);
+        }
+        function ye(t, e) {
+          var r,
+            n = 8;
+          for (r = 0; 16 > r; ++r) n += t[e + r - 32];
+          me(n >> 4, t, e);
+        }
+        function we(t, e) {
+          me(128, t, e);
+        }
+        function Ne(t, e, r) {
+          return t + 2 * e + r + 2 >> 2;
+        }
+        function Le(t, e) {
+          var r,
+            i = e - 32;
+          i = new Uint8Array([Ne(t[i - 1], t[i + 0], t[i + 1]), Ne(t[i + 0], t[i + 1], t[i + 2]), Ne(t[i + 1], t[i + 2], t[i + 3]), Ne(t[i + 2], t[i + 3], t[i + 4])]);
+          for (r = 0; 4 > r; ++r) n(t, e + 32 * r, i, 0, i.length);
+        }
+        function Ae(t, e) {
+          var r = t[e - 1],
+            n = t[e - 1 + 32],
+            i = t[e - 1 + 64],
+            a = t[e - 1 + 96];
+          F(t, e + 0, 16843009 * Ne(t[e - 1 - 32], r, n)), F(t, e + 32, 16843009 * Ne(r, n, i)), F(t, e + 64, 16843009 * Ne(n, i, a)), F(t, e + 96, 16843009 * Ne(i, a, a));
+        }
+        function xe(t, e) {
+          var r,
+            n = 4;
+          for (r = 0; 4 > r; ++r) n += t[e + r - 32] + t[e - 1 + 32 * r];
+          for (n >>= 3, r = 0; 4 > r; ++r) i(t, e + 32 * r, n, 4);
+        }
+        function Se(t, e) {
+          var r = t[e - 1 + 0],
+            n = t[e - 1 + 32],
+            i = t[e - 1 + 64],
+            a = t[e - 1 - 32],
+            o = t[e + 0 - 32],
+            s = t[e + 1 - 32],
+            c = t[e + 2 - 32],
+            u = t[e + 3 - 32];
+          t[e + 0 + 96] = Ne(n, i, t[e - 1 + 96]), t[e + 1 + 96] = t[e + 0 + 64] = Ne(r, n, i), t[e + 2 + 96] = t[e + 1 + 64] = t[e + 0 + 32] = Ne(a, r, n), t[e + 3 + 96] = t[e + 2 + 64] = t[e + 1 + 32] = t[e + 0 + 0] = Ne(o, a, r), t[e + 3 + 64] = t[e + 2 + 32] = t[e + 1 + 0] = Ne(s, o, a), t[e + 3 + 32] = t[e + 2 + 0] = Ne(c, s, o), t[e + 3 + 0] = Ne(u, c, s);
+        }
+        function _e(t, e) {
+          var r = t[e + 1 - 32],
+            n = t[e + 2 - 32],
+            i = t[e + 3 - 32],
+            a = t[e + 4 - 32],
+            o = t[e + 5 - 32],
+            s = t[e + 6 - 32],
+            c = t[e + 7 - 32];
+          t[e + 0 + 0] = Ne(t[e + 0 - 32], r, n), t[e + 1 + 0] = t[e + 0 + 32] = Ne(r, n, i), t[e + 2 + 0] = t[e + 1 + 32] = t[e + 0 + 64] = Ne(n, i, a), t[e + 3 + 0] = t[e + 2 + 32] = t[e + 1 + 64] = t[e + 0 + 96] = Ne(i, a, o), t[e + 3 + 32] = t[e + 2 + 64] = t[e + 1 + 96] = Ne(a, o, s), t[e + 3 + 64] = t[e + 2 + 96] = Ne(o, s, c), t[e + 3 + 96] = Ne(s, c, c);
+        }
+        function Pe(t, e) {
+          var r = t[e - 1 + 0],
+            n = t[e - 1 + 32],
+            i = t[e - 1 + 64],
+            a = t[e - 1 - 32],
+            o = t[e + 0 - 32],
+            s = t[e + 1 - 32],
+            c = t[e + 2 - 32],
+            u = t[e + 3 - 32];
+          t[e + 0 + 0] = t[e + 1 + 64] = a + o + 1 >> 1, t[e + 1 + 0] = t[e + 2 + 64] = o + s + 1 >> 1, t[e + 2 + 0] = t[e + 3 + 64] = s + c + 1 >> 1, t[e + 3 + 0] = c + u + 1 >> 1, t[e + 0 + 96] = Ne(i, n, r), t[e + 0 + 64] = Ne(n, r, a), t[e + 0 + 32] = t[e + 1 + 96] = Ne(r, a, o), t[e + 1 + 32] = t[e + 2 + 96] = Ne(a, o, s), t[e + 2 + 32] = t[e + 3 + 96] = Ne(o, s, c), t[e + 3 + 32] = Ne(s, c, u);
+        }
+        function ke(t, e) {
+          var r = t[e + 0 - 32],
+            n = t[e + 1 - 32],
+            i = t[e + 2 - 32],
+            a = t[e + 3 - 32],
+            o = t[e + 4 - 32],
+            s = t[e + 5 - 32],
+            c = t[e + 6 - 32],
+            u = t[e + 7 - 32];
+          t[e + 0 + 0] = r + n + 1 >> 1, t[e + 1 + 0] = t[e + 0 + 64] = n + i + 1 >> 1, t[e + 2 + 0] = t[e + 1 + 64] = i + a + 1 >> 1, t[e + 3 + 0] = t[e + 2 + 64] = a + o + 1 >> 1, t[e + 0 + 32] = Ne(r, n, i), t[e + 1 + 32] = t[e + 0 + 96] = Ne(n, i, a), t[e + 2 + 32] = t[e + 1 + 96] = Ne(i, a, o), t[e + 3 + 32] = t[e + 2 + 96] = Ne(a, o, s), t[e + 3 + 64] = Ne(o, s, c), t[e + 3 + 96] = Ne(s, c, u);
+        }
+        function Fe(t, e) {
+          var r = t[e - 1 + 0],
+            n = t[e - 1 + 32],
+            i = t[e - 1 + 64],
+            a = t[e - 1 + 96];
+          t[e + 0 + 0] = r + n + 1 >> 1, t[e + 2 + 0] = t[e + 0 + 32] = n + i + 1 >> 1, t[e + 2 + 32] = t[e + 0 + 64] = i + a + 1 >> 1, t[e + 1 + 0] = Ne(r, n, i), t[e + 3 + 0] = t[e + 1 + 32] = Ne(n, i, a), t[e + 3 + 32] = t[e + 1 + 64] = Ne(i, a, a), t[e + 3 + 64] = t[e + 2 + 64] = t[e + 0 + 96] = t[e + 1 + 96] = t[e + 2 + 96] = t[e + 3 + 96] = a;
+        }
+        function Ie(t, e) {
+          var r = t[e - 1 + 0],
+            n = t[e - 1 + 32],
+            i = t[e - 1 + 64],
+            a = t[e - 1 + 96],
+            o = t[e - 1 - 32],
+            s = t[e + 0 - 32],
+            c = t[e + 1 - 32],
+            u = t[e + 2 - 32];
+          t[e + 0 + 0] = t[e + 2 + 32] = r + o + 1 >> 1, t[e + 0 + 32] = t[e + 2 + 64] = n + r + 1 >> 1, t[e + 0 + 64] = t[e + 2 + 96] = i + n + 1 >> 1, t[e + 0 + 96] = a + i + 1 >> 1, t[e + 3 + 0] = Ne(s, c, u), t[e + 2 + 0] = Ne(o, s, c), t[e + 1 + 0] = t[e + 3 + 32] = Ne(r, o, s), t[e + 1 + 32] = t[e + 3 + 64] = Ne(n, r, o), t[e + 1 + 64] = t[e + 3 + 96] = Ne(i, n, r), t[e + 1 + 96] = Ne(a, i, n);
+        }
+        function Ce(t, e) {
+          var r;
+          for (r = 0; 8 > r; ++r) n(t, e + 32 * r, t, e - 32, 8);
+        }
+        function je(t, e) {
+          var r;
+          for (r = 0; 8 > r; ++r) i(t, e, t[e - 1], 8), e += 32;
+        }
+        function Oe(t, e, r) {
+          var n;
+          for (n = 0; 8 > n; ++n) i(e, r + 32 * n, t, 8);
+        }
+        function Be(t, e) {
+          var r,
+            n = 8;
+          for (r = 0; 8 > r; ++r) n += t[e + r - 32] + t[e - 1 + 32 * r];
+          Oe(n >> 4, t, e);
+        }
+        function Me(t, e) {
+          var r,
+            n = 4;
+          for (r = 0; 8 > r; ++r) n += t[e + r - 32];
+          Oe(n >> 3, t, e);
+        }
+        function Ee(t, e) {
+          var r,
+            n = 4;
+          for (r = 0; 8 > r; ++r) n += t[e - 1 + 32 * r];
+          Oe(n >> 3, t, e);
+        }
+        function qe(t, e) {
+          Oe(128, t, e);
+        }
+        function De(t, e, r) {
+          var n = t[e - r],
+            i = t[e + 0],
+            a = 3 * (i - n) + jn[1020 + t[e - 2 * r] - t[e + r]],
+            o = On[112 + (a + 4 >> 3)];
+          t[e - r] = Bn[255 + n + On[112 + (a + 3 >> 3)]], t[e + 0] = Bn[255 + i - o];
+        }
+        function Re(t, e, r, n) {
+          var i = t[e + 0],
+            a = t[e + r];
+          return Mn[255 + t[e - 2 * r] - t[e - r]] > n || Mn[255 + a - i] > n;
+        }
+        function Te(t, e, r, n) {
+          return 4 * Mn[255 + t[e - r] - t[e + 0]] + Mn[255 + t[e - 2 * r] - t[e + r]] <= n;
+        }
+        function Ue(t, e, r, n, i) {
+          var a = t[e - 3 * r],
+            o = t[e - 2 * r],
+            s = t[e - r],
+            c = t[e + 0],
+            u = t[e + r],
+            l = t[e + 2 * r],
+            h = t[e + 3 * r];
+          return 4 * Mn[255 + s - c] + Mn[255 + o - u] > n ? 0 : Mn[255 + t[e - 4 * r] - a] <= i && Mn[255 + a - o] <= i && Mn[255 + o - s] <= i && Mn[255 + h - l] <= i && Mn[255 + l - u] <= i && Mn[255 + u - c] <= i;
+        }
+        function ze(t, e, r, n) {
+          var i = 2 * n + 1;
+          for (n = 0; 16 > n; ++n) Te(t, e + n, r, i) && De(t, e + n, r);
+        }
+        function He(t, e, r, n) {
+          var i = 2 * n + 1;
+          for (n = 0; 16 > n; ++n) Te(t, e + n * r, 1, i) && De(t, e + n * r, 1);
+        }
+        function We(t, e, r, n) {
+          var i;
+          for (i = 3; 0 < i; --i) ze(t, e += 4 * r, r, n);
+        }
+        function Ve(t, e, r, n) {
+          var i;
+          for (i = 3; 0 < i; --i) He(t, e += 4, r, n);
+        }
+        function Ge(t, e, r, n, i, a, o, s) {
+          for (a = 2 * a + 1; 0 < i--;) {
+            if (Ue(t, e, r, a, o)) if (Re(t, e, r, s)) De(t, e, r);else {
+              var c = t,
+                u = e,
+                l = r,
+                h = c[u - 2 * l],
+                f = c[u - l],
+                d = c[u + 0],
+                p = c[u + l],
+                g = c[u + 2 * l],
+                m = 27 * (b = jn[1020 + 3 * (d - f) + jn[1020 + h - p]]) + 63 >> 7,
+                v = 18 * b + 63 >> 7,
+                b = 9 * b + 63 >> 7;
+              c[u - 3 * l] = Bn[255 + c[u - 3 * l] + b], c[u - 2 * l] = Bn[255 + h + v], c[u - l] = Bn[255 + f + m], c[u + 0] = Bn[255 + d - m], c[u + l] = Bn[255 + p - v], c[u + 2 * l] = Bn[255 + g - b];
+            }
+            e += n;
+          }
+        }
+        function Ye(t, e, r, n, i, a, o, s) {
+          for (a = 2 * a + 1; 0 < i--;) {
+            if (Ue(t, e, r, a, o)) if (Re(t, e, r, s)) De(t, e, r);else {
+              var c = t,
+                u = e,
+                l = r,
+                h = c[u - l],
+                f = c[u + 0],
+                d = c[u + l],
+                p = On[112 + ((g = 3 * (f - h)) + 4 >> 3)],
+                g = On[112 + (g + 3 >> 3)],
+                m = p + 1 >> 1;
+              c[u - 2 * l] = Bn[255 + c[u - 2 * l] + m], c[u - l] = Bn[255 + h + g], c[u + 0] = Bn[255 + f - p], c[u + l] = Bn[255 + d - m];
+            }
+            e += n;
+          }
+        }
+        function Je(t, e, r, n, i, a) {
+          Ge(t, e, r, 1, 16, n, i, a);
+        }
+        function Xe(t, e, r, n, i, a) {
+          Ge(t, e, 1, r, 16, n, i, a);
+        }
+        function Ke(t, e, r, n, i, a) {
+          var o;
+          for (o = 3; 0 < o; --o) Ye(t, e += 4 * r, r, 1, 16, n, i, a);
+        }
+        function Ze(t, e, r, n, i, a) {
+          var o;
+          for (o = 3; 0 < o; --o) Ye(t, e += 4, 1, r, 16, n, i, a);
+        }
+        function $e(t, e, r, n, i, a, o, s) {
+          Ge(t, e, i, 1, 8, a, o, s), Ge(r, n, i, 1, 8, a, o, s);
+        }
+        function Qe(t, e, r, n, i, a, o, s) {
+          Ge(t, e, 1, i, 8, a, o, s), Ge(r, n, 1, i, 8, a, o, s);
+        }
+        function tr(t, e, r, n, i, a, o, s) {
+          Ye(t, e + 4 * i, i, 1, 8, a, o, s), Ye(r, n + 4 * i, i, 1, 8, a, o, s);
+        }
+        function er(t, e, r, n, i, a, o, s) {
+          Ye(t, e + 4, 1, i, 8, a, o, s), Ye(r, n + 4, 1, i, 8, a, o, s);
+        }
+        function rr() {
+          this.ba = new ot(), this.ec = [], this.cc = [], this.Mc = [], this.Dc = this.Nc = this.dc = this.fc = 0, this.Oa = new ct(), this.memory = 0, this.Ib = "OutputFunc", this.Jb = "OutputAlphaFunc", this.Nd = "OutputRowFunc";
+        }
+        function nr() {
+          this.data = [], this.offset = this.kd = this.ha = this.w = 0, this.na = [], this.xa = this.gb = this.Ja = this.Sa = this.P = 0;
+        }
+        function ir() {
+          this.nc = this.Ea = this.b = this.hc = 0, this.K = [], this.w = 0;
+        }
+        function ar() {
+          this.ua = 0, this.Wa = new M(), this.vb = new M(), this.md = this.xc = this.wc = 0, this.vc = [], this.Wb = 0, this.Ya = new d(), this.yc = new h();
+        }
+        function or() {
+          this.xb = this.a = 0, this.l = new Gt(), this.ca = new ot(), this.V = [], this.Ba = 0, this.Ta = [], this.Ua = 0, this.m = new N(), this.Pb = 0, this.wd = new N(), this.Ma = this.$ = this.C = this.i = this.c = this.xd = 0, this.s = new ar(), this.ab = 0, this.gc = o(4, ir), this.Oc = 0;
+        }
+        function sr() {
+          this.Lc = this.Z = this.$a = this.i = this.c = 0, this.l = new Gt(), this.ic = 0, this.ca = [], this.tb = 0, this.qd = null, this.rd = 0;
+        }
+        function cr(t, e, r, n, i, a, o) {
+          for (t = null == t ? 0 : t[e + 0], e = 0; e < o; ++e) i[a + e] = t + r[n + e] & 255, t = i[a + e];
+        }
+        function ur(t, e, r, n, i, a, o) {
+          var s;
+          if (null == t) cr(null, null, r, n, i, a, o);else for (s = 0; s < o; ++s) i[a + s] = t[e + s] + r[n + s] & 255;
+        }
+        function lr(t, e, r, n, i, a, o) {
+          if (null == t) cr(null, null, r, n, i, a, o);else {
+            var s,
+              c = t[e + 0],
+              u = c,
+              l = c;
+            for (s = 0; s < o; ++s) u = l + (c = t[e + s]) - u, l = r[n + s] + (-256 & u ? 0 > u ? 0 : 255 : u) & 255, u = c, i[a + s] = l;
+          }
+        }
+        function hr(t, r, i, o) {
+          var s = r.width,
+            c = r.o;
+          if (e(null != t && null != r), 0 > i || 0 >= o || i + o > c) return null;
+          if (!t.Cc) {
+            if (null == t.ga) {
+              var u;
+              if (t.ga = new sr(), (u = null == t.ga) || (u = r.width * r.o, e(0 == t.Gb.length), t.Gb = a(u), t.Uc = 0, null == t.Gb ? u = 0 : (t.mb = t.Gb, t.nb = t.Uc, t.rc = null, u = 1), u = !u), !u) {
+                u = t.ga;
+                var l = t.Fa,
+                  h = t.P,
+                  f = t.qc,
+                  d = t.mb,
+                  p = t.nb,
+                  g = h + 1,
+                  m = f - 1,
+                  b = u.l;
+                if (e(null != l && null != d && null != r), mi[0] = null, mi[1] = cr, mi[2] = ur, mi[3] = lr, u.ca = d, u.tb = p, u.c = r.width, u.i = r.height, e(0 < u.c && 0 < u.i), 1 >= f) r = 0;else if (u.$a = l[h + 0] >> 0 & 3, u.Z = l[h + 0] >> 2 & 3, u.Lc = l[h + 0] >> 4 & 3, h = l[h + 0] >> 6 & 3, 0 > u.$a || 1 < u.$a || 4 <= u.Z || 1 < u.Lc || h) r = 0;else if (b.put = dt, b.ac = ft, b.bc = pt, b.ma = u, b.width = r.width, b.height = r.height, b.Da = r.Da, b.v = r.v, b.va = r.va, b.j = r.j, b.o = r.o, u.$a) t: {
+                  e(1 == u.$a), r = kt();
+                  e: for (;;) {
+                    if (null == r) {
+                      r = 0;
+                      break t;
+                    }
+                    if (e(null != u), u.mc = r, r.c = u.c, r.i = u.i, r.l = u.l, r.l.ma = u, r.l.width = u.c, r.l.height = u.i, r.a = 0, v(r.m, l, g, m), !Ft(u.c, u.i, 1, r, null)) break e;
+                    if (1 == r.ab && 3 == r.gc[0].hc && At(r.s) ? (u.ic = 1, l = r.c * r.i, r.Ta = null, r.Ua = 0, r.V = a(l), r.Ba = 0, null == r.V ? (r.a = 1, r = 0) : r = 1) : (u.ic = 0, r = It(r, u.c)), !r) break e;
+                    r = 1;
+                    break t;
+                  }
+                  u.mc = null, r = 0;
+                } else r = m >= u.c * u.i;
+                u = !r;
+              }
+              if (u) return null;
+              1 != t.ga.Lc ? t.Ga = 0 : o = c - i;
+            }
+            e(null != t.ga), e(i + o <= c);
+            t: {
+              if (r = (l = t.ga).c, c = l.l.o, 0 == l.$a) {
+                if (g = t.rc, m = t.Vc, b = t.Fa, h = t.P + 1 + i * r, f = t.mb, d = t.nb + i * r, e(h <= t.P + t.qc), 0 != l.Z) for (e(null != mi[l.Z]), u = 0; u < o; ++u) mi[l.Z](g, m, b, h, f, d, r), g = f, m = d, d += r, h += r;else for (u = 0; u < o; ++u) n(f, d, b, h, r), g = f, m = d, d += r, h += r;
+                t.rc = g, t.Vc = m;
+              } else {
+                if (e(null != l.mc), r = i + o, e(null != (u = l.mc)), e(r <= u.i), u.C >= r) r = 1;else if (l.ic || mr(), l.ic) {
+                  l = u.V, g = u.Ba, m = u.c;
+                  var y = u.i,
+                    w = (b = 1, h = u.$ / m, f = u.$ % m, d = u.m, p = u.s, u.$),
+                    N = m * y,
+                    L = m * r,
+                    x = p.wc,
+                    _ = w < L ? wt(p, f, h) : null;
+                  e(w <= N), e(r <= y), e(At(p));
+                  e: for (;;) {
+                    for (; !d.h && w < L;) {
+                      if (f & x || (_ = wt(p, f, h)), e(null != _), S(d), 256 > (y = bt(_.G[0], _.H[0], d))) l[g + w] = y, ++w, ++f >= m && (f = 0, ++h <= r && !(h % 16) && St(u, h));else {
+                        if (!(280 > y)) {
+                          b = 0;
+                          break e;
+                        }
+                        y = mt(y - 256, d);
+                        var P,
+                          k = bt(_.G[4], _.H[4], d);
+                        if (S(d), !(w >= (k = vt(m, k = mt(k, d))) && N - w >= y)) {
+                          b = 0;
+                          break e;
+                        }
+                        for (P = 0; P < y; ++P) l[g + w + P] = l[g + w + P - k];
+                        for (w += y, f += y; f >= m;) f -= m, ++h <= r && !(h % 16) && St(u, h);
+                        w < L && f & x && (_ = wt(p, f, h));
+                      }
+                      e(d.h == A(d));
+                    }
+                    St(u, h > r ? r : h);
+                    break e;
+                  }
+                  !b || d.h && w < N ? (b = 0, u.a = d.h ? 5 : 3) : u.$ = w, r = b;
+                } else r = _t(u, u.V, u.Ba, u.c, u.i, r, Ct);
+                if (!r) {
+                  o = 0;
+                  break t;
+                }
+              }
+              i + o >= c && (t.Cc = 1), o = 1;
+            }
+            if (!o) return null;
+            if (t.Cc && (null != (o = t.ga) && (o.mc = null), t.ga = null, 0 < t.Ga)) return alert("todo:WebPDequantizeLevels"), null;
+          }
+          return t.nb + i * s;
+        }
+        function fr(t, e, r, n, i, a) {
+          for (; 0 < i--;) {
+            var o,
+              s = t,
+              c = e + (r ? 1 : 0),
+              u = t,
+              l = e + (r ? 0 : 3);
+            for (o = 0; o < n; ++o) {
+              var h = u[l + 4 * o];
+              255 != h && (h *= 32897, s[c + 4 * o + 0] = s[c + 4 * o + 0] * h >> 23, s[c + 4 * o + 1] = s[c + 4 * o + 1] * h >> 23, s[c + 4 * o + 2] = s[c + 4 * o + 2] * h >> 23);
+            }
+            e += a;
+          }
+        }
+        function dr(t, e, r, n, i) {
+          for (; 0 < n--;) {
+            var a;
+            for (a = 0; a < r; ++a) {
+              var o = t[e + 2 * a + 0],
+                s = 15 & (u = t[e + 2 * a + 1]),
+                c = 4369 * s,
+                u = (240 & u | u >> 4) * c >> 16;
+              t[e + 2 * a + 0] = (240 & o | o >> 4) * c >> 16 & 240 | (15 & o | o << 4) * c >> 16 >> 4 & 15, t[e + 2 * a + 1] = 240 & u | s;
+            }
+            e += i;
+          }
+        }
+        function pr(t, e, r, n, i, a, o, s) {
+          var c,
+            u,
+            l = 255;
+          for (u = 0; u < i; ++u) {
+            for (c = 0; c < n; ++c) {
+              var h = t[e + c];
+              a[o + 4 * c] = h, l &= h;
+            }
+            e += r, o += s;
+          }
+          return 255 != l;
+        }
+        function gr(t, e, r, n, i) {
+          var a;
+          for (a = 0; a < i; ++a) r[n + a] = t[e + a] >> 8;
+        }
+        function mr() {
+          An = fr, xn = dr, Sn = pr, _n = gr;
+        }
+        function vr(r, n, i) {
+          t[r] = function (t, r, a, o, s, c, u, l, h, f, d, p, g, m, v, b, y) {
+            var w,
+              N = y - 1 >> 1,
+              L = s[c + 0] | u[l + 0] << 16,
+              A = h[f + 0] | d[p + 0] << 16;
+            e(null != t);
+            var x = 3 * L + A + 131074 >> 2;
+            for (n(t[r + 0], 255 & x, x >> 16, g, m), null != a && (x = 3 * A + L + 131074 >> 2, n(a[o + 0], 255 & x, x >> 16, v, b)), w = 1; w <= N; ++w) {
+              var S = s[c + w] | u[l + w] << 16,
+                _ = h[f + w] | d[p + w] << 16,
+                P = L + S + A + _ + 524296,
+                k = P + 2 * (S + A) >> 3;
+              x = k + L >> 1, L = (P = P + 2 * (L + _) >> 3) + S >> 1, n(t[r + 2 * w - 1], 255 & x, x >> 16, g, m + (2 * w - 1) * i), n(t[r + 2 * w - 0], 255 & L, L >> 16, g, m + (2 * w - 0) * i), null != a && (x = P + A >> 1, L = k + _ >> 1, n(a[o + 2 * w - 1], 255 & x, x >> 16, v, b + (2 * w - 1) * i), n(a[o + 2 * w + 0], 255 & L, L >> 16, v, b + (2 * w + 0) * i)), L = S, A = _;
+            }
+            1 & y || (x = 3 * L + A + 131074 >> 2, n(t[r + y - 1], 255 & x, x >> 16, g, m + (y - 1) * i), null != a && (x = 3 * A + L + 131074 >> 2, n(a[o + y - 1], 255 & x, x >> 16, v, b + (y - 1) * i)));
+          };
+        }
+        function br() {
+          vi[En] = bi, vi[qn] = wi, vi[Dn] = yi, vi[Rn] = Ni, vi[Tn] = Li, vi[Un] = Ai, vi[zn] = xi, vi[Hn] = wi, vi[Wn] = Ni, vi[Vn] = Li, vi[Gn] = Ai;
+        }
+        function yr(t) {
+          return t & ~Ii ? 0 > t ? 0 : 255 : t >> Fi;
+        }
+        function wr(t, e) {
+          return yr((19077 * t >> 8) + (26149 * e >> 8) - 14234);
+        }
+        function Nr(t, e, r) {
+          return yr((19077 * t >> 8) - (6419 * e >> 8) - (13320 * r >> 8) + 8708);
+        }
+        function Lr(t, e) {
+          return yr((19077 * t >> 8) + (33050 * e >> 8) - 17685);
+        }
+        function Ar(t, e, r, n, i) {
+          n[i + 0] = wr(t, r), n[i + 1] = Nr(t, e, r), n[i + 2] = Lr(t, e);
+        }
+        function xr(t, e, r, n, i) {
+          n[i + 0] = Lr(t, e), n[i + 1] = Nr(t, e, r), n[i + 2] = wr(t, r);
+        }
+        function Sr(t, e, r, n, i) {
+          var a = Nr(t, e, r);
+          e = a << 3 & 224 | Lr(t, e) >> 3, n[i + 0] = 248 & wr(t, r) | a >> 5, n[i + 1] = e;
+        }
+        function _r(t, e, r, n, i) {
+          var a = 240 & Lr(t, e) | 15;
+          n[i + 0] = 240 & wr(t, r) | Nr(t, e, r) >> 4, n[i + 1] = a;
+        }
+        function Pr(t, e, r, n, i) {
+          n[i + 0] = 255, Ar(t, e, r, n, i + 1);
+        }
+        function kr(t, e, r, n, i) {
+          xr(t, e, r, n, i), n[i + 3] = 255;
+        }
+        function Fr(t, e, r, n, i) {
+          Ar(t, e, r, n, i), n[i + 3] = 255;
+        }
+        function Vt(t, e) {
+          return 0 > t ? 0 : t > e ? e : t;
+        }
+        function Ir(e, r, n) {
+          t[e] = function (t, e, i, a, o, s, c, u, l) {
+            for (var h = u + (-2 & l) * n; u != h;) r(t[e + 0], i[a + 0], o[s + 0], c, u), r(t[e + 1], i[a + 0], o[s + 0], c, u + n), e += 2, ++a, ++s, u += 2 * n;
+            1 & l && r(t[e + 0], i[a + 0], o[s + 0], c, u);
+          };
+        }
+        function Cr(t, e, r) {
+          return 0 == r ? 0 == t ? 0 == e ? 6 : 5 : 0 == e ? 4 : 0 : r;
+        }
+        function jr(t, e, r, n, i) {
+          switch (t >>> 30) {
+            case 3:
+              on(e, r, n, i, 0);
+              break;
+            case 2:
+              sn(e, r, n, i);
+              break;
+            case 1:
+              un(e, r, n, i);
+          }
+        }
+        function Or(t, e) {
+          var r,
+            a,
+            o = e.M,
+            s = e.Nb,
+            c = t.oc,
+            u = t.pc + 40,
+            l = t.oc,
+            h = t.pc + 584,
+            f = t.oc,
+            d = t.pc + 600;
+          for (r = 0; 16 > r; ++r) c[u + 32 * r - 1] = 129;
+          for (r = 0; 8 > r; ++r) l[h + 32 * r - 1] = 129, f[d + 32 * r - 1] = 129;
+          for (0 < o ? c[u - 1 - 32] = l[h - 1 - 32] = f[d - 1 - 32] = 129 : (i(c, u - 32 - 1, 127, 21), i(l, h - 32 - 1, 127, 9), i(f, d - 32 - 1, 127, 9)), a = 0; a < t.za; ++a) {
+            var p = e.ya[e.aa + a];
+            if (0 < a) {
+              for (r = -1; 16 > r; ++r) n(c, u + 32 * r - 4, c, u + 32 * r + 12, 4);
+              for (r = -1; 8 > r; ++r) n(l, h + 32 * r - 4, l, h + 32 * r + 4, 4), n(f, d + 32 * r - 4, f, d + 32 * r + 4, 4);
+            }
+            var g = t.Gd,
+              m = t.Hd + a,
+              v = p.ad,
+              b = p.Hc;
+            if (0 < o && (n(c, u - 32, g[m].y, 0, 16), n(l, h - 32, g[m].f, 0, 8), n(f, d - 32, g[m].ea, 0, 8)), p.Za) {
+              var y = c,
+                w = u - 32 + 16;
+              for (0 < o && (a >= t.za - 1 ? i(y, w, g[m].y[15], 4) : n(y, w, g[m + 1].y, 0, 4)), r = 0; 4 > r; r++) y[w + 128 + r] = y[w + 256 + r] = y[w + 384 + r] = y[w + 0 + r];
+              for (r = 0; 16 > r; ++r, b <<= 2) y = c, w = u + Di[r], fi[p.Ob[r]](y, w), jr(b, v, 16 * +r, y, w);
+            } else if (y = Cr(a, o, p.Ob[0]), hi[y](c, u), 0 != b) for (r = 0; 16 > r; ++r, b <<= 2) jr(b, v, 16 * +r, c, u + Di[r]);
+            for (r = p.Gc, y = Cr(a, o, p.Dd), di[y](l, h), di[y](f, d), b = v, y = l, w = h, 255 & (p = r >> 0) && (170 & p ? cn(b, 256, y, w) : ln(b, 256, y, w)), p = f, b = d, 255 & (r >>= 8) && (170 & r ? cn(v, 320, p, b) : ln(v, 320, p, b)), o < t.Ub - 1 && (n(g[m].y, 0, c, u + 480, 16), n(g[m].f, 0, l, h + 224, 8), n(g[m].ea, 0, f, d + 224, 8)), r = 8 * s * t.B, g = t.sa, m = t.ta + 16 * a + 16 * s * t.R, v = t.qa, p = t.ra + 8 * a + r, b = t.Ha, y = t.Ia + 8 * a + r, r = 0; 16 > r; ++r) n(g, m + r * t.R, c, u + 32 * r, 16);
+            for (r = 0; 8 > r; ++r) n(v, p + r * t.B, l, h + 32 * r, 8), n(b, y + r * t.B, f, d + 32 * r, 8);
+          }
+        }
+        function Br(t, n, i, a, o, s, c, u, l) {
+          var h = [0],
+            f = [0],
+            d = 0,
+            p = null != l ? l.kd : 0,
+            g = null != l ? l : new nr();
+          if (null == t || 12 > i) return 7;
+          g.data = t, g.w = n, g.ha = i, n = [n], i = [i], g.gb = [g.gb];
+          t: {
+            var m = n,
+              b = i,
+              y = g.gb;
+            if (e(null != t), e(null != b), e(null != y), y[0] = 0, 12 <= b[0] && !r(t, m[0], "RIFF")) {
+              if (r(t, m[0] + 8, "WEBP")) {
+                y = 3;
+                break t;
+              }
+              var w = j(t, m[0] + 4);
+              if (12 > w || 4294967286 < w) {
+                y = 3;
+                break t;
+              }
+              if (p && w > b[0] - 8) {
+                y = 7;
+                break t;
+              }
+              y[0] = w, m[0] += 12, b[0] -= 12;
+            }
+            y = 0;
+          }
+          if (0 != y) return y;
+          for (w = 0 < g.gb[0], i = i[0];;) {
+            t: {
+              var L = t;
+              b = n, y = i;
+              var A = h,
+                x = f,
+                S = m = [0];
+              if ((k = d = [d])[0] = 0, 8 > y[0]) y = 7;else {
+                if (!r(L, b[0], "VP8X")) {
+                  if (10 != j(L, b[0] + 4)) {
+                    y = 3;
+                    break t;
+                  }
+                  if (18 > y[0]) {
+                    y = 7;
+                    break t;
+                  }
+                  var _ = j(L, b[0] + 8),
+                    P = 1 + C(L, b[0] + 12);
+                  if (2147483648 <= P * (L = 1 + C(L, b[0] + 15))) {
+                    y = 3;
+                    break t;
+                  }
+                  null != S && (S[0] = _), null != A && (A[0] = P), null != x && (x[0] = L), b[0] += 18, y[0] -= 18, k[0] = 1;
+                }
+                y = 0;
+              }
+            }
+            if (d = d[0], m = m[0], 0 != y) return y;
+            if (b = !!(2 & m), !w && d) return 3;
+            if (null != s && (s[0] = !!(16 & m)), null != c && (c[0] = b), null != u && (u[0] = 0), c = h[0], m = f[0], d && b && null == l) {
+              y = 0;
+              break;
+            }
+            if (4 > i) {
+              y = 7;
+              break;
+            }
+            if (w && d || !w && !d && !r(t, n[0], "ALPH")) {
+              i = [i], g.na = [g.na], g.P = [g.P], g.Sa = [g.Sa];
+              t: {
+                _ = t, y = n, w = i;
+                var k = g.gb;
+                A = g.na, x = g.P, S = g.Sa;
+                P = 22, e(null != _), e(null != w), L = y[0];
+                var F = w[0];
+                for (e(null != A), e(null != S), A[0] = null, x[0] = null, S[0] = 0;;) {
+                  if (y[0] = L, w[0] = F, 8 > F) {
+                    y = 7;
+                    break t;
+                  }
+                  var I = j(_, L + 4);
+                  if (4294967286 < I) {
+                    y = 3;
+                    break t;
+                  }
+                  var O = 8 + I + 1 & -2;
+                  if (P += O, 0 < k && P > k) {
+                    y = 3;
+                    break t;
+                  }
+                  if (!r(_, L, "VP8 ") || !r(_, L, "VP8L")) {
+                    y = 0;
+                    break t;
+                  }
+                  if (F[0] < O) {
+                    y = 7;
+                    break t;
+                  }
+                  r(_, L, "ALPH") || (A[0] = _, x[0] = L + 8, S[0] = I), L += O, F -= O;
+                }
+              }
+              if (i = i[0], g.na = g.na[0], g.P = g.P[0], g.Sa = g.Sa[0], 0 != y) break;
+            }
+            i = [i], g.Ja = [g.Ja], g.xa = [g.xa];
+            t: if (k = t, y = n, w = i, A = g.gb[0], x = g.Ja, S = g.xa, _ = y[0], L = !r(k, _, "VP8 "), P = !r(k, _, "VP8L"), e(null != k), e(null != w), e(null != x), e(null != S), 8 > w[0]) y = 7;else {
+              if (L || P) {
+                if (k = j(k, _ + 4), 12 <= A && k > A - 12) {
+                  y = 3;
+                  break t;
+                }
+                if (p && k > w[0] - 8) {
+                  y = 7;
+                  break t;
+                }
+                x[0] = k, y[0] += 8, w[0] -= 8, S[0] = P;
+              } else S[0] = 5 <= w[0] && 47 == k[_ + 0] && !(k[_ + 4] >> 5), x[0] = w[0];
+              y = 0;
+            }
+            if (i = i[0], g.Ja = g.Ja[0], g.xa = g.xa[0], n = n[0], 0 != y) break;
+            if (4294967286 < g.Ja) return 3;
+            if (null == u || b || (u[0] = g.xa ? 2 : 1), c = [c], m = [m], g.xa) {
+              if (5 > i) {
+                y = 7;
+                break;
+              }
+              u = c, p = m, b = s, null == t || 5 > i ? t = 0 : 5 <= i && 47 == t[n + 0] && !(t[n + 4] >> 5) ? (w = [0], k = [0], A = [0], v(x = new N(), t, n, i), gt(x, w, k, A) ? (null != u && (u[0] = w[0]), null != p && (p[0] = k[0]), null != b && (b[0] = A[0]), t = 1) : t = 0) : t = 0;
+            } else {
+              if (10 > i) {
+                y = 7;
+                break;
+              }
+              u = m, null == t || 10 > i || !Xt(t, n + 3, i - 3) ? t = 0 : (p = t[n + 0] | t[n + 1] << 8 | t[n + 2] << 16, b = 16383 & (t[n + 7] << 8 | t[n + 6]), t = 16383 & (t[n + 9] << 8 | t[n + 8]), 1 & p || 3 < (p >> 1 & 7) || !(p >> 4 & 1) || p >> 5 >= g.Ja || !b || !t ? t = 0 : (c && (c[0] = b), u && (u[0] = t), t = 1));
+            }
+            if (!t) return 3;
+            if (c = c[0], m = m[0], d && (h[0] != c || f[0] != m)) return 3;
+            null != l && (l[0] = g, l.offset = n - l.w, e(4294967286 > n - l.w), e(l.offset == l.ha - i));
+            break;
+          }
+          return 0 == y || 7 == y && d && null == l ? (null != s && (s[0] |= null != g.na && 0 < g.na.length), null != a && (a[0] = c), null != o && (o[0] = m), 0) : y;
+        }
+        function Mr(t, e, r) {
+          var n = e.width,
+            i = e.height,
+            a = 0,
+            o = 0,
+            s = n,
+            c = i;
+          if (e.Da = null != t && 0 < t.Da, e.Da && (s = t.cd, c = t.bd, a = t.v, o = t.j, 11 > r || (a &= -2, o &= -2), 0 > a || 0 > o || 0 >= s || 0 >= c || a + s > n || o + c > i)) return 0;
+          if (e.v = a, e.j = o, e.va = a + s, e.o = o + c, e.U = s, e.T = c, e.da = null != t && 0 < t.da, e.da) {
+            if (!E(s, c, r = [t.ib], a = [t.hb])) return 0;
+            e.ib = r[0], e.hb = a[0];
+          }
+          return e.ob = null != t && t.ob, e.Kb = null == t || !t.Sd, e.da && (e.ob = e.ib < 3 * n / 4 && e.hb < 3 * i / 4, e.Kb = 0), 1;
+        }
+        function Er(t) {
+          if (null == t) return 2;
+          if (11 > t.S) {
+            var e = t.f.RGBA;
+            e.fb += (t.height - 1) * e.A, e.A = -e.A;
+          } else e = t.f.kb, t = t.height, e.O += (t - 1) * e.fa, e.fa = -e.fa, e.N += (t - 1 >> 1) * e.Ab, e.Ab = -e.Ab, e.W += (t - 1 >> 1) * e.Db, e.Db = -e.Db, null != e.F && (e.J += (t - 1) * e.lb, e.lb = -e.lb);
+          return 0;
+        }
+        function qr(t, e, r, n) {
+          if (null == n || 0 >= t || 0 >= e) return 2;
+          if (null != r) {
+            if (r.Da) {
+              var i = r.cd,
+                o = r.bd,
+                s = -2 & r.v,
+                c = -2 & r.j;
+              if (0 > s || 0 > c || 0 >= i || 0 >= o || s + i > t || c + o > e) return 2;
+              t = i, e = o;
+            }
+            if (r.da) {
+              if (!E(t, e, i = [r.ib], o = [r.hb])) return 2;
+              t = i[0], e = o[0];
+            }
+          }
+          n.width = t, n.height = e;
+          t: {
+            var u = n.width,
+              l = n.height;
+            if (t = n.S, 0 >= u || 0 >= l || !(t >= En && 13 > t)) t = 2;else {
+              if (0 >= n.Rd && null == n.sd) {
+                s = o = i = e = 0;
+                var h = (c = u * zi[t]) * l;
+                if (11 > t || (o = (l + 1) / 2 * (e = (u + 1) / 2), 12 == t && (s = (i = u) * l)), null == (l = a(h + 2 * o + s))) {
+                  t = 1;
+                  break t;
+                }
+                n.sd = l, 11 > t ? ((u = n.f.RGBA).eb = l, u.fb = 0, u.A = c, u.size = h) : ((u = n.f.kb).y = l, u.O = 0, u.fa = c, u.Fd = h, u.f = l, u.N = 0 + h, u.Ab = e, u.Cd = o, u.ea = l, u.W = 0 + h + o, u.Db = e, u.Ed = o, 12 == t && (u.F = l, u.J = 0 + h + 2 * o), u.Tc = s, u.lb = i);
+              }
+              if (e = 1, i = n.S, o = n.width, s = n.height, i >= En && 13 > i) {
+                if (11 > i) t = n.f.RGBA, e &= (c = Math.abs(t.A)) * (s - 1) + o <= t.size, e &= c >= o * zi[i], e &= null != t.eb;else {
+                  t = n.f.kb, c = (o + 1) / 2, h = (s + 1) / 2, u = Math.abs(t.fa);
+                  l = Math.abs(t.Ab);
+                  var f = Math.abs(t.Db),
+                    d = Math.abs(t.lb),
+                    p = d * (s - 1) + o;
+                  e &= u * (s - 1) + o <= t.Fd, e &= l * (h - 1) + c <= t.Cd, e = (e &= f * (h - 1) + c <= t.Ed) & u >= o & l >= c & f >= c, e &= null != t.y, e &= null != t.f, e &= null != t.ea, 12 == i && (e &= d >= o, e &= p <= t.Tc, e &= null != t.F);
+                }
+              } else e = 0;
+              t = e ? 0 : 2;
+            }
+          }
+          return 0 != t || null != r && r.fd && (t = Er(n)), t;
+        }
+        var Dr = 64,
+          Rr = [0, 1, 3, 7, 15, 31, 63, 127, 255, 511, 1023, 2047, 4095, 8191, 16383, 32767, 65535, 131071, 262143, 524287, 1048575, 2097151, 4194303, 8388607, 16777215],
+          Tr = 24,
+          Ur = 32,
+          zr = 8,
+          Hr = [0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7];
+        R("Predictor0", "PredictorAdd0"), t.Predictor0 = function () {
+          return 4278190080;
+        }, t.Predictor1 = function (t) {
+          return t;
+        }, t.Predictor2 = function (t, e, r) {
+          return e[r + 0];
+        }, t.Predictor3 = function (t, e, r) {
+          return e[r + 1];
+        }, t.Predictor4 = function (t, e, r) {
+          return e[r - 1];
+        }, t.Predictor5 = function (t, e, r) {
+          return U(U(t, e[r + 1]), e[r + 0]);
+        }, t.Predictor6 = function (t, e, r) {
+          return U(t, e[r - 1]);
+        }, t.Predictor7 = function (t, e, r) {
+          return U(t, e[r + 0]);
+        }, t.Predictor8 = function (t, e, r) {
+          return U(e[r - 1], e[r + 0]);
+        }, t.Predictor9 = function (t, e, r) {
+          return U(e[r + 0], e[r + 1]);
+        }, t.Predictor10 = function (t, e, r) {
+          return U(U(t, e[r - 1]), U(e[r + 0], e[r + 1]));
+        }, t.Predictor11 = function (t, e, r) {
+          var n = e[r + 0];
+          return 0 >= W(n >> 24 & 255, t >> 24 & 255, (e = e[r - 1]) >> 24 & 255) + W(n >> 16 & 255, t >> 16 & 255, e >> 16 & 255) + W(n >> 8 & 255, t >> 8 & 255, e >> 8 & 255) + W(255 & n, 255 & t, 255 & e) ? n : t;
+        }, t.Predictor12 = function (t, e, r) {
+          var n = e[r + 0];
+          return (z((t >> 24 & 255) + (n >> 24 & 255) - ((e = e[r - 1]) >> 24 & 255)) << 24 | z((t >> 16 & 255) + (n >> 16 & 255) - (e >> 16 & 255)) << 16 | z((t >> 8 & 255) + (n >> 8 & 255) - (e >> 8 & 255)) << 8 | z((255 & t) + (255 & n) - (255 & e))) >>> 0;
+        }, t.Predictor13 = function (t, e, r) {
+          var n = e[r - 1];
+          return (H((t = U(t, e[r + 0])) >> 24 & 255, n >> 24 & 255) << 24 | H(t >> 16 & 255, n >> 16 & 255) << 16 | H(t >> 8 & 255, n >> 8 & 255) << 8 | H(t >> 0 & 255, n >> 0 & 255)) >>> 0;
+        };
+        var Wr = t.PredictorAdd0;
+        t.PredictorAdd1 = V, R("Predictor2", "PredictorAdd2"), R("Predictor3", "PredictorAdd3"), R("Predictor4", "PredictorAdd4"), R("Predictor5", "PredictorAdd5"), R("Predictor6", "PredictorAdd6"), R("Predictor7", "PredictorAdd7"), R("Predictor8", "PredictorAdd8"), R("Predictor9", "PredictorAdd9"), R("Predictor10", "PredictorAdd10"), R("Predictor11", "PredictorAdd11"), R("Predictor12", "PredictorAdd12"), R("Predictor13", "PredictorAdd13");
+        var Vr = t.PredictorAdd2;
+        X("ColorIndexInverseTransform", "MapARGB", "32b", function (t) {
+          return t >> 8 & 255;
+        }, function (t) {
+          return t;
+        }), X("VP8LColorIndexInverseTransformAlpha", "MapAlpha", "8b", function (t) {
+          return t;
+        }, function (t) {
+          return t >> 8 & 255;
+        });
+        var Gr,
+          Yr = t.ColorIndexInverseTransform,
+          Jr = t.MapARGB,
+          Xr = t.VP8LColorIndexInverseTransformAlpha,
+          Kr = t.MapAlpha,
+          Zr = t.VP8LPredictorsAdd = [];
+        Zr.length = 16, (t.VP8LPredictors = []).length = 16, (t.VP8LPredictorsAdd_C = []).length = 16, (t.VP8LPredictors_C = []).length = 16;
+        var $r,
+          Qr,
+          tn,
+          en,
+          rn,
+          nn,
+          an,
+          on,
+          sn,
+          cn,
+          un,
+          ln,
+          hn,
+          fn,
+          dn,
+          pn,
+          gn,
+          mn,
+          vn,
+          bn,
+          yn,
+          wn,
+          Nn,
+          Ln,
+          An,
+          xn,
+          Sn,
+          _n,
+          Pn = a(511),
+          kn = a(2041),
+          Fn = a(225),
+          In = a(767),
+          Cn = 0,
+          jn = kn,
+          On = Fn,
+          Bn = In,
+          Mn = Pn,
+          En = 0,
+          qn = 1,
+          Dn = 2,
+          Rn = 3,
+          Tn = 4,
+          Un = 5,
+          zn = 6,
+          Hn = 7,
+          Wn = 8,
+          Vn = 9,
+          Gn = 10,
+          Yn = [2, 3, 7],
+          Jn = [3, 3, 11],
+          Xn = [280, 256, 256, 256, 40],
+          Kn = [0, 1, 1, 1, 0],
+          Zn = [17, 18, 0, 1, 2, 3, 4, 5, 16, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+          $n = [24, 7, 23, 25, 40, 6, 39, 41, 22, 26, 38, 42, 56, 5, 55, 57, 21, 27, 54, 58, 37, 43, 72, 4, 71, 73, 20, 28, 53, 59, 70, 74, 36, 44, 88, 69, 75, 52, 60, 3, 87, 89, 19, 29, 86, 90, 35, 45, 68, 76, 85, 91, 51, 61, 104, 2, 103, 105, 18, 30, 102, 106, 34, 46, 84, 92, 67, 77, 101, 107, 50, 62, 120, 1, 119, 121, 83, 93, 17, 31, 100, 108, 66, 78, 118, 122, 33, 47, 117, 123, 49, 63, 99, 109, 82, 94, 0, 116, 124, 65, 79, 16, 32, 98, 110, 48, 115, 125, 81, 95, 64, 114, 126, 97, 111, 80, 113, 127, 96, 112],
+          Qn = [2954, 2956, 2958, 2962, 2970, 2986, 3018, 3082, 3212, 3468, 3980, 5004],
+          ti = 8,
+          ei = [4, 5, 6, 7, 8, 9, 10, 10, 11, 12, 13, 14, 15, 16, 17, 17, 18, 19, 20, 20, 21, 21, 22, 22, 23, 23, 24, 25, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 91, 93, 95, 96, 98, 100, 101, 102, 104, 106, 108, 110, 112, 114, 116, 118, 122, 124, 126, 128, 130, 132, 134, 136, 138, 140, 143, 145, 148, 151, 154, 157],
+          ri = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 60, 62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94, 96, 98, 100, 102, 104, 106, 108, 110, 112, 114, 116, 119, 122, 125, 128, 131, 134, 137, 140, 143, 146, 149, 152, 155, 158, 161, 164, 167, 170, 173, 177, 181, 185, 189, 193, 197, 201, 205, 209, 213, 217, 221, 225, 229, 234, 239, 245, 249, 254, 259, 264, 269, 274, 279, 284],
+          ni = null,
+          ii = [[173, 148, 140, 0], [176, 155, 140, 135, 0], [180, 157, 141, 134, 130, 0], [254, 254, 243, 230, 196, 177, 153, 140, 133, 130, 129, 0]],
+          ai = [0, 1, 4, 8, 5, 2, 3, 6, 9, 12, 13, 10, 7, 11, 14, 15],
+          oi = [-0, 1, -1, 2, -2, 3, 4, 6, -3, 5, -4, -5, -6, 7, -7, 8, -8, -9],
+          si = [[[[128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128], [128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128], [128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128]], [[253, 136, 254, 255, 228, 219, 128, 128, 128, 128, 128], [189, 129, 242, 255, 227, 213, 255, 219, 128, 128, 128], [106, 126, 227, 252, 214, 209, 255, 255, 128, 128, 128]], [[1, 98, 248, 255, 236, 226, 255, 255, 128, 128, 128], [181, 133, 238, 254, 221, 234, 255, 154, 128, 128, 128], [78, 134, 202, 247, 198, 180, 255, 219, 128, 128, 128]], [[1, 185, 249, 255, 243, 255, 128, 128, 128, 128, 128], [184, 150, 247, 255, 236, 224, 128, 128, 128, 128, 128], [77, 110, 216, 255, 236, 230, 128, 128, 128, 128, 128]], [[1, 101, 251, 255, 241, 255, 128, 128, 128, 128, 128], [170, 139, 241, 252, 236, 209, 255, 255, 128, 128, 128], [37, 116, 196, 243, 228, 255, 255, 255, 128, 128, 128]], [[1, 204, 254, 255, 245, 255, 128, 128, 128, 128, 128], [207, 160, 250, 255, 238, 128, 128, 128, 128, 128, 128], [102, 103, 231, 255, 211, 171, 128, 128, 128, 128, 128]], [[1, 152, 252, 255, 240, 255, 128, 128, 128, 128, 128], [177, 135, 243, 255, 234, 225, 128, 128, 128, 128, 128], [80, 129, 211, 255, 194, 224, 128, 128, 128, 128, 128]], [[1, 1, 255, 128, 128, 128, 128, 128, 128, 128, 128], [246, 1, 255, 128, 128, 128, 128, 128, 128, 128, 128], [255, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128]]], [[[198, 35, 237, 223, 193, 187, 162, 160, 145, 155, 62], [131, 45, 198, 221, 172, 176, 220, 157, 252, 221, 1], [68, 47, 146, 208, 149, 167, 221, 162, 255, 223, 128]], [[1, 149, 241, 255, 221, 224, 255, 255, 128, 128, 128], [184, 141, 234, 253, 222, 220, 255, 199, 128, 128, 128], [81, 99, 181, 242, 176, 190, 249, 202, 255, 255, 128]], [[1, 129, 232, 253, 214, 197, 242, 196, 255, 255, 128], [99, 121, 210, 250, 201, 198, 255, 202, 128, 128, 128], [23, 91, 163, 242, 170, 187, 247, 210, 255, 255, 128]], [[1, 200, 246, 255, 234, 255, 128, 128, 128, 128, 128], [109, 178, 241, 255, 231, 245, 255, 255, 128, 128, 128], [44, 130, 201, 253, 205, 192, 255, 255, 128, 128, 128]], [[1, 132, 239, 251, 219, 209, 255, 165, 128, 128, 128], [94, 136, 225, 251, 218, 190, 255, 255, 128, 128, 128], [22, 100, 174, 245, 186, 161, 255, 199, 128, 128, 128]], [[1, 182, 249, 255, 232, 235, 128, 128, 128, 128, 128], [124, 143, 241, 255, 227, 234, 128, 128, 128, 128, 128], [35, 77, 181, 251, 193, 211, 255, 205, 128, 128, 128]], [[1, 157, 247, 255, 236, 231, 255, 255, 128, 128, 128], [121, 141, 235, 255, 225, 227, 255, 255, 128, 128, 128], [45, 99, 188, 251, 195, 217, 255, 224, 128, 128, 128]], [[1, 1, 251, 255, 213, 255, 128, 128, 128, 128, 128], [203, 1, 248, 255, 255, 128, 128, 128, 128, 128, 128], [137, 1, 177, 255, 224, 255, 128, 128, 128, 128, 128]]], [[[253, 9, 248, 251, 207, 208, 255, 192, 128, 128, 128], [175, 13, 224, 243, 193, 185, 249, 198, 255, 255, 128], [73, 17, 171, 221, 161, 179, 236, 167, 255, 234, 128]], [[1, 95, 247, 253, 212, 183, 255, 255, 128, 128, 128], [239, 90, 244, 250, 211, 209, 255, 255, 128, 128, 128], [155, 77, 195, 248, 188, 195, 255, 255, 128, 128, 128]], [[1, 24, 239, 251, 218, 219, 255, 205, 128, 128, 128], [201, 51, 219, 255, 196, 186, 128, 128, 128, 128, 128], [69, 46, 190, 239, 201, 218, 255, 228, 128, 128, 128]], [[1, 191, 251, 255, 255, 128, 128, 128, 128, 128, 128], [223, 165, 249, 255, 213, 255, 128, 128, 128, 128, 128], [141, 124, 248, 255, 255, 128, 128, 128, 128, 128, 128]], [[1, 16, 248, 255, 255, 128, 128, 128, 128, 128, 128], [190, 36, 230, 255, 236, 255, 128, 128, 128, 128, 128], [149, 1, 255, 128, 128, 128, 128, 128, 128, 128, 128]], [[1, 226, 255, 128, 128, 128, 128, 128, 128, 128, 128], [247, 192, 255, 128, 128, 128, 128, 128, 128, 128, 128], [240, 128, 255, 128, 128, 128, 128, 128, 128, 128, 128]], [[1, 134, 252, 255, 255, 128, 128, 128, 128, 128, 128], [213, 62, 250, 255, 255, 128, 128, 128, 128, 128, 128], [55, 93, 255, 128, 128, 128, 128, 128, 128, 128, 128]], [[128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128], [128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128], [128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128]]], [[[202, 24, 213, 235, 186, 191, 220, 160, 240, 175, 255], [126, 38, 182, 232, 169, 184, 228, 174, 255, 187, 128], [61, 46, 138, 219, 151, 178, 240, 170, 255, 216, 128]], [[1, 112, 230, 250, 199, 191, 247, 159, 255, 255, 128], [166, 109, 228, 252, 211, 215, 255, 174, 128, 128, 128], [39, 77, 162, 232, 172, 180, 245, 178, 255, 255, 128]], [[1, 52, 220, 246, 198, 199, 249, 220, 255, 255, 128], [124, 74, 191, 243, 183, 193, 250, 221, 255, 255, 128], [24, 71, 130, 219, 154, 170, 243, 182, 255, 255, 128]], [[1, 182, 225, 249, 219, 240, 255, 224, 128, 128, 128], [149, 150, 226, 252, 216, 205, 255, 171, 128, 128, 128], [28, 108, 170, 242, 183, 194, 254, 223, 255, 255, 128]], [[1, 81, 230, 252, 204, 203, 255, 192, 128, 128, 128], [123, 102, 209, 247, 188, 196, 255, 233, 128, 128, 128], [20, 95, 153, 243, 164, 173, 255, 203, 128, 128, 128]], [[1, 222, 248, 255, 216, 213, 128, 128, 128, 128, 128], [168, 175, 246, 252, 235, 205, 255, 255, 128, 128, 128], [47, 116, 215, 255, 211, 212, 255, 255, 128, 128, 128]], [[1, 121, 236, 253, 212, 214, 255, 255, 128, 128, 128], [141, 84, 213, 252, 201, 202, 255, 219, 128, 128, 128], [42, 80, 160, 240, 162, 185, 255, 205, 128, 128, 128]], [[1, 1, 255, 128, 128, 128, 128, 128, 128, 128, 128], [244, 1, 255, 128, 128, 128, 128, 128, 128, 128, 128], [238, 1, 255, 128, 128, 128, 128, 128, 128, 128, 128]]]],
+          ci = [[[231, 120, 48, 89, 115, 113, 120, 152, 112], [152, 179, 64, 126, 170, 118, 46, 70, 95], [175, 69, 143, 80, 85, 82, 72, 155, 103], [56, 58, 10, 171, 218, 189, 17, 13, 152], [114, 26, 17, 163, 44, 195, 21, 10, 173], [121, 24, 80, 195, 26, 62, 44, 64, 85], [144, 71, 10, 38, 171, 213, 144, 34, 26], [170, 46, 55, 19, 136, 160, 33, 206, 71], [63, 20, 8, 114, 114, 208, 12, 9, 226], [81, 40, 11, 96, 182, 84, 29, 16, 36]], [[134, 183, 89, 137, 98, 101, 106, 165, 148], [72, 187, 100, 130, 157, 111, 32, 75, 80], [66, 102, 167, 99, 74, 62, 40, 234, 128], [41, 53, 9, 178, 241, 141, 26, 8, 107], [74, 43, 26, 146, 73, 166, 49, 23, 157], [65, 38, 105, 160, 51, 52, 31, 115, 128], [104, 79, 12, 27, 217, 255, 87, 17, 7], [87, 68, 71, 44, 114, 51, 15, 186, 23], [47, 41, 14, 110, 182, 183, 21, 17, 194], [66, 45, 25, 102, 197, 189, 23, 18, 22]], [[88, 88, 147, 150, 42, 46, 45, 196, 205], [43, 97, 183, 117, 85, 38, 35, 179, 61], [39, 53, 200, 87, 26, 21, 43, 232, 171], [56, 34, 51, 104, 114, 102, 29, 93, 77], [39, 28, 85, 171, 58, 165, 90, 98, 64], [34, 22, 116, 206, 23, 34, 43, 166, 73], [107, 54, 32, 26, 51, 1, 81, 43, 31], [68, 25, 106, 22, 64, 171, 36, 225, 114], [34, 19, 21, 102, 132, 188, 16, 76, 124], [62, 18, 78, 95, 85, 57, 50, 48, 51]], [[193, 101, 35, 159, 215, 111, 89, 46, 111], [60, 148, 31, 172, 219, 228, 21, 18, 111], [112, 113, 77, 85, 179, 255, 38, 120, 114], [40, 42, 1, 196, 245, 209, 10, 25, 109], [88, 43, 29, 140, 166, 213, 37, 43, 154], [61, 63, 30, 155, 67, 45, 68, 1, 209], [100, 80, 8, 43, 154, 1, 51, 26, 71], [142, 78, 78, 16, 255, 128, 34, 197, 171], [41, 40, 5, 102, 211, 183, 4, 1, 221], [51, 50, 17, 168, 209, 192, 23, 25, 82]], [[138, 31, 36, 171, 27, 166, 38, 44, 229], [67, 87, 58, 169, 82, 115, 26, 59, 179], [63, 59, 90, 180, 59, 166, 93, 73, 154], [40, 40, 21, 116, 143, 209, 34, 39, 175], [47, 15, 16, 183, 34, 223, 49, 45, 183], [46, 17, 33, 183, 6, 98, 15, 32, 183], [57, 46, 22, 24, 128, 1, 54, 17, 37], [65, 32, 73, 115, 28, 128, 23, 128, 205], [40, 3, 9, 115, 51, 192, 18, 6, 223], [87, 37, 9, 115, 59, 77, 64, 21, 47]], [[104, 55, 44, 218, 9, 54, 53, 130, 226], [64, 90, 70, 205, 40, 41, 23, 26, 57], [54, 57, 112, 184, 5, 41, 38, 166, 213], [30, 34, 26, 133, 152, 116, 10, 32, 134], [39, 19, 53, 221, 26, 114, 32, 73, 255], [31, 9, 65, 234, 2, 15, 1, 118, 73], [75, 32, 12, 51, 192, 255, 160, 43, 51], [88, 31, 35, 67, 102, 85, 55, 186, 85], [56, 21, 23, 111, 59, 205, 45, 37, 192], [55, 38, 70, 124, 73, 102, 1, 34, 98]], [[125, 98, 42, 88, 104, 85, 117, 175, 82], [95, 84, 53, 89, 128, 100, 113, 101, 45], [75, 79, 123, 47, 51, 128, 81, 171, 1], [57, 17, 5, 71, 102, 57, 53, 41, 49], [38, 33, 13, 121, 57, 73, 26, 1, 85], [41, 10, 67, 138, 77, 110, 90, 47, 114], [115, 21, 2, 10, 102, 255, 166, 23, 6], [101, 29, 16, 10, 85, 128, 101, 196, 26], [57, 18, 10, 102, 102, 213, 34, 20, 43], [117, 20, 15, 36, 163, 128, 68, 1, 26]], [[102, 61, 71, 37, 34, 53, 31, 243, 192], [69, 60, 71, 38, 73, 119, 28, 222, 37], [68, 45, 128, 34, 1, 47, 11, 245, 171], [62, 17, 19, 70, 146, 85, 55, 62, 70], [37, 43, 37, 154, 100, 163, 85, 160, 1], [63, 9, 92, 136, 28, 64, 32, 201, 85], [75, 15, 9, 9, 64, 255, 184, 119, 16], [86, 6, 28, 5, 64, 255, 25, 248, 1], [56, 8, 17, 132, 137, 255, 55, 116, 128], [58, 15, 20, 82, 135, 57, 26, 121, 40]], [[164, 50, 31, 137, 154, 133, 25, 35, 218], [51, 103, 44, 131, 131, 123, 31, 6, 158], [86, 40, 64, 135, 148, 224, 45, 183, 128], [22, 26, 17, 131, 240, 154, 14, 1, 209], [45, 16, 21, 91, 64, 222, 7, 1, 197], [56, 21, 39, 155, 60, 138, 23, 102, 213], [83, 12, 13, 54, 192, 255, 68, 47, 28], [85, 26, 85, 85, 128, 128, 32, 146, 171], [18, 11, 7, 63, 144, 171, 4, 4, 246], [35, 27, 10, 146, 174, 171, 12, 26, 128]], [[190, 80, 35, 99, 180, 80, 126, 54, 45], [85, 126, 47, 87, 176, 51, 41, 20, 32], [101, 75, 128, 139, 118, 146, 116, 128, 85], [56, 41, 15, 176, 236, 85, 37, 9, 62], [71, 30, 17, 119, 118, 255, 17, 18, 138], [101, 38, 60, 138, 55, 70, 43, 26, 142], [146, 36, 19, 30, 171, 255, 97, 27, 20], [138, 45, 61, 62, 219, 1, 81, 188, 64], [32, 41, 20, 117, 151, 142, 20, 21, 163], [112, 19, 12, 61, 195, 128, 48, 4, 24]]],
+          ui = [[[[255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[176, 246, 255, 255, 255, 255, 255, 255, 255, 255, 255], [223, 241, 252, 255, 255, 255, 255, 255, 255, 255, 255], [249, 253, 253, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 244, 252, 255, 255, 255, 255, 255, 255, 255, 255], [234, 254, 254, 255, 255, 255, 255, 255, 255, 255, 255], [253, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 246, 254, 255, 255, 255, 255, 255, 255, 255, 255], [239, 253, 254, 255, 255, 255, 255, 255, 255, 255, 255], [254, 255, 254, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 248, 254, 255, 255, 255, 255, 255, 255, 255, 255], [251, 255, 254, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 253, 254, 255, 255, 255, 255, 255, 255, 255, 255], [251, 254, 254, 255, 255, 255, 255, 255, 255, 255, 255], [254, 255, 254, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 254, 253, 255, 254, 255, 255, 255, 255, 255, 255], [250, 255, 254, 255, 254, 255, 255, 255, 255, 255, 255], [254, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]]], [[[217, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [225, 252, 241, 253, 255, 255, 254, 255, 255, 255, 255], [234, 250, 241, 250, 253, 255, 253, 254, 255, 255, 255]], [[255, 254, 255, 255, 255, 255, 255, 255, 255, 255, 255], [223, 254, 254, 255, 255, 255, 255, 255, 255, 255, 255], [238, 253, 254, 254, 255, 255, 255, 255, 255, 255, 255]], [[255, 248, 254, 255, 255, 255, 255, 255, 255, 255, 255], [249, 254, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 253, 255, 255, 255, 255, 255, 255, 255, 255, 255], [247, 254, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 253, 254, 255, 255, 255, 255, 255, 255, 255, 255], [252, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 254, 254, 255, 255, 255, 255, 255, 255, 255, 255], [253, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 254, 253, 255, 255, 255, 255, 255, 255, 255, 255], [250, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [254, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]]], [[[186, 251, 250, 255, 255, 255, 255, 255, 255, 255, 255], [234, 251, 244, 254, 255, 255, 255, 255, 255, 255, 255], [251, 251, 243, 253, 254, 255, 254, 255, 255, 255, 255]], [[255, 253, 254, 255, 255, 255, 255, 255, 255, 255, 255], [236, 253, 254, 255, 255, 255, 255, 255, 255, 255, 255], [251, 253, 253, 254, 254, 255, 255, 255, 255, 255, 255]], [[255, 254, 254, 255, 255, 255, 255, 255, 255, 255, 255], [254, 254, 254, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 254, 255, 255, 255, 255, 255, 255, 255, 255, 255], [254, 254, 255, 255, 255, 255, 255, 255, 255, 255, 255], [254, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [254, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]]], [[[248, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [250, 254, 252, 254, 255, 255, 255, 255, 255, 255, 255], [248, 254, 249, 253, 255, 255, 255, 255, 255, 255, 255]], [[255, 253, 253, 255, 255, 255, 255, 255, 255, 255, 255], [246, 253, 253, 255, 255, 255, 255, 255, 255, 255, 255], [252, 254, 251, 254, 254, 255, 255, 255, 255, 255, 255]], [[255, 254, 252, 255, 255, 255, 255, 255, 255, 255, 255], [248, 254, 253, 255, 255, 255, 255, 255, 255, 255, 255], [253, 255, 254, 254, 255, 255, 255, 255, 255, 255, 255]], [[255, 251, 254, 255, 255, 255, 255, 255, 255, 255, 255], [245, 251, 254, 255, 255, 255, 255, 255, 255, 255, 255], [253, 253, 254, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 251, 253, 255, 255, 255, 255, 255, 255, 255, 255], [252, 253, 254, 255, 255, 255, 255, 255, 255, 255, 255], [255, 254, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 252, 255, 255, 255, 255, 255, 255, 255, 255, 255], [249, 255, 254, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 254, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 255, 253, 255, 255, 255, 255, 255, 255, 255, 255], [250, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]], [[255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [254, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]]]],
+          li = [0, 1, 2, 3, 6, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7, 0],
+          hi = [],
+          fi = [],
+          di = [],
+          pi = 1,
+          gi = 2,
+          mi = [],
+          vi = [];
+        vr("UpsampleRgbLinePair", Ar, 3), vr("UpsampleBgrLinePair", xr, 3), vr("UpsampleRgbaLinePair", Fr, 4), vr("UpsampleBgraLinePair", kr, 4), vr("UpsampleArgbLinePair", Pr, 4), vr("UpsampleRgba4444LinePair", _r, 2), vr("UpsampleRgb565LinePair", Sr, 2);
+        var bi = t.UpsampleRgbLinePair,
+          yi = t.UpsampleBgrLinePair,
+          wi = t.UpsampleRgbaLinePair,
+          Ni = t.UpsampleBgraLinePair,
+          Li = t.UpsampleArgbLinePair,
+          Ai = t.UpsampleRgba4444LinePair,
+          xi = t.UpsampleRgb565LinePair,
+          Si = 16,
+          _i = 1 << Si - 1,
+          Pi = -227,
+          ki = 482,
+          Fi = 6,
+          Ii = (256 << Fi) - 1,
+          Ci = 0,
+          ji = a(256),
+          Oi = a(256),
+          Bi = a(256),
+          Mi = a(256),
+          Ei = a(ki - Pi),
+          qi = a(ki - Pi);
+        Ir("YuvToRgbRow", Ar, 3), Ir("YuvToBgrRow", xr, 3), Ir("YuvToRgbaRow", Fr, 4), Ir("YuvToBgraRow", kr, 4), Ir("YuvToArgbRow", Pr, 4), Ir("YuvToRgba4444Row", _r, 2), Ir("YuvToRgb565Row", Sr, 2);
+        var Di = [0, 4, 8, 12, 128, 132, 136, 140, 256, 260, 264, 268, 384, 388, 392, 396],
+          Ri = [0, 2, 8],
+          Ti = [8, 7, 6, 4, 4, 2, 2, 2, 1, 1, 1, 1],
+          Ui = 1;
+        this.WebPDecodeRGBA = function (t, r, n, i, a) {
+          var o = qn,
+            s = new rr(),
+            c = new ot();
+          s.ba = c, c.S = o, c.width = [c.width], c.height = [c.height];
+          var u = c.width,
+            l = c.height,
+            h = new st();
+          if (null == h || null == t) var f = 2;else e(null != h), f = Br(t, r, n, h.width, h.height, h.Pd, h.Qd, h.format, null);
+          if (0 != f ? u = 0 : (null != u && (u[0] = h.width[0]), null != l && (l[0] = h.height[0]), u = 1), u) {
+            c.width = c.width[0], c.height = c.height[0], null != i && (i[0] = c.width), null != a && (a[0] = c.height);
+            t: {
+              if (i = new Gt(), (a = new nr()).data = t, a.w = r, a.ha = n, a.kd = 1, r = [0], e(null != a), (0 == (t = Br(a.data, a.w, a.ha, null, null, null, r, null, a)) || 7 == t) && r[0] && (t = 4), 0 == (r = t)) {
+                if (e(null != s), i.data = a.data, i.w = a.w + a.offset, i.ha = a.ha - a.offset, i.put = dt, i.ac = ft, i.bc = pt, i.ma = s, a.xa) {
+                  if (null == (t = kt())) {
+                    s = 1;
+                    break t;
+                  }
+                  if (function (t, r) {
+                    var n = [0],
+                      i = [0],
+                      a = [0];
+                    e: for (;;) {
+                      if (null == t) return 0;
+                      if (null == r) return t.a = 2, 0;
+                      if (t.l = r, t.a = 0, v(t.m, r.data, r.w, r.ha), !gt(t.m, n, i, a)) {
+                        t.a = 3;
+                        break e;
+                      }
+                      if (t.xb = gi, r.width = n[0], r.height = i[0], !Ft(n[0], i[0], 1, t, null)) break e;
+                      return 1;
+                    }
+                    return e(0 != t.a), 0;
+                  }(t, i)) {
+                    if (i = 0 == (r = qr(i.width, i.height, s.Oa, s.ba))) {
+                      e: {
+                        i = t;
+                        r: for (;;) {
+                          if (null == i) {
+                            i = 0;
+                            break e;
+                          }
+                          if (e(null != i.s.yc), e(null != i.s.Ya), e(0 < i.s.Wb), e(null != (n = i.l)), e(null != (a = n.ma)), 0 != i.xb) {
+                            if (i.ca = a.ba, i.tb = a.tb, e(null != i.ca), !Mr(a.Oa, n, Rn)) {
+                              i.a = 2;
+                              break r;
+                            }
+                            if (!It(i, n.width)) break r;
+                            if (n.da) break r;
+                            if ((n.da || nt(i.ca.S)) && mr(), 11 > i.ca.S || (alert("todo:WebPInitConvertARGBToYUV"), null != i.ca.f.kb.F && mr()), i.Pb && 0 < i.s.ua && null == i.s.vb.X && !O(i.s.vb, i.s.Wa.Xa)) {
+                              i.a = 1;
+                              break r;
+                            }
+                            i.xb = 0;
+                          }
+                          if (!_t(i, i.V, i.Ba, i.c, i.i, n.o, Lt)) break r;
+                          a.Dc = i.Ma, i = 1;
+                          break e;
+                        }
+                        e(0 != i.a), i = 0;
+                      }
+                      i = !i;
+                    }
+                    i && (r = t.a);
+                  } else r = t.a;
+                } else {
+                  if (null == (t = new Yt())) {
+                    s = 1;
+                    break t;
+                  }
+                  if (t.Fa = a.na, t.P = a.P, t.qc = a.Sa, Kt(t, i)) {
+                    if (0 == (r = qr(i.width, i.height, s.Oa, s.ba))) {
+                      if (t.Aa = 0, n = s.Oa, e(null != (a = t)), null != n) {
+                        if (0 < (u = 0 > (u = n.Md) ? 0 : 100 < u ? 255 : 255 * u / 100)) {
+                          for (l = h = 0; 4 > l; ++l) 12 > (f = a.pb[l]).lc && (f.ia = u * Ti[0 > f.lc ? 0 : f.lc] >> 3), h |= f.ia;
+                          h && (alert("todo:VP8InitRandom"), a.ia = 1);
+                        }
+                        a.Ga = n.Id, 100 < a.Ga ? a.Ga = 100 : 0 > a.Ga && (a.Ga = 0);
+                      }
+                      Qt(t, i) || (r = t.a);
+                    }
+                  } else r = t.a;
+                }
+                0 == r && null != s.Oa && s.Oa.fd && (r = Er(s.ba));
+              }
+              s = r;
+            }
+            o = 0 != s ? null : 11 > o ? c.f.RGBA.eb : c.f.kb.y;
+          } else o = null;
+          return o;
+        };
+        var zi = [3, 4, 3, 4, 4, 2, 2, 4, 4, 4, 2, 1, 1];
+      };
+      function u(t, e) {
+        for (var r = "", n = 0; n < 4; n++) r += String.fromCharCode(t[e++]);
+        return r;
+      }
+      function l(t, e) {
+        return (t[e + 0] << 0 | t[e + 1] << 8 | t[e + 2] << 16) >>> 0;
+      }
+      function h(t, e) {
+        return (t[e + 0] << 0 | t[e + 1] << 8 | t[e + 2] << 16 | t[e + 3] << 24) >>> 0;
+      }
+      new c();
+      var f = [0],
+        d = [0],
+        p = [],
+        g = new c(),
+        m = t,
+        v = function (t, e) {
+          var r = {},
+            n = 0,
+            i = !1,
+            a = 0,
+            o = 0;
+          if (r.frames = [], !
+          /** @license
+               * Copyright (c) 2017 Dominik Homberger
+              Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+              The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+              THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+              https://webpjs.appspot.com
+              WebPRiffParser dominikhlbg@gmail.com
+              */
+          function (t, e, r, n) {
+            for (var i = 0; i < n; i++) if (t[e + i] != r.charCodeAt(i)) return !0;
+            return !1;
+          }(t, e, "RIFF", 4)) {
+            var s, c;
+            h(t, e += 4);
+            for (e += 8; e < t.length;) {
+              var f = u(t, e),
+                d = h(t, e += 4);
+              e += 4;
+              var p = d + (1 & d);
+              switch (f) {
+                case "VP8 ":
+                case "VP8L":
+                  void 0 === r.frames[n] && (r.frames[n] = {});
+                  (v = r.frames[n]).src_off = i ? o : e - 8, v.src_size = a + d + 8, n++, i && (i = !1, a = 0, o = 0);
+                  break;
+                case "VP8X":
+                  (v = r.header = {}).feature_flags = t[e];
+                  var g = e + 4;
+                  v.canvas_width = 1 + l(t, g);
+                  g += 3;
+                  v.canvas_height = 1 + l(t, g);
+                  g += 3;
+                  break;
+                case "ALPH":
+                  i = !0, a = p + 8, o = e - 8;
+                  break;
+                case "ANIM":
+                  (v = r.header).bgcolor = h(t, e);
+                  g = e + 4;
+                  v.loop_count = (s = t)[(c = g) + 0] << 0 | s[c + 1] << 8;
+                  g += 2;
+                  break;
+                case "ANMF":
+                  var m, v;
+                  (v = r.frames[n] = {}).offset_x = 2 * l(t, e), e += 3, v.offset_y = 2 * l(t, e), e += 3, v.width = 1 + l(t, e), e += 3, v.height = 1 + l(t, e), e += 3, v.duration = l(t, e), e += 3, m = t[e++], v.dispose = 1 & m, v.blend = m >> 1 & 1;
+              }
+              "ANMF" != f && (e += p);
+            }
+            return r;
+          }
+        }(m, 0);
+      v.response = m, v.rgbaoutput = !0, v.dataurl = !1;
+      var b = v.header ? v.header : null,
+        y = v.frames ? v.frames : null;
+      if (b) {
+        b.loop_counter = b.loop_count, f = [b.canvas_height], d = [b.canvas_width];
+        for (var w = 0; w < y.length && 0 != y[w].blend; w++);
+      }
+      var N = y[0],
+        L = g.WebPDecodeRGBA(m, N.src_off, N.src_size, d, f);
+      N.rgba = L, N.imgwidth = d[0], N.imgheight = f[0];
+      for (var A = 0; A < d[0] * f[0] * 4; A++) p[A] = L[A];
+      return this.width = d, this.height = f, this.data = p, this;
+    }
+    !function (t) {
+      var e = function e() {
+          return !0;
+        },
+        r = function r(e, _r2, i, u) {
+          var l = 4,
+            h = o;
+          switch (u) {
+            case t.image_compression.FAST:
+              l = 1, h = a;
+              break;
+            case t.image_compression.MEDIUM:
+              l = 6, h = s;
+              break;
+            case t.image_compression.SLOW:
+              l = 9, h = c;
+          }
+          var f = Ie(e = n(e, _r2, i, h), {
+            level: l
+          });
+          return t.__addimage__.arrayBufferToBinaryString(f);
+        },
+        n = function n(t, e, r, _n2) {
+          for (var i, a, o, s = t.length / e, c = new Uint8Array(t.length + s), u = l(), f = 0; f < s; f += 1) {
+            if (o = f * e, i = t.subarray(o, o + e), _n2) c.set(_n2(i, r, a), o + f);else {
+              for (var d, p = u.length, g = []; d < p; d += 1) g[d] = u[d](i, r, a);
+              var m = h(g.concat());
+              c.set(g[m], o + f);
+            }
+            a = i;
+          }
+          return c;
+        },
+        i = function i(t) {
+          var e = Array.apply([], t);
+          return e.unshift(0), e;
+        },
+        a = function a(t, e) {
+          var r,
+            n = [],
+            i = t.length;
+          n[0] = 1;
+          for (var a = 0; a < i; a += 1) r = t[a - e] || 0, n[a + 1] = t[a] - r + 256 & 255;
+          return n;
+        },
+        o = function o(t, e, r) {
+          var n,
+            i = [],
+            a = t.length;
+          i[0] = 2;
+          for (var o = 0; o < a; o += 1) n = r && r[o] || 0, i[o + 1] = t[o] - n + 256 & 255;
+          return i;
+        },
+        s = function s(t, e, r) {
+          var n,
+            i,
+            a = [],
+            o = t.length;
+          a[0] = 3;
+          for (var s = 0; s < o; s += 1) n = t[s - e] || 0, i = r && r[s] || 0, a[s + 1] = t[s] + 256 - (n + i >>> 1) & 255;
+          return a;
+        },
+        c = function c(t, e, r) {
+          var n,
+            i,
+            a,
+            o,
+            s = [],
+            c = t.length;
+          s[0] = 4;
+          for (var l = 0; l < c; l += 1) n = t[l - e] || 0, i = r && r[l] || 0, a = r && r[l - e] || 0, o = u(n, i, a), s[l + 1] = t[l] - o + 256 & 255;
+          return s;
+        },
+        u = function u(t, e, r) {
+          if (t === e && e === r) return t;
+          var n = Math.abs(e - r),
+            i = Math.abs(t - r),
+            a = Math.abs(t + e - r - r);
+          return n <= i && n <= a ? t : i <= a ? e : r;
+        },
+        l = function l() {
+          return [i, a, o, s, c];
+        },
+        h = function h(t) {
+          var e = t.map(function (t) {
+            return t.reduce(function (t, e) {
+              return t + Math.abs(e);
+            }, 0);
+          });
+          return e.indexOf(Math.min.apply(null, e));
+        };
+      t.processPNG = function (n, i, a, o) {
+        var s,
+          c,
+          u,
+          l,
+          h,
+          f,
+          d,
+          p,
+          g,
+          m,
+          v,
+          b,
+          y,
+          w,
+          N,
+          L = this.decode.FLATE_DECODE,
+          A = "";
+        if (this.__addimage__.isArrayBuffer(n) && (n = new Uint8Array(n)), this.__addimage__.isArrayBufferView(n)) {
+          if (n = (u = new De(n)).imgData, c = u.bits, s = u.colorSpace, h = u.colors, -1 !== [4, 6].indexOf(u.colorType)) {
+            if (8 === u.bits) {
+              g = (p = 32 == u.pixelBitlength ? new Uint32Array(u.decodePixels().buffer) : 16 == u.pixelBitlength ? new Uint16Array(u.decodePixels().buffer) : new Uint8Array(u.decodePixels().buffer)).length, v = new Uint8Array(g * u.colors), m = new Uint8Array(g);
+              var x,
+                S = u.pixelBitlength - u.bits;
+              for (w = 0, N = 0; w < g; w++) {
+                for (y = p[w], x = 0; x < S;) v[N++] = y >>> x & 255, x += u.bits;
+                m[w] = y >>> x & 255;
+              }
+            }
+            if (16 === u.bits) {
+              g = (p = new Uint32Array(u.decodePixels().buffer)).length, v = new Uint8Array(g * (32 / u.pixelBitlength) * u.colors), m = new Uint8Array(g * (32 / u.pixelBitlength)), b = u.colors > 1, w = 0, N = 0;
+              for (var _ = 0; w < g;) y = p[w++], v[N++] = y >>> 0 & 255, b && (v[N++] = y >>> 16 & 255, y = p[w++], v[N++] = y >>> 0 & 255), m[_++] = y >>> 16 & 255;
+              c = 8;
+            }
+            o !== t.image_compression.NONE && e() ? (n = r(v, u.width * u.colors, u.colors, o), d = r(m, u.width, 1, o)) : (n = v, d = m, L = void 0);
+          }
+          if (3 === u.colorType && (s = this.color_spaces.INDEXED, f = u.palette, u.transparency.indexed)) {
+            var P = u.transparency.indexed,
+              k = 0;
+            for (w = 0, g = P.length; w < g; ++w) k += P[w];
+            if ((k /= 255) === g - 1 && -1 !== P.indexOf(0)) l = [P.indexOf(0)];else if (k !== g) {
+              for (p = u.decodePixels(), m = new Uint8Array(p.length), w = 0, g = p.length; w < g; w++) m[w] = P[p[w]];
+              d = r(m, u.width, 1);
+            }
+          }
+          var F = function (e) {
+            var r;
+            switch (e) {
+              case t.image_compression.FAST:
+                r = 11;
+                break;
+              case t.image_compression.MEDIUM:
+                r = 13;
+                break;
+              case t.image_compression.SLOW:
+                r = 14;
+                break;
+              default:
+                r = 12;
+            }
+            return r;
+          }(o);
+          return L === this.decode.FLATE_DECODE && (A = "/Predictor " + F + " "), A += "/Colors " + h + " /BitsPerComponent " + c + " /Columns " + u.width, (this.__addimage__.isArrayBuffer(n) || this.__addimage__.isArrayBufferView(n)) && (n = this.__addimage__.arrayBufferToBinaryString(n)), (d && this.__addimage__.isArrayBuffer(d) || this.__addimage__.isArrayBufferView(d)) && (d = this.__addimage__.arrayBufferToBinaryString(d)), {
+            alias: a,
+            data: n,
+            index: i,
+            filter: L,
+            decodeParameters: A,
+            transparency: l,
+            palette: f,
+            sMask: d,
+            predictor: F,
+            width: u.width,
+            height: u.height,
+            bitsPerComponent: c,
+            colorSpace: s
+          };
+        }
+      };
+    }(M.API), function (t) {
+      t.processGIF89A = function (e, r, n, i) {
+        var a = new Re(e),
+          o = a.width,
+          s = a.height,
+          c = [];
+        a.decodeAndBlitFrameRGBA(0, c);
+        var u = {
+            data: c,
+            width: o,
+            height: s
+          },
+          l = new Ue(100).encode(u, 100);
+        return t.processJPEG.call(this, l, r, n, i);
+      }, t.processGIF87A = t.processGIF89A;
+    }(M.API), ze.prototype.parseHeader = function () {
+      if (this.fileSize = this.datav.getUint32(this.pos, !0), this.pos += 4, this.reserved = this.datav.getUint32(this.pos, !0), this.pos += 4, this.offset = this.datav.getUint32(this.pos, !0), this.pos += 4, this.headerSize = this.datav.getUint32(this.pos, !0), this.pos += 4, this.width = this.datav.getUint32(this.pos, !0), this.pos += 4, this.height = this.datav.getInt32(this.pos, !0), this.pos += 4, this.planes = this.datav.getUint16(this.pos, !0), this.pos += 2, this.bitPP = this.datav.getUint16(this.pos, !0), this.pos += 2, this.compress = this.datav.getUint32(this.pos, !0), this.pos += 4, this.rawSize = this.datav.getUint32(this.pos, !0), this.pos += 4, this.hr = this.datav.getUint32(this.pos, !0), this.pos += 4, this.vr = this.datav.getUint32(this.pos, !0), this.pos += 4, this.colors = this.datav.getUint32(this.pos, !0), this.pos += 4, this.importantColors = this.datav.getUint32(this.pos, !0), this.pos += 4, 16 === this.bitPP && this.is_with_alpha && (this.bitPP = 15), this.bitPP < 15) {
+        var t = 0 === this.colors ? 1 << this.bitPP : this.colors;
+        this.palette = new Array(t);
+        for (var e = 0; e < t; e++) {
+          var r = this.datav.getUint8(this.pos++, !0),
+            n = this.datav.getUint8(this.pos++, !0),
+            i = this.datav.getUint8(this.pos++, !0),
+            a = this.datav.getUint8(this.pos++, !0);
+          this.palette[e] = {
+            red: i,
+            green: n,
+            blue: r,
+            quad: a
+          };
+        }
+      }
+      this.height < 0 && (this.height *= -1, this.bottom_up = !1);
+    }, ze.prototype.parseBGR = function () {
+      this.pos = this.offset;
+      try {
+        var t = "bit" + this.bitPP,
+          e = this.width * this.height * 4;
+        this.data = new Uint8Array(e), this[t]();
+      } catch (t) {
+        i.log("bit decode error:" + t);
+      }
+    }, ze.prototype.bit1 = function () {
+      var t,
+        e = Math.ceil(this.width / 8),
+        r = e % 4;
+      for (t = this.height - 1; t >= 0; t--) {
+        for (var n = this.bottom_up ? t : this.height - 1 - t, i = 0; i < e; i++) for (var a = this.datav.getUint8(this.pos++, !0), o = n * this.width * 4 + 8 * i * 4, s = 0; s < 8 && 8 * i + s < this.width; s++) {
+          var c = this.palette[a >> 7 - s & 1];
+          this.data[o + 4 * s] = c.blue, this.data[o + 4 * s + 1] = c.green, this.data[o + 4 * s + 2] = c.red, this.data[o + 4 * s + 3] = 255;
+        }
+        0 !== r && (this.pos += 4 - r);
+      }
+    }, ze.prototype.bit4 = function () {
+      for (var t = Math.ceil(this.width / 2), e = t % 4, r = this.height - 1; r >= 0; r--) {
+        for (var n = this.bottom_up ? r : this.height - 1 - r, i = 0; i < t; i++) {
+          var a = this.datav.getUint8(this.pos++, !0),
+            o = n * this.width * 4 + 2 * i * 4,
+            s = a >> 4,
+            c = 15 & a,
+            u = this.palette[s];
+          if (this.data[o] = u.blue, this.data[o + 1] = u.green, this.data[o + 2] = u.red, this.data[o + 3] = 255, 2 * i + 1 >= this.width) break;
+          u = this.palette[c], this.data[o + 4] = u.blue, this.data[o + 4 + 1] = u.green, this.data[o + 4 + 2] = u.red, this.data[o + 4 + 3] = 255;
+        }
+        0 !== e && (this.pos += 4 - e);
+      }
+    }, ze.prototype.bit8 = function () {
+      for (var t = this.width % 4, e = this.height - 1; e >= 0; e--) {
+        for (var r = this.bottom_up ? e : this.height - 1 - e, n = 0; n < this.width; n++) {
+          var i = this.datav.getUint8(this.pos++, !0),
+            a = r * this.width * 4 + 4 * n;
+          if (i < this.palette.length) {
+            var o = this.palette[i];
+            this.data[a] = o.red, this.data[a + 1] = o.green, this.data[a + 2] = o.blue, this.data[a + 3] = 255;
+          } else this.data[a] = 255, this.data[a + 1] = 255, this.data[a + 2] = 255, this.data[a + 3] = 255;
+        }
+        0 !== t && (this.pos += 4 - t);
+      }
+    }, ze.prototype.bit15 = function () {
+      for (var t = this.width % 3, e = parseInt("11111", 2), r = this.height - 1; r >= 0; r--) {
+        for (var n = this.bottom_up ? r : this.height - 1 - r, i = 0; i < this.width; i++) {
+          var a = this.datav.getUint16(this.pos, !0);
+          this.pos += 2;
+          var o = (a & e) / e * 255 | 0,
+            s = (a >> 5 & e) / e * 255 | 0,
+            c = (a >> 10 & e) / e * 255 | 0,
+            u = a >> 15 ? 255 : 0,
+            l = n * this.width * 4 + 4 * i;
+          this.data[l] = c, this.data[l + 1] = s, this.data[l + 2] = o, this.data[l + 3] = u;
+        }
+        this.pos += t;
+      }
+    }, ze.prototype.bit16 = function () {
+      for (var t = this.width % 3, e = parseInt("11111", 2), r = parseInt("111111", 2), n = this.height - 1; n >= 0; n--) {
+        for (var i = this.bottom_up ? n : this.height - 1 - n, a = 0; a < this.width; a++) {
+          var o = this.datav.getUint16(this.pos, !0);
+          this.pos += 2;
+          var s = (o & e) / e * 255 | 0,
+            c = (o >> 5 & r) / r * 255 | 0,
+            u = (o >> 11) / e * 255 | 0,
+            l = i * this.width * 4 + 4 * a;
+          this.data[l] = u, this.data[l + 1] = c, this.data[l + 2] = s, this.data[l + 3] = 255;
+        }
+        this.pos += t;
+      }
+    }, ze.prototype.bit24 = function () {
+      for (var t = this.height - 1; t >= 0; t--) {
+        for (var e = this.bottom_up ? t : this.height - 1 - t, r = 0; r < this.width; r++) {
+          var n = this.datav.getUint8(this.pos++, !0),
+            i = this.datav.getUint8(this.pos++, !0),
+            a = this.datav.getUint8(this.pos++, !0),
+            o = e * this.width * 4 + 4 * r;
+          this.data[o] = a, this.data[o + 1] = i, this.data[o + 2] = n, this.data[o + 3] = 255;
+        }
+        this.pos += this.width % 4;
+      }
+    }, ze.prototype.bit32 = function () {
+      for (var t = this.height - 1; t >= 0; t--) for (var e = this.bottom_up ? t : this.height - 1 - t, r = 0; r < this.width; r++) {
+        var n = this.datav.getUint8(this.pos++, !0),
+          i = this.datav.getUint8(this.pos++, !0),
+          a = this.datav.getUint8(this.pos++, !0),
+          o = this.datav.getUint8(this.pos++, !0),
+          s = e * this.width * 4 + 4 * r;
+        this.data[s] = a, this.data[s + 1] = i, this.data[s + 2] = n, this.data[s + 3] = o;
+      }
+    }, ze.prototype.getData = function () {
+      return this.data;
+    },
+    /**
+       * @license
+       * Copyright (c) 2018 Aras Abbasi
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      t.processBMP = function (e, r, n, i) {
+        var a = new ze(e, !1),
+          o = a.width,
+          s = a.height,
+          c = {
+            data: a.getData(),
+            width: o,
+            height: s
+          },
+          u = new Ue(100).encode(c, 100);
+        return t.processJPEG.call(this, u, r, n, i);
+      };
+    }(M.API), He.prototype.getData = function () {
+      return this.data;
+    },
+    /**
+       * @license
+       * Copyright (c) 2019 Aras Abbasi
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      t.processWEBP = function (e, r, n, i) {
+        var a = new He(e),
+          o = a.width,
+          s = a.height,
+          c = {
+            data: a.getData(),
+            width: o,
+            height: s
+          },
+          u = new Ue(100).encode(c, 100);
+        return t.processJPEG.call(this, u, r, n, i);
+      };
+    }(M.API),
+    /**
+       * @license
+       *
+       * Copyright (c) 2021 Antti Palola, https://github.com/Pantura
+       *
+       * Permission is hereby granted, free of charge, to any person obtaining
+       * a copy of this software and associated documentation files (the
+       * "Software"), to deal in the Software without restriction, including
+       * without limitation the rights to use, copy, modify, merge, publish,
+       * distribute, sublicense, and/or sell copies of the Software, and to
+       * permit persons to whom the Software is furnished to do so, subject to
+       * the following conditions:
+       *
+       * The above copyright notice and this permission notice shall be
+       * included in all copies or substantial portions of the Software.
+       *
+       * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+       * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+       * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+       * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+       * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+       * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+       * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+       * ====================================================================
+       */
+    function (t) {
+      t.processRGBA = function (t, e, r) {
+        for (var n = t.data, i = n.length, a = new Uint8Array(i / 4 * 3), o = new Uint8Array(i / 4), s = 0, c = 0, u = 0; u < i; u += 4) {
+          var l = n[u],
+            h = n[u + 1],
+            f = n[u + 2],
+            d = n[u + 3];
+          a[s++] = l, a[s++] = h, a[s++] = f, o[c++] = d;
+        }
+        var p = this.__addimage__.arrayBufferToBinaryString(a);
+        return {
+          alpha: this.__addimage__.arrayBufferToBinaryString(o),
+          data: p,
+          index: e,
+          alias: r,
+          colorSpace: "DeviceRGB",
+          bitsPerComponent: 8,
+          width: t.width,
+          height: t.height
+        };
+      };
+    }(M.API),
+    /**
+       * @license
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      t.setLanguage = function (t) {
+        return void 0 === this.internal.languageSettings && (this.internal.languageSettings = {}, this.internal.languageSettings.isSubscribed = !1), void 0 !== {
+          af: "Afrikaans",
+          sq: "Albanian",
+          ar: "Arabic (Standard)",
+          "ar-DZ": "Arabic (Algeria)",
+          "ar-BH": "Arabic (Bahrain)",
+          "ar-EG": "Arabic (Egypt)",
+          "ar-IQ": "Arabic (Iraq)",
+          "ar-JO": "Arabic (Jordan)",
+          "ar-KW": "Arabic (Kuwait)",
+          "ar-LB": "Arabic (Lebanon)",
+          "ar-LY": "Arabic (Libya)",
+          "ar-MA": "Arabic (Morocco)",
+          "ar-OM": "Arabic (Oman)",
+          "ar-QA": "Arabic (Qatar)",
+          "ar-SA": "Arabic (Saudi Arabia)",
+          "ar-SY": "Arabic (Syria)",
+          "ar-TN": "Arabic (Tunisia)",
+          "ar-AE": "Arabic (U.A.E.)",
+          "ar-YE": "Arabic (Yemen)",
+          an: "Aragonese",
+          hy: "Armenian",
+          as: "Assamese",
+          ast: "Asturian",
+          az: "Azerbaijani",
+          eu: "Basque",
+          be: "Belarusian",
+          bn: "Bengali",
+          bs: "Bosnian",
+          br: "Breton",
+          bg: "Bulgarian",
+          my: "Burmese",
+          ca: "Catalan",
+          ch: "Chamorro",
+          ce: "Chechen",
+          zh: "Chinese",
+          "zh-HK": "Chinese (Hong Kong)",
+          "zh-CN": "Chinese (PRC)",
+          "zh-SG": "Chinese (Singapore)",
+          "zh-TW": "Chinese (Taiwan)",
+          cv: "Chuvash",
+          co: "Corsican",
+          cr: "Cree",
+          hr: "Croatian",
+          cs: "Czech",
+          da: "Danish",
+          nl: "Dutch (Standard)",
+          "nl-BE": "Dutch (Belgian)",
+          en: "English",
+          "en-AU": "English (Australia)",
+          "en-BZ": "English (Belize)",
+          "en-CA": "English (Canada)",
+          "en-IE": "English (Ireland)",
+          "en-JM": "English (Jamaica)",
+          "en-NZ": "English (New Zealand)",
+          "en-PH": "English (Philippines)",
+          "en-ZA": "English (South Africa)",
+          "en-TT": "English (Trinidad & Tobago)",
+          "en-GB": "English (United Kingdom)",
+          "en-US": "English (United States)",
+          "en-ZW": "English (Zimbabwe)",
+          eo: "Esperanto",
+          et: "Estonian",
+          fo: "Faeroese",
+          fj: "Fijian",
+          fi: "Finnish",
+          fr: "French (Standard)",
+          "fr-BE": "French (Belgium)",
+          "fr-CA": "French (Canada)",
+          "fr-FR": "French (France)",
+          "fr-LU": "French (Luxembourg)",
+          "fr-MC": "French (Monaco)",
+          "fr-CH": "French (Switzerland)",
+          fy: "Frisian",
+          fur: "Friulian",
+          gd: "Gaelic (Scots)",
+          "gd-IE": "Gaelic (Irish)",
+          gl: "Galacian",
+          ka: "Georgian",
+          de: "German (Standard)",
+          "de-AT": "German (Austria)",
+          "de-DE": "German (Germany)",
+          "de-LI": "German (Liechtenstein)",
+          "de-LU": "German (Luxembourg)",
+          "de-CH": "German (Switzerland)",
+          el: "Greek",
+          gu: "Gujurati",
+          ht: "Haitian",
+          he: "Hebrew",
+          hi: "Hindi",
+          hu: "Hungarian",
+          is: "Icelandic",
+          id: "Indonesian",
+          iu: "Inuktitut",
+          ga: "Irish",
+          it: "Italian (Standard)",
+          "it-CH": "Italian (Switzerland)",
+          ja: "Japanese",
+          kn: "Kannada",
+          ks: "Kashmiri",
+          kk: "Kazakh",
+          km: "Khmer",
+          ky: "Kirghiz",
+          tlh: "Klingon",
+          ko: "Korean",
+          "ko-KP": "Korean (North Korea)",
+          "ko-KR": "Korean (South Korea)",
+          la: "Latin",
+          lv: "Latvian",
+          lt: "Lithuanian",
+          lb: "Luxembourgish",
+          mk: "North Macedonia",
+          ms: "Malay",
+          ml: "Malayalam",
+          mt: "Maltese",
+          mi: "Maori",
+          mr: "Marathi",
+          mo: "Moldavian",
+          nv: "Navajo",
+          ng: "Ndonga",
+          ne: "Nepali",
+          no: "Norwegian",
+          nb: "Norwegian (Bokmal)",
+          nn: "Norwegian (Nynorsk)",
+          oc: "Occitan",
+          or: "Oriya",
+          om: "Oromo",
+          fa: "Persian",
+          "fa-IR": "Persian/Iran",
+          pl: "Polish",
+          pt: "Portuguese",
+          "pt-BR": "Portuguese (Brazil)",
+          pa: "Punjabi",
+          "pa-IN": "Punjabi (India)",
+          "pa-PK": "Punjabi (Pakistan)",
+          qu: "Quechua",
+          rm: "Rhaeto-Romanic",
+          ro: "Romanian",
+          "ro-MO": "Romanian (Moldavia)",
+          ru: "Russian",
+          "ru-MO": "Russian (Moldavia)",
+          sz: "Sami (Lappish)",
+          sg: "Sango",
+          sa: "Sanskrit",
+          sc: "Sardinian",
+          sd: "Sindhi",
+          si: "Singhalese",
+          sr: "Serbian",
+          sk: "Slovak",
+          sl: "Slovenian",
+          so: "Somani",
+          sb: "Sorbian",
+          es: "Spanish",
+          "es-AR": "Spanish (Argentina)",
+          "es-BO": "Spanish (Bolivia)",
+          "es-CL": "Spanish (Chile)",
+          "es-CO": "Spanish (Colombia)",
+          "es-CR": "Spanish (Costa Rica)",
+          "es-DO": "Spanish (Dominican Republic)",
+          "es-EC": "Spanish (Ecuador)",
+          "es-SV": "Spanish (El Salvador)",
+          "es-GT": "Spanish (Guatemala)",
+          "es-HN": "Spanish (Honduras)",
+          "es-MX": "Spanish (Mexico)",
+          "es-NI": "Spanish (Nicaragua)",
+          "es-PA": "Spanish (Panama)",
+          "es-PY": "Spanish (Paraguay)",
+          "es-PE": "Spanish (Peru)",
+          "es-PR": "Spanish (Puerto Rico)",
+          "es-ES": "Spanish (Spain)",
+          "es-UY": "Spanish (Uruguay)",
+          "es-VE": "Spanish (Venezuela)",
+          sx: "Sutu",
+          sw: "Swahili",
+          sv: "Swedish",
+          "sv-FI": "Swedish (Finland)",
+          "sv-SV": "Swedish (Sweden)",
+          ta: "Tamil",
+          tt: "Tatar",
+          te: "Teluga",
+          th: "Thai",
+          tig: "Tigre",
+          ts: "Tsonga",
+          tn: "Tswana",
+          tr: "Turkish",
+          tk: "Turkmen",
+          uk: "Ukrainian",
+          hsb: "Upper Sorbian",
+          ur: "Urdu",
+          ve: "Venda",
+          vi: "Vietnamese",
+          vo: "Volapuk",
+          wa: "Walloon",
+          cy: "Welsh",
+          xh: "Xhosa",
+          ji: "Yiddish",
+          zu: "Zulu"
+        }[t] && (this.internal.languageSettings.languageCode = t, !1 === this.internal.languageSettings.isSubscribed && (this.internal.events.subscribe("putCatalog", function () {
+          this.internal.write("/Lang (" + this.internal.languageSettings.languageCode + ")");
+        }), this.internal.languageSettings.isSubscribed = !0)), this;
+      };
+    }(M.API), Oe = M.API, Be = Oe.getCharWidthsArray = function (t, r) {
+      var n,
+        i,
+        a = (r = r || {}).font || this.internal.getFont(),
+        o = r.fontSize || this.internal.getFontSize(),
+        s = r.charSpace || this.internal.getCharSpace(),
+        c = r.widths ? r.widths : a.metadata.Unicode.widths,
+        u = c.fof ? c.fof : 1,
+        l = r.kerning ? r.kerning : a.metadata.Unicode.kerning,
+        h = l.fof ? l.fof : 1,
+        f = !1 !== r.doKerning,
+        d = 0,
+        p = t.length,
+        g = 0,
+        m = c[0] || u,
+        v = [];
+      for (n = 0; n < p; n++) i = t.charCodeAt(n), "function" == typeof a.metadata.widthOfString ? v.push((a.metadata.widthOfGlyph(a.metadata.characterToGlyph(i)) + s * (1e3 / o) || 0) / 1e3) : (d = f && "object" === e(l[i]) && !isNaN(parseInt(l[i][g], 10)) ? l[i][g] / h : 0, v.push((c[i] || m) / u + d)), g = i;
+      return v;
+    }, Me = Oe.getStringUnitWidth = function (t, e) {
+      var r = (e = e || {}).fontSize || this.internal.getFontSize(),
+        n = e.font || this.internal.getFont(),
+        i = e.charSpace || this.internal.getCharSpace();
+      return Oe.processArabic && (t = Oe.processArabic(t)), "function" == typeof n.metadata.widthOfString ? n.metadata.widthOfString(t, r, i) / r : Be.apply(this, arguments).reduce(function (t, e) {
+        return t + e;
+      }, 0);
+    }, Ee = function Ee(t, e, r, n) {
+      for (var i = [], a = 0, o = t.length, s = 0; a !== o && s + e[a] < r;) s += e[a], a++;
+      i.push(t.slice(0, a));
+      var c = a;
+      for (s = 0; a !== o;) s + e[a] > n && (i.push(t.slice(c, a)), s = 0, c = a), s += e[a], a++;
+      return c !== a && i.push(t.slice(c, a)), i;
+    }, qe = function qe(t, e, r) {
+      r || (r = {});
+      var n,
+        i,
+        a,
+        o,
+        s,
+        c,
+        u,
+        l = [],
+        h = [l],
+        f = r.textIndent || 0,
+        d = 0,
+        p = 0,
+        g = t.split(" "),
+        m = Be.apply(this, [" ", r])[0];
+      if (c = -1 === r.lineIndent ? g[0].length + 2 : r.lineIndent || 0) {
+        var v = Array(c).join(" "),
+          b = [];
+        g.map(function (t) {
+          (t = t.split(/\s*\n/)).length > 1 ? b = b.concat(t.map(function (t, e) {
+            return (e && t.length ? "\n" : "") + t;
+          })) : b.push(t[0]);
+        }), g = b, c = Me.apply(this, [v, r]);
+      }
+      for (a = 0, o = g.length; a < o; a++) {
+        var y = 0;
+        if (n = g[a], c && "\n" == n[0] && (n = n.substr(1), y = 1), f + d + (p = (i = Be.apply(this, [n, r])).reduce(function (t, e) {
+          return t + e;
+        }, 0)) > e || y) {
+          if (p > e) {
+            for (s = Ee.apply(this, [n, i, e - (f + d), e]), l.push(s.shift()), l = [s.pop()]; s.length;) h.push([s.shift()]);
+            p = i.slice(n.length - (l[0] ? l[0].length : 0)).reduce(function (t, e) {
+              return t + e;
+            }, 0);
+          } else l = [n];
+          h.push(l), f = p + c, d = m;
+        } else l.push(n), f += d + p, d = m;
+      }
+      return u = c ? function (t, e) {
+        return (e ? v : "") + t.join(" ");
+      } : function (t) {
+        return t.join(" ");
+      }, h.map(u);
+    }, Oe.splitTextToSize = function (t, e, r) {
+      var n,
+        i = (r = r || {}).fontSize || this.internal.getFontSize(),
+        a = function (t) {
+          if (t.widths && t.kerning) return {
+            widths: t.widths,
+            kerning: t.kerning
+          };
+          var e = this.internal.getFont(t.fontName, t.fontStyle);
+          return e.metadata.Unicode ? {
+            widths: e.metadata.Unicode.widths || {
+              0: 1
+            },
+            kerning: e.metadata.Unicode.kerning || {}
+          } : {
+            font: e.metadata,
+            fontSize: this.internal.getFontSize(),
+            charSpace: this.internal.getCharSpace()
+          };
+        }.call(this, r);
+      n = Array.isArray(t) ? t : String(t).split(/\r?\n/);
+      var o = 1 * this.internal.scaleFactor * e / i;
+      a.textIndent = r.textIndent ? 1 * r.textIndent * this.internal.scaleFactor / i : 0, a.lineIndent = r.lineIndent;
+      var s,
+        c,
+        u = [];
+      for (s = 0, c = n.length; s < c; s++) u = u.concat(qe.apply(this, [n[s], o, a]));
+      return u;
+    }, function (t) {
+      t.__fontmetrics__ = t.__fontmetrics__ || {};
+      for (var r = "klmnopqrstuvwxyz", n = {}, i = {}, a = 0; a < r.length; a++) n[r[a]] = "0123456789abcdef"[a], i["0123456789abcdef"[a]] = r[a];
+      var o = function o(t) {
+          return "0x" + parseInt(t, 10).toString(16);
+        },
+        s = t.__fontmetrics__.compress = function (t) {
+          var r,
+            n,
+            a,
+            c,
+            u = ["{"];
+          for (var l in t) {
+            if (r = t[l], isNaN(parseInt(l, 10)) ? n = "'" + l + "'" : (l = parseInt(l, 10), n = (n = o(l).slice(2)).slice(0, -1) + i[n.slice(-1)]), "number" == typeof r) r < 0 ? (a = o(r).slice(3), c = "-") : (a = o(r).slice(2), c = ""), a = c + a.slice(0, -1) + i[a.slice(-1)];else {
+              if ("object" !== e(r)) throw new Error("Don't know what to do with value type " + e(r) + ".");
+              a = s(r);
+            }
+            u.push(n + a);
+          }
+          return u.push("}"), u.join("");
+        },
+        c = t.__fontmetrics__.uncompress = function (t) {
+          if ("string" != typeof t) throw new Error("Invalid argument passed to uncompress.");
+          for (var e, r, i, a, o = {}, s = 1, c = o, u = [], l = "", h = "", f = t.length - 1, d = 1; d < f; d += 1) "'" == (a = t[d]) ? e ? (i = e.join(""), e = void 0) : e = [] : e ? e.push(a) : "{" == a ? (u.push([c, i]), c = {}, i = void 0) : "}" == a ? ((r = u.pop())[0][r[1]] = c, i = void 0, c = r[0]) : "-" == a ? s = -1 : void 0 === i ? n.hasOwnProperty(a) ? (l += n[a], i = parseInt(l, 16) * s, s = 1, l = "") : l += a : n.hasOwnProperty(a) ? (h += n[a], c[i] = parseInt(h, 16) * s, s = 1, i = void 0, h = "") : h += a;
+          return o;
+        },
+        u = {
+          codePages: ["WinAnsiEncoding"],
+          WinAnsiEncoding: c("{19m8n201n9q201o9r201s9l201t9m201u8m201w9n201x9o201y8o202k8q202l8r202m9p202q8p20aw8k203k8t203t8v203u9v2cq8s212m9t15m8w15n9w2dw9s16k8u16l9u17s9z17x8y17y9y}")
+        },
+        l = {
+          Unicode: {
+            Courier: u,
+            "Courier-Bold": u,
+            "Courier-BoldOblique": u,
+            "Courier-Oblique": u,
+            Helvetica: u,
+            "Helvetica-Bold": u,
+            "Helvetica-BoldOblique": u,
+            "Helvetica-Oblique": u,
+            "Times-Roman": u,
+            "Times-Bold": u,
+            "Times-BoldItalic": u,
+            "Times-Italic": u
+          }
+        },
+        h = {
+          Unicode: {
+            "Courier-Oblique": c("{'widths'{k3w'fof'6o}'kerning'{'fof'-6o}}"),
+            "Times-BoldItalic": c("{'widths'{k3o2q4ycx2r201n3m201o6o201s2l201t2l201u2l201w3m201x3m201y3m2k1t2l2r202m2n2n3m2o3m2p5n202q6o2r1w2s2l2t2l2u3m2v3t2w1t2x2l2y1t2z1w3k3m3l3m3m3m3n3m3o3m3p3m3q3m3r3m3s3m203t2l203u2l3v2l3w3t3x3t3y3t3z3m4k5n4l4m4m4m4n4m4o4s4p4m4q4m4r4s4s4y4t2r4u3m4v4m4w3x4x5t4y4s4z4s5k3x5l4s5m4m5n3r5o3x5p4s5q4m5r5t5s4m5t3x5u3x5v2l5w1w5x2l5y3t5z3m6k2l6l3m6m3m6n2w6o3m6p2w6q2l6r3m6s3r6t1w6u1w6v3m6w1w6x4y6y3r6z3m7k3m7l3m7m2r7n2r7o1w7p3r7q2w7r4m7s3m7t2w7u2r7v2n7w1q7x2n7y3t202l3mcl4mal2ram3man3mao3map3mar3mas2lat4uau1uav3maw3way4uaz2lbk2sbl3t'fof'6obo2lbp3tbq3mbr1tbs2lbu1ybv3mbz3mck4m202k3mcm4mcn4mco4mcp4mcq5ycr4mcs4mct4mcu4mcv4mcw2r2m3rcy2rcz2rdl4sdm4sdn4sdo4sdp4sdq4sds4sdt4sdu4sdv4sdw4sdz3mek3mel3mem3men3meo3mep3meq4ser2wes2wet2weu2wev2wew1wex1wey1wez1wfl3rfm3mfn3mfo3mfp3mfq3mfr3tfs3mft3rfu3rfv3rfw3rfz2w203k6o212m6o2dw2l2cq2l3t3m3u2l17s3x19m3m}'kerning'{cl{4qu5kt5qt5rs17ss5ts}201s{201ss}201t{cks4lscmscnscoscpscls2wu2yu201ts}201x{2wu2yu}2k{201ts}2w{4qx5kx5ou5qx5rs17su5tu}2x{17su5tu5ou}2y{4qx5kx5ou5qx5rs17ss5ts}'fof'-6ofn{17sw5tw5ou5qw5rs}7t{cksclscmscnscoscps4ls}3u{17su5tu5os5qs}3v{17su5tu5os5qs}7p{17su5tu}ck{4qu5kt5qt5rs17ss5ts}4l{4qu5kt5qt5rs17ss5ts}cm{4qu5kt5qt5rs17ss5ts}cn{4qu5kt5qt5rs17ss5ts}co{4qu5kt5qt5rs17ss5ts}cp{4qu5kt5qt5rs17ss5ts}6l{4qu5ou5qw5rt17su5tu}5q{ckuclucmucnucoucpu4lu}5r{ckuclucmucnucoucpu4lu}7q{cksclscmscnscoscps4ls}6p{4qu5ou5qw5rt17sw5tw}ek{4qu5ou5qw5rt17su5tu}el{4qu5ou5qw5rt17su5tu}em{4qu5ou5qw5rt17su5tu}en{4qu5ou5qw5rt17su5tu}eo{4qu5ou5qw5rt17su5tu}ep{4qu5ou5qw5rt17su5tu}es{17ss5ts5qs4qu}et{4qu5ou5qw5rt17sw5tw}eu{4qu5ou5qw5rt17ss5ts}ev{17ss5ts5qs4qu}6z{17sw5tw5ou5qw5rs}fm{17sw5tw5ou5qw5rs}7n{201ts}fo{17sw5tw5ou5qw5rs}fp{17sw5tw5ou5qw5rs}fq{17sw5tw5ou5qw5rs}7r{cksclscmscnscoscps4ls}fs{17sw5tw5ou5qw5rs}ft{17su5tu}fu{17su5tu}fv{17su5tu}fw{17su5tu}fz{cksclscmscnscoscps4ls}}}"),
+            "Helvetica-Bold": c("{'widths'{k3s2q4scx1w201n3r201o6o201s1w201t1w201u1w201w3m201x3m201y3m2k1w2l2l202m2n2n3r2o3r2p5t202q6o2r1s2s2l2t2l2u2r2v3u2w1w2x2l2y1w2z1w3k3r3l3r3m3r3n3r3o3r3p3r3q3r3r3r3s3r203t2l203u2l3v2l3w3u3x3u3y3u3z3x4k6l4l4s4m4s4n4s4o4s4p4m4q3x4r4y4s4s4t1w4u3r4v4s4w3x4x5n4y4s4z4y5k4m5l4y5m4s5n4m5o3x5p4s5q4m5r5y5s4m5t4m5u3x5v2l5w1w5x2l5y3u5z3r6k2l6l3r6m3x6n3r6o3x6p3r6q2l6r3x6s3x6t1w6u1w6v3r6w1w6x5t6y3x6z3x7k3x7l3x7m2r7n3r7o2l7p3x7q3r7r4y7s3r7t3r7u3m7v2r7w1w7x2r7y3u202l3rcl4sal2lam3ran3rao3rap3rar3ras2lat4tau2pav3raw3uay4taz2lbk2sbl3u'fof'6obo2lbp3xbq3rbr1wbs2lbu2obv3rbz3xck4s202k3rcm4scn4sco4scp4scq6ocr4scs4mct4mcu4mcv4mcw1w2m2zcy1wcz1wdl4sdm4ydn4ydo4ydp4ydq4yds4ydt4sdu4sdv4sdw4sdz3xek3rel3rem3ren3reo3rep3req5ter3res3ret3reu3rev3rew1wex1wey1wez1wfl3xfm3xfn3xfo3xfp3xfq3xfr3ufs3xft3xfu3xfv3xfw3xfz3r203k6o212m6o2dw2l2cq2l3t3r3u2l17s4m19m3r}'kerning'{cl{4qs5ku5ot5qs17sv5tv}201t{2ww4wy2yw}201w{2ks}201x{2ww4wy2yw}2k{201ts201xs}2w{7qs4qu5kw5os5qw5rs17su5tu7tsfzs}2x{5ow5qs}2y{7qs4qu5kw5os5qw5rs17su5tu7tsfzs}'fof'-6o7p{17su5tu5ot}ck{4qs5ku5ot5qs17sv5tv}4l{4qs5ku5ot5qs17sv5tv}cm{4qs5ku5ot5qs17sv5tv}cn{4qs5ku5ot5qs17sv5tv}co{4qs5ku5ot5qs17sv5tv}cp{4qs5ku5ot5qs17sv5tv}6l{17st5tt5os}17s{2kwclvcmvcnvcovcpv4lv4wwckv}5o{2kucltcmtcntcotcpt4lt4wtckt}5q{2ksclscmscnscoscps4ls4wvcks}5r{2ks4ws}5t{2kwclvcmvcnvcovcpv4lv4wwckv}eo{17st5tt5os}fu{17su5tu5ot}6p{17ss5ts}ek{17st5tt5os}el{17st5tt5os}em{17st5tt5os}en{17st5tt5os}6o{201ts}ep{17st5tt5os}es{17ss5ts}et{17ss5ts}eu{17ss5ts}ev{17ss5ts}6z{17su5tu5os5qt}fm{17su5tu5os5qt}fn{17su5tu5os5qt}fo{17su5tu5os5qt}fp{17su5tu5os5qt}fq{17su5tu5os5qt}fs{17su5tu5os5qt}ft{17su5tu5ot}7m{5os}fv{17su5tu5ot}fw{17su5tu5ot}}}"),
+            Courier: c("{'widths'{k3w'fof'6o}'kerning'{'fof'-6o}}"),
+            "Courier-BoldOblique": c("{'widths'{k3w'fof'6o}'kerning'{'fof'-6o}}"),
+            "Times-Bold": c("{'widths'{k3q2q5ncx2r201n3m201o6o201s2l201t2l201u2l201w3m201x3m201y3m2k1t2l2l202m2n2n3m2o3m2p6o202q6o2r1w2s2l2t2l2u3m2v3t2w1t2x2l2y1t2z1w3k3m3l3m3m3m3n3m3o3m3p3m3q3m3r3m3s3m203t2l203u2l3v2l3w3t3x3t3y3t3z3m4k5x4l4s4m4m4n4s4o4s4p4m4q3x4r4y4s4y4t2r4u3m4v4y4w4m4x5y4y4s4z4y5k3x5l4y5m4s5n3r5o4m5p4s5q4s5r6o5s4s5t4s5u4m5v2l5w1w5x2l5y3u5z3m6k2l6l3m6m3r6n2w6o3r6p2w6q2l6r3m6s3r6t1w6u2l6v3r6w1w6x5n6y3r6z3m7k3r7l3r7m2w7n2r7o2l7p3r7q3m7r4s7s3m7t3m7u2w7v2r7w1q7x2r7y3o202l3mcl4sal2lam3man3mao3map3mar3mas2lat4uau1yav3maw3tay4uaz2lbk2sbl3t'fof'6obo2lbp3rbr1tbs2lbu2lbv3mbz3mck4s202k3mcm4scn4sco4scp4scq6ocr4scs4mct4mcu4mcv4mcw2r2m3rcy2rcz2rdl4sdm4ydn4ydo4ydp4ydq4yds4ydt4sdu4sdv4sdw4sdz3rek3mel3mem3men3meo3mep3meq4ser2wes2wet2weu2wev2wew1wex1wey1wez1wfl3rfm3mfn3mfo3mfp3mfq3mfr3tfs3mft3rfu3rfv3rfw3rfz3m203k6o212m6o2dw2l2cq2l3t3m3u2l17s4s19m3m}'kerning'{cl{4qt5ks5ot5qy5rw17sv5tv}201t{cks4lscmscnscoscpscls4wv}2k{201ts}2w{4qu5ku7mu5os5qx5ru17su5tu}2x{17su5tu5ou5qs}2y{4qv5kv7mu5ot5qz5ru17su5tu}'fof'-6o7t{cksclscmscnscoscps4ls}3u{17su5tu5os5qu}3v{17su5tu5os5qu}fu{17su5tu5ou5qu}7p{17su5tu5ou5qu}ck{4qt5ks5ot5qy5rw17sv5tv}4l{4qt5ks5ot5qy5rw17sv5tv}cm{4qt5ks5ot5qy5rw17sv5tv}cn{4qt5ks5ot5qy5rw17sv5tv}co{4qt5ks5ot5qy5rw17sv5tv}cp{4qt5ks5ot5qy5rw17sv5tv}6l{17st5tt5ou5qu}17s{ckuclucmucnucoucpu4lu4wu}5o{ckuclucmucnucoucpu4lu4wu}5q{ckzclzcmzcnzcozcpz4lz4wu}5r{ckxclxcmxcnxcoxcpx4lx4wu}5t{ckuclucmucnucoucpu4lu4wu}7q{ckuclucmucnucoucpu4lu}6p{17sw5tw5ou5qu}ek{17st5tt5qu}el{17st5tt5ou5qu}em{17st5tt5qu}en{17st5tt5qu}eo{17st5tt5qu}ep{17st5tt5ou5qu}es{17ss5ts5qu}et{17sw5tw5ou5qu}eu{17sw5tw5ou5qu}ev{17ss5ts5qu}6z{17sw5tw5ou5qu5rs}fm{17sw5tw5ou5qu5rs}fn{17sw5tw5ou5qu5rs}fo{17sw5tw5ou5qu5rs}fp{17sw5tw5ou5qu5rs}fq{17sw5tw5ou5qu5rs}7r{cktcltcmtcntcotcpt4lt5os}fs{17sw5tw5ou5qu5rs}ft{17su5tu5ou5qu}7m{5os}fv{17su5tu5ou5qu}fw{17su5tu5ou5qu}fz{cksclscmscnscoscps4ls}}}"),
+            Symbol: c("{'widths'{k3uaw4r19m3m2k1t2l2l202m2y2n3m2p5n202q6o3k3m2s2l2t2l2v3r2w1t3m3m2y1t2z1wbk2sbl3r'fof'6o3n3m3o3m3p3m3q3m3r3m3s3m3t3m3u1w3v1w3w3r3x3r3y3r3z2wbp3t3l3m5v2l5x2l5z3m2q4yfr3r7v3k7w1o7x3k}'kerning'{'fof'-6o}}"),
+            Helvetica: c("{'widths'{k3p2q4mcx1w201n3r201o6o201s1q201t1q201u1q201w2l201x2l201y2l2k1w2l1w202m2n2n3r2o3r2p5t202q6o2r1n2s2l2t2l2u2r2v3u2w1w2x2l2y1w2z1w3k3r3l3r3m3r3n3r3o3r3p3r3q3r3r3r3s3r203t2l203u2l3v1w3w3u3x3u3y3u3z3r4k6p4l4m4m4m4n4s4o4s4p4m4q3x4r4y4s4s4t1w4u3m4v4m4w3r4x5n4y4s4z4y5k4m5l4y5m4s5n4m5o3x5p4s5q4m5r5y5s4m5t4m5u3x5v1w5w1w5x1w5y2z5z3r6k2l6l3r6m3r6n3m6o3r6p3r6q1w6r3r6s3r6t1q6u1q6v3m6w1q6x5n6y3r6z3r7k3r7l3r7m2l7n3m7o1w7p3r7q3m7r4s7s3m7t3m7u3m7v2l7w1u7x2l7y3u202l3rcl4mal2lam3ran3rao3rap3rar3ras2lat4tau2pav3raw3uay4taz2lbk2sbl3u'fof'6obo2lbp3rbr1wbs2lbu2obv3rbz3xck4m202k3rcm4mcn4mco4mcp4mcq6ocr4scs4mct4mcu4mcv4mcw1w2m2ncy1wcz1wdl4sdm4ydn4ydo4ydp4ydq4yds4ydt4sdu4sdv4sdw4sdz3xek3rel3rem3ren3reo3rep3req5ter3mes3ret3reu3rev3rew1wex1wey1wez1wfl3rfm3rfn3rfo3rfp3rfq3rfr3ufs3xft3rfu3rfv3rfw3rfz3m203k6o212m6o2dw2l2cq2l3t3r3u1w17s4m19m3r}'kerning'{5q{4wv}cl{4qs5kw5ow5qs17sv5tv}201t{2wu4w1k2yu}201x{2wu4wy2yu}17s{2ktclucmucnu4otcpu4lu4wycoucku}2w{7qs4qz5k1m17sy5ow5qx5rsfsu5ty7tufzu}2x{17sy5ty5oy5qs}2y{7qs4qz5k1m17sy5ow5qx5rsfsu5ty7tufzu}'fof'-6o7p{17sv5tv5ow}ck{4qs5kw5ow5qs17sv5tv}4l{4qs5kw5ow5qs17sv5tv}cm{4qs5kw5ow5qs17sv5tv}cn{4qs5kw5ow5qs17sv5tv}co{4qs5kw5ow5qs17sv5tv}cp{4qs5kw5ow5qs17sv5tv}6l{17sy5ty5ow}do{17st5tt}4z{17st5tt}7s{fst}dm{17st5tt}dn{17st5tt}5o{ckwclwcmwcnwcowcpw4lw4wv}dp{17st5tt}dq{17st5tt}7t{5ow}ds{17st5tt}5t{2ktclucmucnu4otcpu4lu4wycoucku}fu{17sv5tv5ow}6p{17sy5ty5ow5qs}ek{17sy5ty5ow}el{17sy5ty5ow}em{17sy5ty5ow}en{5ty}eo{17sy5ty5ow}ep{17sy5ty5ow}es{17sy5ty5qs}et{17sy5ty5ow5qs}eu{17sy5ty5ow5qs}ev{17sy5ty5ow5qs}6z{17sy5ty5ow5qs}fm{17sy5ty5ow5qs}fn{17sy5ty5ow5qs}fo{17sy5ty5ow5qs}fp{17sy5ty5qs}fq{17sy5ty5ow5qs}7r{5ow}fs{17sy5ty5ow5qs}ft{17sv5tv5ow}7m{5ow}fv{17sv5tv5ow}fw{17sv5tv5ow}}}"),
+            "Helvetica-BoldOblique": c("{'widths'{k3s2q4scx1w201n3r201o6o201s1w201t1w201u1w201w3m201x3m201y3m2k1w2l2l202m2n2n3r2o3r2p5t202q6o2r1s2s2l2t2l2u2r2v3u2w1w2x2l2y1w2z1w3k3r3l3r3m3r3n3r3o3r3p3r3q3r3r3r3s3r203t2l203u2l3v2l3w3u3x3u3y3u3z3x4k6l4l4s4m4s4n4s4o4s4p4m4q3x4r4y4s4s4t1w4u3r4v4s4w3x4x5n4y4s4z4y5k4m5l4y5m4s5n4m5o3x5p4s5q4m5r5y5s4m5t4m5u3x5v2l5w1w5x2l5y3u5z3r6k2l6l3r6m3x6n3r6o3x6p3r6q2l6r3x6s3x6t1w6u1w6v3r6w1w6x5t6y3x6z3x7k3x7l3x7m2r7n3r7o2l7p3x7q3r7r4y7s3r7t3r7u3m7v2r7w1w7x2r7y3u202l3rcl4sal2lam3ran3rao3rap3rar3ras2lat4tau2pav3raw3uay4taz2lbk2sbl3u'fof'6obo2lbp3xbq3rbr1wbs2lbu2obv3rbz3xck4s202k3rcm4scn4sco4scp4scq6ocr4scs4mct4mcu4mcv4mcw1w2m2zcy1wcz1wdl4sdm4ydn4ydo4ydp4ydq4yds4ydt4sdu4sdv4sdw4sdz3xek3rel3rem3ren3reo3rep3req5ter3res3ret3reu3rev3rew1wex1wey1wez1wfl3xfm3xfn3xfo3xfp3xfq3xfr3ufs3xft3xfu3xfv3xfw3xfz3r203k6o212m6o2dw2l2cq2l3t3r3u2l17s4m19m3r}'kerning'{cl{4qs5ku5ot5qs17sv5tv}201t{2ww4wy2yw}201w{2ks}201x{2ww4wy2yw}2k{201ts201xs}2w{7qs4qu5kw5os5qw5rs17su5tu7tsfzs}2x{5ow5qs}2y{7qs4qu5kw5os5qw5rs17su5tu7tsfzs}'fof'-6o7p{17su5tu5ot}ck{4qs5ku5ot5qs17sv5tv}4l{4qs5ku5ot5qs17sv5tv}cm{4qs5ku5ot5qs17sv5tv}cn{4qs5ku5ot5qs17sv5tv}co{4qs5ku5ot5qs17sv5tv}cp{4qs5ku5ot5qs17sv5tv}6l{17st5tt5os}17s{2kwclvcmvcnvcovcpv4lv4wwckv}5o{2kucltcmtcntcotcpt4lt4wtckt}5q{2ksclscmscnscoscps4ls4wvcks}5r{2ks4ws}5t{2kwclvcmvcnvcovcpv4lv4wwckv}eo{17st5tt5os}fu{17su5tu5ot}6p{17ss5ts}ek{17st5tt5os}el{17st5tt5os}em{17st5tt5os}en{17st5tt5os}6o{201ts}ep{17st5tt5os}es{17ss5ts}et{17ss5ts}eu{17ss5ts}ev{17ss5ts}6z{17su5tu5os5qt}fm{17su5tu5os5qt}fn{17su5tu5os5qt}fo{17su5tu5os5qt}fp{17su5tu5os5qt}fq{17su5tu5os5qt}fs{17su5tu5os5qt}ft{17su5tu5ot}7m{5os}fv{17su5tu5ot}fw{17su5tu5ot}}}"),
+            ZapfDingbats: c("{'widths'{k4u2k1w'fof'6o}'kerning'{'fof'-6o}}"),
+            "Courier-Bold": c("{'widths'{k3w'fof'6o}'kerning'{'fof'-6o}}"),
+            "Times-Italic": c("{'widths'{k3n2q4ycx2l201n3m201o5t201s2l201t2l201u2l201w3r201x3r201y3r2k1t2l2l202m2n2n3m2o3m2p5n202q5t2r1p2s2l2t2l2u3m2v4n2w1t2x2l2y1t2z1w3k3m3l3m3m3m3n3m3o3m3p3m3q3m3r3m3s3m203t2l203u2l3v2l3w4n3x4n3y4n3z3m4k5w4l3x4m3x4n4m4o4s4p3x4q3x4r4s4s4s4t2l4u2w4v4m4w3r4x5n4y4m4z4s5k3x5l4s5m3x5n3m5o3r5p4s5q3x5r5n5s3x5t3r5u3r5v2r5w1w5x2r5y2u5z3m6k2l6l3m6m3m6n2w6o3m6p2w6q1w6r3m6s3m6t1w6u1w6v2w6w1w6x4s6y3m6z3m7k3m7l3m7m2r7n2r7o1w7p3m7q2w7r4m7s2w7t2w7u2r7v2s7w1v7x2s7y3q202l3mcl3xal2ram3man3mao3map3mar3mas2lat4wau1vav3maw4nay4waz2lbk2sbl4n'fof'6obo2lbp3mbq3obr1tbs2lbu1zbv3mbz3mck3x202k3mcm3xcn3xco3xcp3xcq5tcr4mcs3xct3xcu3xcv3xcw2l2m2ucy2lcz2ldl4mdm4sdn4sdo4sdp4sdq4sds4sdt4sdu4sdv4sdw4sdz3mek3mel3mem3men3meo3mep3meq4mer2wes2wet2weu2wev2wew1wex1wey1wez1wfl3mfm3mfn3mfo3mfp3mfq3mfr4nfs3mft3mfu3mfv3mfw3mfz2w203k6o212m6m2dw2l2cq2l3t3m3u2l17s3r19m3m}'kerning'{cl{5kt4qw}201s{201sw}201t{201tw2wy2yy6q-t}201x{2wy2yy}2k{201tw}2w{7qs4qy7rs5ky7mw5os5qx5ru17su5tu}2x{17ss5ts5os}2y{7qs4qy7rs5ky7mw5os5qx5ru17su5tu}'fof'-6o6t{17ss5ts5qs}7t{5os}3v{5qs}7p{17su5tu5qs}ck{5kt4qw}4l{5kt4qw}cm{5kt4qw}cn{5kt4qw}co{5kt4qw}cp{5kt4qw}6l{4qs5ks5ou5qw5ru17su5tu}17s{2ks}5q{ckvclvcmvcnvcovcpv4lv}5r{ckuclucmucnucoucpu4lu}5t{2ks}6p{4qs5ks5ou5qw5ru17su5tu}ek{4qs5ks5ou5qw5ru17su5tu}el{4qs5ks5ou5qw5ru17su5tu}em{4qs5ks5ou5qw5ru17su5tu}en{4qs5ks5ou5qw5ru17su5tu}eo{4qs5ks5ou5qw5ru17su5tu}ep{4qs5ks5ou5qw5ru17su5tu}es{5ks5qs4qs}et{4qs5ks5ou5qw5ru17su5tu}eu{4qs5ks5qw5ru17su5tu}ev{5ks5qs4qs}ex{17ss5ts5qs}6z{4qv5ks5ou5qw5ru17su5tu}fm{4qv5ks5ou5qw5ru17su5tu}fn{4qv5ks5ou5qw5ru17su5tu}fo{4qv5ks5ou5qw5ru17su5tu}fp{4qv5ks5ou5qw5ru17su5tu}fq{4qv5ks5ou5qw5ru17su5tu}7r{5os}fs{4qv5ks5ou5qw5ru17su5tu}ft{17su5tu5qs}fu{17su5tu5qs}fv{17su5tu5qs}fw{17su5tu5qs}}}"),
+            "Times-Roman": c("{'widths'{k3n2q4ycx2l201n3m201o6o201s2l201t2l201u2l201w2w201x2w201y2w2k1t2l2l202m2n2n3m2o3m2p5n202q6o2r1m2s2l2t2l2u3m2v3s2w1t2x2l2y1t2z1w3k3m3l3m3m3m3n3m3o3m3p3m3q3m3r3m3s3m203t2l203u2l3v1w3w3s3x3s3y3s3z2w4k5w4l4s4m4m4n4m4o4s4p3x4q3r4r4s4s4s4t2l4u2r4v4s4w3x4x5t4y4s4z4s5k3r5l4s5m4m5n3r5o3x5p4s5q4s5r5y5s4s5t4s5u3x5v2l5w1w5x2l5y2z5z3m6k2l6l2w6m3m6n2w6o3m6p2w6q2l6r3m6s3m6t1w6u1w6v3m6w1w6x4y6y3m6z3m7k3m7l3m7m2l7n2r7o1w7p3m7q3m7r4s7s3m7t3m7u2w7v3k7w1o7x3k7y3q202l3mcl4sal2lam3man3mao3map3mar3mas2lat4wau1vav3maw3say4waz2lbk2sbl3s'fof'6obo2lbp3mbq2xbr1tbs2lbu1zbv3mbz2wck4s202k3mcm4scn4sco4scp4scq5tcr4mcs3xct3xcu3xcv3xcw2l2m2tcy2lcz2ldl4sdm4sdn4sdo4sdp4sdq4sds4sdt4sdu4sdv4sdw4sdz3mek2wel2wem2wen2weo2wep2weq4mer2wes2wet2weu2wev2wew1wex1wey1wez1wfl3mfm3mfn3mfo3mfp3mfq3mfr3sfs3mft3mfu3mfv3mfw3mfz3m203k6o212m6m2dw2l2cq2l3t3m3u1w17s4s19m3m}'kerning'{cl{4qs5ku17sw5ou5qy5rw201ss5tw201ws}201s{201ss}201t{ckw4lwcmwcnwcowcpwclw4wu201ts}2k{201ts}2w{4qs5kw5os5qx5ru17sx5tx}2x{17sw5tw5ou5qu}2y{4qs5kw5os5qx5ru17sx5tx}'fof'-6o7t{ckuclucmucnucoucpu4lu5os5rs}3u{17su5tu5qs}3v{17su5tu5qs}7p{17sw5tw5qs}ck{4qs5ku17sw5ou5qy5rw201ss5tw201ws}4l{4qs5ku17sw5ou5qy5rw201ss5tw201ws}cm{4qs5ku17sw5ou5qy5rw201ss5tw201ws}cn{4qs5ku17sw5ou5qy5rw201ss5tw201ws}co{4qs5ku17sw5ou5qy5rw201ss5tw201ws}cp{4qs5ku17sw5ou5qy5rw201ss5tw201ws}6l{17su5tu5os5qw5rs}17s{2ktclvcmvcnvcovcpv4lv4wuckv}5o{ckwclwcmwcnwcowcpw4lw4wu}5q{ckyclycmycnycoycpy4ly4wu5ms}5r{cktcltcmtcntcotcpt4lt4ws}5t{2ktclvcmvcnvcovcpv4lv4wuckv}7q{cksclscmscnscoscps4ls}6p{17su5tu5qw5rs}ek{5qs5rs}el{17su5tu5os5qw5rs}em{17su5tu5os5qs5rs}en{17su5qs5rs}eo{5qs5rs}ep{17su5tu5os5qw5rs}es{5qs}et{17su5tu5qw5rs}eu{17su5tu5qs5rs}ev{5qs}6z{17sv5tv5os5qx5rs}fm{5os5qt5rs}fn{17sv5tv5os5qx5rs}fo{17sv5tv5os5qx5rs}fp{5os5qt5rs}fq{5os5qt5rs}7r{ckuclucmucnucoucpu4lu5os}fs{17sv5tv5os5qx5rs}ft{17ss5ts5qs}fu{17sw5tw5qs}fv{17sw5tw5qs}fw{17ss5ts5qs}fz{ckuclucmucnucoucpu4lu5os5rs}}}"),
+            "Helvetica-Oblique": c("{'widths'{k3p2q4mcx1w201n3r201o6o201s1q201t1q201u1q201w2l201x2l201y2l2k1w2l1w202m2n2n3r2o3r2p5t202q6o2r1n2s2l2t2l2u2r2v3u2w1w2x2l2y1w2z1w3k3r3l3r3m3r3n3r3o3r3p3r3q3r3r3r3s3r203t2l203u2l3v1w3w3u3x3u3y3u3z3r4k6p4l4m4m4m4n4s4o4s4p4m4q3x4r4y4s4s4t1w4u3m4v4m4w3r4x5n4y4s4z4y5k4m5l4y5m4s5n4m5o3x5p4s5q4m5r5y5s4m5t4m5u3x5v1w5w1w5x1w5y2z5z3r6k2l6l3r6m3r6n3m6o3r6p3r6q1w6r3r6s3r6t1q6u1q6v3m6w1q6x5n6y3r6z3r7k3r7l3r7m2l7n3m7o1w7p3r7q3m7r4s7s3m7t3m7u3m7v2l7w1u7x2l7y3u202l3rcl4mal2lam3ran3rao3rap3rar3ras2lat4tau2pav3raw3uay4taz2lbk2sbl3u'fof'6obo2lbp3rbr1wbs2lbu2obv3rbz3xck4m202k3rcm4mcn4mco4mcp4mcq6ocr4scs4mct4mcu4mcv4mcw1w2m2ncy1wcz1wdl4sdm4ydn4ydo4ydp4ydq4yds4ydt4sdu4sdv4sdw4sdz3xek3rel3rem3ren3reo3rep3req5ter3mes3ret3reu3rev3rew1wex1wey1wez1wfl3rfm3rfn3rfo3rfp3rfq3rfr3ufs3xft3rfu3rfv3rfw3rfz3m203k6o212m6o2dw2l2cq2l3t3r3u1w17s4m19m3r}'kerning'{5q{4wv}cl{4qs5kw5ow5qs17sv5tv}201t{2wu4w1k2yu}201x{2wu4wy2yu}17s{2ktclucmucnu4otcpu4lu4wycoucku}2w{7qs4qz5k1m17sy5ow5qx5rsfsu5ty7tufzu}2x{17sy5ty5oy5qs}2y{7qs4qz5k1m17sy5ow5qx5rsfsu5ty7tufzu}'fof'-6o7p{17sv5tv5ow}ck{4qs5kw5ow5qs17sv5tv}4l{4qs5kw5ow5qs17sv5tv}cm{4qs5kw5ow5qs17sv5tv}cn{4qs5kw5ow5qs17sv5tv}co{4qs5kw5ow5qs17sv5tv}cp{4qs5kw5ow5qs17sv5tv}6l{17sy5ty5ow}do{17st5tt}4z{17st5tt}7s{fst}dm{17st5tt}dn{17st5tt}5o{ckwclwcmwcnwcowcpw4lw4wv}dp{17st5tt}dq{17st5tt}7t{5ow}ds{17st5tt}5t{2ktclucmucnu4otcpu4lu4wycoucku}fu{17sv5tv5ow}6p{17sy5ty5ow5qs}ek{17sy5ty5ow}el{17sy5ty5ow}em{17sy5ty5ow}en{5ty}eo{17sy5ty5ow}ep{17sy5ty5ow}es{17sy5ty5qs}et{17sy5ty5ow5qs}eu{17sy5ty5ow5qs}ev{17sy5ty5ow5qs}6z{17sy5ty5ow5qs}fm{17sy5ty5ow5qs}fn{17sy5ty5ow5qs}fo{17sy5ty5ow5qs}fp{17sy5ty5qs}fq{17sy5ty5ow5qs}7r{5ow}fs{17sy5ty5ow5qs}ft{17sv5tv5ow}7m{5ow}fv{17sv5tv5ow}fw{17sv5tv5ow}}}")
+          }
+        };
+      t.events.push(["addFont", function (t) {
+        var e = t.font,
+          r = h.Unicode[e.postScriptName];
+        r && (e.metadata.Unicode = {}, e.metadata.Unicode.widths = r.widths, e.metadata.Unicode.kerning = r.kerning);
+        var n = l.Unicode[e.postScriptName];
+        n && (e.metadata.Unicode.encoding = n, e.encoding = n.codePages[0]);
+      }]);
+    }(M.API),
+    /**
+       * @license
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      var e = function e(t) {
+        for (var e = t.length, r = new Uint8Array(e), n = 0; n < e; n++) r[n] = t.charCodeAt(n);
+        return r;
+      };
+      t.API.events.push(["addFont", function (r) {
+        var n = void 0,
+          i = r.font,
+          a = r.instance;
+        if (!i.isStandardFont) {
+          if (void 0 === a) throw new Error("Font does not exist in vFS, import fonts or remove declaration doc.addFont('" + i.postScriptName + "').");
+          if ("string" != typeof (n = !1 === a.existsFileInVFS(i.postScriptName) ? a.loadFile(i.postScriptName) : a.getFileFromVFS(i.postScriptName))) throw new Error("Font is not stored as string-data in vFS, import fonts or remove declaration doc.addFont('" + i.postScriptName + "').");
+          !function (r, n) {
+            n = /^\x00\x01\x00\x00/.test(n) ? e(n) : e(c(n)), r.metadata = t.API.TTFFont.open(n), r.metadata.Unicode = r.metadata.Unicode || {
+              encoding: {},
+              kerning: {},
+              widths: []
+            }, r.metadata.glyIdsUsed = [0];
+          }(i, n);
+        }
+      }]);
+    }(M), function (n) {
+      function a() {
+        return (r.canvg ? Promise.resolve(r.canvg) : "object" === (void 0 === t ? "undefined" : e(t)) && "undefined" != typeof module ? new Promise(function (t, e) {
+          try {
+            t(require("canvg"));
+          } catch (t) {
+            e(t);
+          }
+        }) : "function" == typeof define && define.amd ? new Promise(function (t, e) {
+          try {
+            require(["canvg"], t);
+          } catch (t) {
+            e(t);
+          }
+        }) : Promise.reject(new Error("Could not load canvg"))).catch(function (t) {
+          return Promise.reject(new Error("Could not load canvg: " + t));
+        }).then(function (t) {
+          return t.default ? t.default : t;
+        });
+      }
+      n.addSvgAsImage = function (t, e, r, n, o, s, c, u) {
+        if (isNaN(e) || isNaN(r)) throw i.error("jsPDF.addSvgAsImage: Invalid coordinates", arguments), new Error("Invalid coordinates passed to jsPDF.addSvgAsImage");
+        if (isNaN(n) || isNaN(o)) throw i.error("jsPDF.addSvgAsImage: Invalid measurements", arguments), new Error("Invalid measurements (width and/or height) passed to jsPDF.addSvgAsImage");
+        var l = document.createElement("canvas");
+        l.width = n, l.height = o;
+        var h = l.getContext("2d");
+        h.fillStyle = "#fff", h.fillRect(0, 0, l.width, l.height);
+        var f = {
+            ignoreMouse: !0,
+            ignoreAnimation: !0,
+            ignoreDimensions: !0
+          },
+          d = this;
+        return a().then(function (e) {
+          return e.fromString(h, t, f);
+        }, function () {
+          return Promise.reject(new Error("Could not load canvg."));
+        }).then(function (t) {
+          return t.render(f);
+        }).then(function () {
+          d.addImage(l.toDataURL("image/jpeg", 1), e, r, n, o, c, u);
+        });
+      };
+    }(M.API),
+    /**
+       * @license
+       * ====================================================================
+       * Copyright (c) 2013 Eduardo Menezes de Morais, eduardo.morais@usp.br
+       *
+       * Permission is hereby granted, free of charge, to any person obtaining
+       * a copy of this software and associated documentation files (the
+       * "Software"), to deal in the Software without restriction, including
+       * without limitation the rights to use, copy, modify, merge, publish,
+       * distribute, sublicense, and/or sell copies of the Software, and to
+       * permit persons to whom the Software is furnished to do so, subject to
+       * the following conditions:
+       *
+       * The above copyright notice and this permission notice shall be
+       * included in all copies or substantial portions of the Software.
+       *
+       * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+       * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+       * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+       * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+       * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+       * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+       * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+       * ====================================================================
+       */
+    function (t) {
+      t.putTotalPages = function (t) {
+        var e,
+          r = 0;
+        parseInt(this.internal.getFont().id.substr(1), 10) < 15 ? (e = new RegExp(t, "g"), r = this.internal.getNumberOfPages()) : (e = new RegExp(this.pdfEscape16(t, this.internal.getFont()), "g"), r = this.pdfEscape16(this.internal.getNumberOfPages() + "", this.internal.getFont()));
+        for (var n = 1; n <= this.internal.getNumberOfPages(); n++) for (var i = 0; i < this.internal.pages[n].length; i++) this.internal.pages[n][i] = this.internal.pages[n][i].replace(e, r);
+        return this;
+      };
+    }(M.API), function (t) {
+      t.viewerPreferences = function (t, r) {
+        var n;
+        t = t || {}, r = r || !1;
+        var i,
+          a,
+          o,
+          s = {
+            HideToolbar: {
+              defaultValue: !1,
+              value: !1,
+              type: "boolean",
+              explicitSet: !1,
+              valueSet: [!0, !1],
+              pdfVersion: 1.3
+            },
+            HideMenubar: {
+              defaultValue: !1,
+              value: !1,
+              type: "boolean",
+              explicitSet: !1,
+              valueSet: [!0, !1],
+              pdfVersion: 1.3
+            },
+            HideWindowUI: {
+              defaultValue: !1,
+              value: !1,
+              type: "boolean",
+              explicitSet: !1,
+              valueSet: [!0, !1],
+              pdfVersion: 1.3
+            },
+            FitWindow: {
+              defaultValue: !1,
+              value: !1,
+              type: "boolean",
+              explicitSet: !1,
+              valueSet: [!0, !1],
+              pdfVersion: 1.3
+            },
+            CenterWindow: {
+              defaultValue: !1,
+              value: !1,
+              type: "boolean",
+              explicitSet: !1,
+              valueSet: [!0, !1],
+              pdfVersion: 1.3
+            },
+            DisplayDocTitle: {
+              defaultValue: !1,
+              value: !1,
+              type: "boolean",
+              explicitSet: !1,
+              valueSet: [!0, !1],
+              pdfVersion: 1.4
+            },
+            NonFullScreenPageMode: {
+              defaultValue: "UseNone",
+              value: "UseNone",
+              type: "name",
+              explicitSet: !1,
+              valueSet: ["UseNone", "UseOutlines", "UseThumbs", "UseOC"],
+              pdfVersion: 1.3
+            },
+            Direction: {
+              defaultValue: "L2R",
+              value: "L2R",
+              type: "name",
+              explicitSet: !1,
+              valueSet: ["L2R", "R2L"],
+              pdfVersion: 1.3
+            },
+            ViewArea: {
+              defaultValue: "CropBox",
+              value: "CropBox",
+              type: "name",
+              explicitSet: !1,
+              valueSet: ["MediaBox", "CropBox", "TrimBox", "BleedBox", "ArtBox"],
+              pdfVersion: 1.4
+            },
+            ViewClip: {
+              defaultValue: "CropBox",
+              value: "CropBox",
+              type: "name",
+              explicitSet: !1,
+              valueSet: ["MediaBox", "CropBox", "TrimBox", "BleedBox", "ArtBox"],
+              pdfVersion: 1.4
+            },
+            PrintArea: {
+              defaultValue: "CropBox",
+              value: "CropBox",
+              type: "name",
+              explicitSet: !1,
+              valueSet: ["MediaBox", "CropBox", "TrimBox", "BleedBox", "ArtBox"],
+              pdfVersion: 1.4
+            },
+            PrintClip: {
+              defaultValue: "CropBox",
+              value: "CropBox",
+              type: "name",
+              explicitSet: !1,
+              valueSet: ["MediaBox", "CropBox", "TrimBox", "BleedBox", "ArtBox"],
+              pdfVersion: 1.4
+            },
+            PrintScaling: {
+              defaultValue: "AppDefault",
+              value: "AppDefault",
+              type: "name",
+              explicitSet: !1,
+              valueSet: ["AppDefault", "None"],
+              pdfVersion: 1.6
+            },
+            Duplex: {
+              defaultValue: "",
+              value: "none",
+              type: "name",
+              explicitSet: !1,
+              valueSet: ["Simplex", "DuplexFlipShortEdge", "DuplexFlipLongEdge", "none"],
+              pdfVersion: 1.7
+            },
+            PickTrayByPDFSize: {
+              defaultValue: !1,
+              value: !1,
+              type: "boolean",
+              explicitSet: !1,
+              valueSet: [!0, !1],
+              pdfVersion: 1.7
+            },
+            PrintPageRange: {
+              defaultValue: "",
+              value: "",
+              type: "array",
+              explicitSet: !1,
+              valueSet: null,
+              pdfVersion: 1.7
+            },
+            NumCopies: {
+              defaultValue: 1,
+              value: 1,
+              type: "integer",
+              explicitSet: !1,
+              valueSet: null,
+              pdfVersion: 1.7
+            }
+          },
+          c = Object.keys(s),
+          u = [],
+          l = 0,
+          h = 0,
+          f = 0;
+        function d(t, e) {
+          var r,
+            n = !1;
+          for (r = 0; r < t.length; r += 1) t[r] === e && (n = !0);
+          return n;
+        }
+        if (void 0 === this.internal.viewerpreferences && (this.internal.viewerpreferences = {}, this.internal.viewerpreferences.configuration = JSON.parse(JSON.stringify(s)), this.internal.viewerpreferences.isSubscribed = !1), n = this.internal.viewerpreferences.configuration, "reset" === t || !0 === r) {
+          var p = c.length;
+          for (f = 0; f < p; f += 1) n[c[f]].value = n[c[f]].defaultValue, n[c[f]].explicitSet = !1;
+        }
+        if ("object" === e(t)) for (a in t) if (o = t[a], d(c, a) && void 0 !== o) {
+          if ("boolean" === n[a].type && "boolean" == typeof o) n[a].value = o;else if ("name" === n[a].type && d(n[a].valueSet, o)) n[a].value = o;else if ("integer" === n[a].type && Number.isInteger(o)) n[a].value = o;else if ("array" === n[a].type) {
+            for (l = 0; l < o.length; l += 1) if (i = !0, 1 === o[l].length && "number" == typeof o[l][0]) u.push(String(o[l] - 1));else if (o[l].length > 1) {
+              for (h = 0; h < o[l].length; h += 1) "number" != typeof o[l][h] && (i = !1);
+              !0 === i && u.push([o[l][0] - 1, o[l][1] - 1].join(" "));
+            }
+            n[a].value = "[" + u.join(" ") + "]";
+          } else n[a].value = n[a].defaultValue;
+          n[a].explicitSet = !0;
+        }
+        return !1 === this.internal.viewerpreferences.isSubscribed && (this.internal.events.subscribe("putCatalog", function () {
+          var t,
+            e = [];
+          for (t in n) !0 === n[t].explicitSet && ("name" === n[t].type ? e.push("/" + t + " /" + n[t].value) : e.push("/" + t + " " + n[t].value));
+          0 !== e.length && this.internal.write("/ViewerPreferences\n<<\n" + e.join("\n") + "\n>>");
+        }), this.internal.viewerpreferences.isSubscribed = !0), this.internal.viewerpreferences.configuration = n, this;
+      };
+    }(M.API),
+    /** ====================================================================
+       * @license
+       * jsPDF XMP metadata plugin
+       * Copyright (c) 2016 Jussi Utunen, u-jussi@suomi24.fi
+       *
+       * Permission is hereby granted, free of charge, to any person obtaining
+       * a copy of this software and associated documentation files (the
+       * "Software"), to deal in the Software without restriction, including
+       * without limitation the rights to use, copy, modify, merge, publish,
+       * distribute, sublicense, and/or sell copies of the Software, and to
+       * permit persons to whom the Software is furnished to do so, subject to
+       * the following conditions:
+       *
+       * The above copyright notice and this permission notice shall be
+       * included in all copies or substantial portions of the Software.
+       *
+       * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+       * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+       * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+       * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+       * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+       * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+       * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+       * ====================================================================
+       */
+    function (t) {
+      var e = function e() {
+          var t = '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:jspdf="' + this.internal.__metadata__.namespaceuri + '"><jspdf:metadata>',
+            e = unescape(encodeURIComponent('<x:xmpmeta xmlns:x="adobe:ns:meta/">')),
+            r = unescape(encodeURIComponent(t)),
+            n = unescape(encodeURIComponent(this.internal.__metadata__.metadata)),
+            i = unescape(encodeURIComponent("</jspdf:metadata></rdf:Description></rdf:RDF>")),
+            a = unescape(encodeURIComponent("</x:xmpmeta>")),
+            o = r.length + n.length + i.length + e.length + a.length;
+          this.internal.__metadata__.metadata_object_number = this.internal.newObject(), this.internal.write("<< /Type /Metadata /Subtype /XML /Length " + o + " >>"), this.internal.write("stream"), this.internal.write(e + r + n + i + a), this.internal.write("endstream"), this.internal.write("endobj");
+        },
+        r = function r() {
+          this.internal.__metadata__.metadata_object_number && this.internal.write("/Metadata " + this.internal.__metadata__.metadata_object_number + " 0 R");
+        };
+      t.addMetadata = function (t, n) {
+        return void 0 === this.internal.__metadata__ && (this.internal.__metadata__ = {
+          metadata: t,
+          namespaceuri: n || "http://jspdf.default.namespaceuri/"
+        }, this.internal.events.subscribe("putCatalog", r), this.internal.events.subscribe("postPutResources", e)), this;
+      };
+    }(M.API), function (t) {
+      var e = t.API,
+        r = e.pdfEscape16 = function (t, e) {
+          for (var r, n = e.metadata.Unicode.widths, i = ["", "0", "00", "000", "0000"], a = [""], o = 0, s = t.length; o < s; ++o) {
+            if (r = e.metadata.characterToGlyph(t.charCodeAt(o)), e.metadata.glyIdsUsed.push(r), e.metadata.toUnicode[r] = t.charCodeAt(o), -1 == n.indexOf(r) && (n.push(r), n.push([parseInt(e.metadata.widthOfGlyph(r), 10)])), "0" == r) return a.join("");
+            r = r.toString(16), a.push(i[4 - r.length], r);
+          }
+          return a.join("");
+        },
+        n = function n(t) {
+          var e, r, n, i, a, o, s;
+          for (a = "/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n/CIDSystemInfo <<\n  /Registry (Adobe)\n  /Ordering (UCS)\n  /Supplement 0\n>> def\n/CMapName /Adobe-Identity-UCS def\n/CMapType 2 def\n1 begincodespacerange\n<0000><ffff>\nendcodespacerange", n = [], o = 0, s = (r = Object.keys(t).sort(function (t, e) {
+            return t - e;
+          })).length; o < s; o++) e = r[o], n.length >= 100 && (a += "\n" + n.length + " beginbfchar\n" + n.join("\n") + "\nendbfchar", n = []), void 0 !== t[e] && null !== t[e] && "function" == typeof t[e].toString && (i = ("0000" + t[e].toString(16)).slice(-4), e = ("0000" + (+e).toString(16)).slice(-4), n.push("<" + e + "><" + i + ">"));
+          return n.length && (a += "\n" + n.length + " beginbfchar\n" + n.join("\n") + "\nendbfchar\n"), a += "endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend";
+        };
+      e.events.push(["putFont", function (e) {
+        !function (e) {
+          var r = e.font,
+            i = e.out,
+            a = e.newObject,
+            o = e.putStream;
+          if (r.metadata instanceof t.API.TTFFont && "Identity-H" === r.encoding) {
+            for (var s = r.metadata.Unicode.widths, c = r.metadata.subset.encode(r.metadata.glyIdsUsed, 1), u = "", l = 0; l < c.length; l++) u += String.fromCharCode(c[l]);
+            var h = a();
+            o({
+              data: u,
+              addLength1: !0,
+              objectId: h
+            }), i("endobj");
+            var f = a();
+            o({
+              data: n(r.metadata.toUnicode),
+              addLength1: !0,
+              objectId: f
+            }), i("endobj");
+            var d = a();
+            i("<<"), i("/Type /FontDescriptor"), i("/FontName /" + F(r.fontName)), i("/FontFile2 " + h + " 0 R"), i("/FontBBox " + t.API.PDFObject.convert(r.metadata.bbox)), i("/Flags " + r.metadata.flags), i("/StemV " + r.metadata.stemV), i("/ItalicAngle " + r.metadata.italicAngle), i("/Ascent " + r.metadata.ascender), i("/Descent " + r.metadata.decender), i("/CapHeight " + r.metadata.capHeight), i(">>"), i("endobj");
+            var p = a();
+            i("<<"), i("/Type /Font"), i("/BaseFont /" + F(r.fontName)), i("/FontDescriptor " + d + " 0 R"), i("/W " + t.API.PDFObject.convert(s)), i("/CIDToGIDMap /Identity"), i("/DW 1000"), i("/Subtype /CIDFontType2"), i("/CIDSystemInfo"), i("<<"), i("/Supplement 0"), i("/Registry (Adobe)"), i("/Ordering (" + r.encoding + ")"), i(">>"), i(">>"), i("endobj"), r.objectNumber = a(), i("<<"), i("/Type /Font"), i("/Subtype /Type0"), i("/ToUnicode " + f + " 0 R"), i("/BaseFont /" + F(r.fontName)), i("/Encoding /" + r.encoding), i("/DescendantFonts [" + p + " 0 R]"), i(">>"), i("endobj"), r.isAlreadyPutted = !0;
+          }
+        }(e);
+      }]);
+      e.events.push(["putFont", function (e) {
+        !function (e) {
+          var r = e.font,
+            i = e.out,
+            a = e.newObject,
+            o = e.putStream;
+          if (r.metadata instanceof t.API.TTFFont && "WinAnsiEncoding" === r.encoding) {
+            for (var s = r.metadata.rawData, c = "", u = 0; u < s.length; u++) c += String.fromCharCode(s[u]);
+            var l = a();
+            o({
+              data: c,
+              addLength1: !0,
+              objectId: l
+            }), i("endobj");
+            var h = a();
+            o({
+              data: n(r.metadata.toUnicode),
+              addLength1: !0,
+              objectId: h
+            }), i("endobj");
+            var f = a();
+            i("<<"), i("/Descent " + r.metadata.decender), i("/CapHeight " + r.metadata.capHeight), i("/StemV " + r.metadata.stemV), i("/Type /FontDescriptor"), i("/FontFile2 " + l + " 0 R"), i("/Flags 96"), i("/FontBBox " + t.API.PDFObject.convert(r.metadata.bbox)), i("/FontName /" + F(r.fontName)), i("/ItalicAngle " + r.metadata.italicAngle), i("/Ascent " + r.metadata.ascender), i(">>"), i("endobj"), r.objectNumber = a();
+            for (var d = 0; d < r.metadata.hmtx.widths.length; d++) r.metadata.hmtx.widths[d] = parseInt(r.metadata.hmtx.widths[d] * (1e3 / r.metadata.head.unitsPerEm));
+            i("<</Subtype/TrueType/Type/Font/ToUnicode " + h + " 0 R/BaseFont/" + F(r.fontName) + "/FontDescriptor " + f + " 0 R/Encoding/" + r.encoding + " /FirstChar 29 /LastChar 255 /Widths " + t.API.PDFObject.convert(r.metadata.hmtx.widths) + ">>"), i("endobj"), r.isAlreadyPutted = !0;
+          }
+        }(e);
+      }]);
+      var i = function i(t) {
+        var e,
+          n = t.text || "",
+          i = t.x,
+          a = t.y,
+          o = t.options || {},
+          s = t.mutex || {},
+          c = s.pdfEscape,
+          u = s.activeFontKey,
+          l = s.fonts,
+          h = u,
+          f = "",
+          d = 0,
+          p = "",
+          g = l[h].encoding;
+        if ("Identity-H" !== l[h].encoding) return {
+          text: n,
+          x: i,
+          y: a,
+          options: o,
+          mutex: s
+        };
+        for (p = n, h = u, Array.isArray(n) && (p = n[0]), d = 0; d < p.length; d += 1) l[h].metadata.hasOwnProperty("cmap") && (e = l[h].metadata.cmap.unicode.codeMap[p[d].charCodeAt(0)]), e || p[d].charCodeAt(0) < 256 && l[h].metadata.hasOwnProperty("Unicode") ? f += p[d] : f += "";
+        var m = "";
+        return parseInt(h.slice(1)) < 14 || "WinAnsiEncoding" === g ? m = c(f, h).split("").map(function (t) {
+          return t.charCodeAt(0).toString(16);
+        }).join("") : "Identity-H" === g && (m = r(f, l[h])), s.isHex = !0, {
+          text: m,
+          x: i,
+          y: a,
+          options: o,
+          mutex: s
+        };
+      };
+      e.events.push(["postProcessText", function (t) {
+        var e = t.text || "",
+          r = [],
+          n = {
+            text: e,
+            x: t.x,
+            y: t.y,
+            options: t.options,
+            mutex: t.mutex
+          };
+        if (Array.isArray(e)) {
+          var a = 0;
+          for (a = 0; a < e.length; a += 1) Array.isArray(e[a]) && 3 === e[a].length ? r.push([i(Object.assign({}, n, {
+            text: e[a][0]
+          })).text, e[a][1], e[a][2]]) : r.push(i(Object.assign({}, n, {
+            text: e[a]
+          })).text);
+          t.text = r;
+        } else t.text = i(Object.assign({}, n, {
+          text: e
+        })).text;
+      }]);
+    }(M),
+    /**
+       * @license
+       * jsPDF virtual FileSystem functionality
+       *
+       * Licensed under the MIT License.
+       * http://opensource.org/licenses/mit-license
+       */
+    function (t) {
+      var e = function e() {
+        return void 0 === this.internal.vFS && (this.internal.vFS = {}), !0;
+      };
+      t.existsFileInVFS = function (t) {
+        return e.call(this), void 0 !== this.internal.vFS[t];
+      }, t.addFileToVFS = function (t, r) {
+        return e.call(this), this.internal.vFS[t] = r, this;
+      }, t.getFileFromVFS = function (t) {
+        return e.call(this), void 0 !== this.internal.vFS[t] ? this.internal.vFS[t] : null;
+      };
+    }(M.API),
+    /**
+       * @license
+       * Unicode Bidi Engine based on the work of Alex Shensis (@asthensis)
+       * MIT License
+       */
+    function (t) {
+      t.__bidiEngine__ = t.prototype.__bidiEngine__ = function (t) {
+        var r,
+          n,
+          i,
+          a,
+          o,
+          s,
+          c,
+          u = e,
+          l = [[0, 3, 0, 1, 0, 0, 0], [0, 3, 0, 1, 2, 2, 0], [0, 3, 0, 17, 2, 0, 1], [0, 3, 5, 5, 4, 1, 0], [0, 3, 21, 21, 4, 0, 1], [0, 3, 5, 5, 4, 2, 0]],
+          h = [[2, 0, 1, 1, 0, 1, 0], [2, 0, 1, 1, 0, 2, 0], [2, 0, 2, 1, 3, 2, 0], [2, 0, 2, 33, 3, 1, 1]],
+          f = {
+            L: 0,
+            R: 1,
+            EN: 2,
+            AN: 3,
+            N: 4,
+            B: 5,
+            S: 6
+          },
+          d = {
+            0: 0,
+            5: 1,
+            6: 2,
+            7: 3,
+            32: 4,
+            251: 5,
+            254: 6,
+            255: 7
+          },
+          p = ["(", ")", "(", "<", ">", "<", "[", "]", "[", "{", "}", "{", "«", "»", "«", "‹", "›", "‹", "⁅", "⁆", "⁅", "⁽", "⁾", "⁽", "₍", "₎", "₍", "≤", "≥", "≤", "〈", "〉", "〈", "﹙", "﹚", "﹙", "﹛", "﹜", "﹛", "﹝", "﹞", "﹝", "﹤", "﹥", "﹤"],
+          g = new RegExp(/^([1-4|9]|1[0-9]|2[0-9]|3[0168]|4[04589]|5[012]|7[78]|159|16[0-9]|17[0-2]|21[569]|22[03489]|250)$/),
+          m = !1,
+          v = 0;
+        this.__bidiEngine__ = {};
+        var b = function b(t) {
+            var e = t.charCodeAt(),
+              r = e >> 8,
+              n = d[r];
+            return void 0 !== n ? u[256 * n + (255 & e)] : 252 === r || 253 === r ? "AL" : g.test(r) ? "L" : 8 === r ? "R" : "N";
+          },
+          y = function y(t) {
+            for (var e, r = 0; r < t.length; r++) {
+              if ("L" === (e = b(t.charAt(r)))) return !1;
+              if ("R" === e) return !0;
+            }
+            return !1;
+          },
+          w = function w(t, e, o, s) {
+            var c,
+              u,
+              l,
+              h,
+              f = e[s];
+            switch (f) {
+              case "L":
+              case "R":
+                m = !1;
+                break;
+              case "N":
+              case "AN":
+                break;
+              case "EN":
+                m && (f = "AN");
+                break;
+              case "AL":
+                m = !0, f = "R";
+                break;
+              case "WS":
+                f = "N";
+                break;
+              case "CS":
+                s < 1 || s + 1 >= e.length || "EN" !== (c = o[s - 1]) && "AN" !== c || "EN" !== (u = e[s + 1]) && "AN" !== u ? f = "N" : m && (u = "AN"), f = u === c ? u : "N";
+                break;
+              case "ES":
+                f = "EN" === (c = s > 0 ? o[s - 1] : "B") && s + 1 < e.length && "EN" === e[s + 1] ? "EN" : "N";
+                break;
+              case "ET":
+                if (s > 0 && "EN" === o[s - 1]) {
+                  f = "EN";
+                  break;
+                }
+                if (m) {
+                  f = "N";
+                  break;
+                }
+                for (l = s + 1, h = e.length; l < h && "ET" === e[l];) l++;
+                f = l < h && "EN" === e[l] ? "EN" : "N";
+                break;
+              case "NSM":
+                if (i && !a) {
+                  for (h = e.length, l = s + 1; l < h && "NSM" === e[l];) l++;
+                  if (l < h) {
+                    var d = t[s],
+                      p = d >= 1425 && d <= 2303 || 64286 === d;
+                    if (c = e[l], p && ("R" === c || "AL" === c)) {
+                      f = "R";
+                      break;
+                    }
+                  }
+                }
+                f = s < 1 || "B" === (c = e[s - 1]) ? "N" : o[s - 1];
+                break;
+              case "B":
+                m = !1, r = !0, f = v;
+                break;
+              case "S":
+                n = !0, f = "N";
+                break;
+              case "LRE":
+              case "RLE":
+              case "LRO":
+              case "RLO":
+              case "PDF":
+                m = !1;
+                break;
+              case "BN":
+                f = "N";
+            }
+            return f;
+          },
+          N = function N(t, e, r) {
+            var n = t.split("");
+            return r && L(n, r, {
+              hiLevel: v
+            }), n.reverse(), e && e.reverse(), n.join("");
+          },
+          L = function L(t, e, i) {
+            var a,
+              o,
+              s,
+              c,
+              u,
+              d = -1,
+              p = t.length,
+              g = 0,
+              y = [],
+              N = v ? h : l,
+              L = [];
+            for (m = !1, r = !1, n = !1, o = 0; o < p; o++) L[o] = b(t[o]);
+            for (s = 0; s < p; s++) {
+              if (u = g, y[s] = w(t, L, y, s), a = 240 & (g = N[u][f[y[s]]]), g &= 15, e[s] = c = N[g][5], a > 0) if (16 === a) {
+                for (o = d; o < s; o++) e[o] = 1;
+                d = -1;
+              } else d = -1;
+              if (N[g][6]) -1 === d && (d = s);else if (d > -1) {
+                for (o = d; o < s; o++) e[o] = c;
+                d = -1;
+              }
+              "B" === L[s] && (e[s] = 0), i.hiLevel |= c;
+            }
+            n && function (t, e, r) {
+              for (var n = 0; n < r; n++) if ("S" === t[n]) {
+                e[n] = v;
+                for (var i = n - 1; i >= 0 && "WS" === t[i]; i--) e[i] = v;
+              }
+            }(L, e, p);
+          },
+          A = function A(t, e, n, i, a) {
+            if (!(a.hiLevel < t)) {
+              if (1 === t && 1 === v && !r) return e.reverse(), void (n && n.reverse());
+              for (var o, s, c, u, l = e.length, h = 0; h < l;) {
+                if (i[h] >= t) {
+                  for (c = h + 1; c < l && i[c] >= t;) c++;
+                  for (u = h, s = c - 1; u < s; u++, s--) o = e[u], e[u] = e[s], e[s] = o, n && (o = n[u], n[u] = n[s], n[s] = o);
+                  h = c;
+                }
+                h++;
+              }
+            }
+          },
+          x = function x(t, e, r) {
+            var n = t.split(""),
+              i = {
+                hiLevel: v
+              };
+            return r || (r = []), L(n, r, i), function (t, e, r) {
+              if (0 !== r.hiLevel && c) for (var n, i = 0; i < t.length; i++) 1 === e[i] && (n = p.indexOf(t[i])) >= 0 && (t[i] = p[n + 1]);
+            }(n, r, i), A(2, n, e, r, i), A(1, n, e, r, i), n.join("");
+          };
+        return this.__bidiEngine__.doBidiReorder = function (t, e, r) {
+          if (function (t, e) {
+            if (e) for (var r = 0; r < t.length; r++) e[r] = r;
+            void 0 === a && (a = y(t)), void 0 === s && (s = y(t));
+          }(t, e), i || !o || s) {
+            if (i && o && a ^ s) v = a ? 1 : 0, t = N(t, e, r);else if (!i && o && s) v = a ? 1 : 0, t = x(t, e, r), t = N(t, e);else if (!i || a || o || s) {
+              if (i && !o && a ^ s) t = N(t, e), a ? (v = 0, t = x(t, e, r)) : (v = 1, t = x(t, e, r), t = N(t, e));else if (i && a && !o && s) v = 1, t = x(t, e, r), t = N(t, e);else if (!i && !o && a ^ s) {
+                var n = c;
+                a ? (v = 1, t = x(t, e, r), v = 0, c = !1, t = x(t, e, r), c = n) : (v = 0, t = x(t, e, r), t = N(t, e), v = 1, c = !1, t = x(t, e, r), c = n, t = N(t, e));
+              }
+            } else v = 0, t = x(t, e, r);
+          } else v = a ? 1 : 0, t = x(t, e, r);
+          return t;
+        }, this.__bidiEngine__.setOptions = function (t) {
+          t && (i = t.isInputVisual, o = t.isOutputVisual, a = t.isInputRtl, s = t.isOutputRtl, c = t.isSymmetricSwapping);
+        }, this.__bidiEngine__.setOptions(t), this.__bidiEngine__;
+      };
+      var e = ["BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "S", "B", "S", "WS", "B", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "B", "B", "B", "S", "WS", "N", "N", "ET", "ET", "ET", "N", "N", "N", "N", "N", "ES", "CS", "ES", "CS", "CS", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "CS", "N", "N", "N", "N", "N", "N", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "N", "N", "N", "N", "N", "N", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "N", "N", "N", "N", "BN", "BN", "BN", "BN", "BN", "BN", "B", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "BN", "CS", "N", "ET", "ET", "ET", "ET", "N", "N", "N", "N", "L", "N", "N", "BN", "N", "N", "ET", "ET", "EN", "EN", "N", "L", "N", "N", "N", "EN", "L", "N", "N", "N", "N", "N", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "N", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "N", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "N", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "N", "N", "L", "L", "L", "L", "L", "L", "L", "N", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "N", "L", "N", "N", "N", "N", "N", "ET", "N", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "R", "NSM", "R", "NSM", "NSM", "R", "NSM", "NSM", "R", "NSM", "N", "N", "N", "N", "N", "N", "N", "N", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "N", "N", "N", "N", "N", "R", "R", "R", "R", "R", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "AN", "AN", "AN", "AN", "AN", "AN", "N", "N", "AL", "ET", "ET", "AL", "CS", "AL", "N", "N", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "AL", "AL", "N", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "AN", "AN", "AN", "AN", "AN", "AN", "AN", "AN", "AN", "AN", "ET", "AN", "AN", "AL", "AL", "AL", "NSM", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "AN", "N", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "AL", "AL", "NSM", "NSM", "N", "NSM", "NSM", "NSM", "NSM", "AL", "AL", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "N", "AL", "AL", "NSM", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "N", "N", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "AL", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "R", "R", "N", "N", "N", "N", "R", "N", "N", "N", "N", "N", "WS", "WS", "WS", "WS", "WS", "WS", "WS", "WS", "WS", "WS", "WS", "BN", "BN", "BN", "L", "R", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "WS", "B", "LRE", "RLE", "PDF", "LRO", "RLO", "CS", "ET", "ET", "ET", "ET", "ET", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "CS", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "WS", "BN", "BN", "BN", "BN", "BN", "N", "LRI", "RLI", "FSI", "PDI", "BN", "BN", "BN", "BN", "BN", "BN", "EN", "L", "N", "N", "EN", "EN", "EN", "EN", "EN", "EN", "ES", "ES", "N", "N", "N", "L", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "ES", "ES", "N", "N", "N", "N", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "N", "N", "N", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "ET", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "L", "L", "L", "L", "L", "L", "L", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "L", "L", "L", "L", "L", "N", "N", "N", "N", "N", "R", "NSM", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "ES", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "N", "R", "R", "R", "R", "R", "N", "R", "N", "R", "R", "N", "R", "R", "N", "R", "R", "R", "R", "R", "R", "R", "R", "R", "R", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "NSM", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "CS", "N", "CS", "N", "N", "CS", "N", "N", "N", "N", "N", "N", "N", "N", "N", "ET", "N", "N", "ES", "ES", "N", "N", "N", "N", "N", "ET", "ET", "N", "N", "N", "N", "N", "AL", "AL", "AL", "AL", "AL", "N", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "AL", "N", "N", "BN", "N", "N", "N", "ET", "ET", "ET", "N", "N", "N", "N", "N", "ES", "CS", "ES", "CS", "CS", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "EN", "CS", "N", "N", "N", "N", "N", "N", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "N", "N", "N", "N", "N", "N", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "L", "N", "N", "N", "L", "L", "L", "L", "L", "L", "N", "N", "L", "L", "L", "L", "L", "L", "N", "N", "L", "L", "L", "L", "L", "L", "N", "N", "L", "L", "L", "N", "N", "N", "ET", "ET", "N", "N", "N", "ET", "ET", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N", "N"],
+        r = new t.__bidiEngine__({
+          isInputVisual: !0
+        });
+      t.API.events.push(["postProcessText", function (t) {
+        var e = t.text,
+          n = (t.x, t.y, t.options || {}),
+          i = (t.mutex, n.lang, []);
+        if (n.isInputVisual = "boolean" != typeof n.isInputVisual || n.isInputVisual, r.setOptions(n), "[object Array]" === Object.prototype.toString.call(e)) {
+          var a = 0;
+          for (i = [], a = 0; a < e.length; a += 1) "[object Array]" === Object.prototype.toString.call(e[a]) ? i.push([r.doBidiReorder(e[a][0]), e[a][1], e[a][2]]) : i.push([r.doBidiReorder(e[a])]);
+          t.text = i;
+        } else t.text = r.doBidiReorder(e);
+        r.setOptions({
+          isInputVisual: !0
+        });
+      }]);
+    }(M), M.API.TTFFont = function () {
+      function t(t) {
+        var e;
+        if (this.rawData = t, e = this.contents = new Ve(t), this.contents.pos = 4, "ttcf" === e.readString(4)) throw new Error("TTCF not supported.");
+        e.pos = 0, this.parse(), this.subset = new lr(this), this.registerTTF();
+      }
+      return t.open = function (e) {
+        return new t(e);
+      }, t.prototype.parse = function () {
+        return this.directory = new Ge(this.contents), this.head = new Xe(this), this.name = new rr(this), this.cmap = new Ze(this), this.toUnicode = {}, this.hhea = new $e(this), this.maxp = new nr(this), this.hmtx = new ir(this), this.post = new tr(this), this.os2 = new Qe(this), this.loca = new ur(this), this.glyf = new or(this), this.ascender = this.os2.exists && this.os2.ascender || this.hhea.ascender, this.decender = this.os2.exists && this.os2.decender || this.hhea.decender, this.lineGap = this.os2.exists && this.os2.lineGap || this.hhea.lineGap, this.bbox = [this.head.xMin, this.head.yMin, this.head.xMax, this.head.yMax];
+      }, t.prototype.registerTTF = function () {
+        var t, e, r, n, i;
+        if (this.scaleFactor = 1e3 / this.head.unitsPerEm, this.bbox = function () {
+          var e, r, n, i;
+          for (i = [], e = 0, r = (n = this.bbox).length; e < r; e++) t = n[e], i.push(Math.round(t * this.scaleFactor));
+          return i;
+        }.call(this), this.stemV = 0, this.post.exists ? (r = 255 & (n = this.post.italic_angle), 0 != (32768 & (e = n >> 16)) && (e = -(1 + (65535 ^ e))), this.italicAngle = +(e + "." + r)) : this.italicAngle = 0, this.ascender = Math.round(this.ascender * this.scaleFactor), this.decender = Math.round(this.decender * this.scaleFactor), this.lineGap = Math.round(this.lineGap * this.scaleFactor), this.capHeight = this.os2.exists && this.os2.capHeight || this.ascender, this.xHeight = this.os2.exists && this.os2.xHeight || 0, this.familyClass = (this.os2.exists && this.os2.familyClass || 0) >> 8, this.isSerif = 1 === (i = this.familyClass) || 2 === i || 3 === i || 4 === i || 5 === i || 7 === i, this.isScript = 10 === this.familyClass, this.flags = 0, this.post.isFixedPitch && (this.flags |= 1), this.isSerif && (this.flags |= 2), this.isScript && (this.flags |= 8), 0 !== this.italicAngle && (this.flags |= 64), this.flags |= 32, !this.cmap.unicode) throw new Error("No unicode cmap for font");
+      }, t.prototype.characterToGlyph = function (t) {
+        var e;
+        return (null != (e = this.cmap.unicode) ? e.codeMap[t] : void 0) || 0;
+      }, t.prototype.widthOfGlyph = function (t) {
+        var e;
+        return e = 1e3 / this.head.unitsPerEm, this.hmtx.forGlyph(t).advance * e;
+      }, t.prototype.widthOfString = function (t, e, r) {
+        var n, i, a, o;
+        for (a = 0, i = 0, o = (t = "" + t).length; 0 <= o ? i < o : i > o; i = 0 <= o ? ++i : --i) n = t.charCodeAt(i), a += this.widthOfGlyph(this.characterToGlyph(n)) + r * (1e3 / e) || 0;
+        return a * (e / 1e3);
+      }, t.prototype.lineHeight = function (t, e) {
+        var r;
+        return null == e && (e = !1), r = e ? this.lineGap : 0, (this.ascender + r - this.decender) / 1e3 * t;
+      }, t;
+    }();
+    var We,
+      Ve = function () {
+        function t(t) {
+          this.data = null != t ? t : [], this.pos = 0, this.length = this.data.length;
+        }
+        return t.prototype.readByte = function () {
+          return this.data[this.pos++];
+        }, t.prototype.writeByte = function (t) {
+          return this.data[this.pos++] = t;
+        }, t.prototype.readUInt32 = function () {
+          return 16777216 * this.readByte() + (this.readByte() << 16) + (this.readByte() << 8) + this.readByte();
+        }, t.prototype.writeUInt32 = function (t) {
+          return this.writeByte(t >>> 24 & 255), this.writeByte(t >> 16 & 255), this.writeByte(t >> 8 & 255), this.writeByte(255 & t);
+        }, t.prototype.readInt32 = function () {
+          var t;
+          return (t = this.readUInt32()) >= 2147483648 ? t - 4294967296 : t;
+        }, t.prototype.writeInt32 = function (t) {
+          return t < 0 && (t += 4294967296), this.writeUInt32(t);
+        }, t.prototype.readUInt16 = function () {
+          return this.readByte() << 8 | this.readByte();
+        }, t.prototype.writeUInt16 = function (t) {
+          return this.writeByte(t >> 8 & 255), this.writeByte(255 & t);
+        }, t.prototype.readInt16 = function () {
+          var t;
+          return (t = this.readUInt16()) >= 32768 ? t - 65536 : t;
+        }, t.prototype.writeInt16 = function (t) {
+          return t < 0 && (t += 65536), this.writeUInt16(t);
+        }, t.prototype.readString = function (t) {
+          var e, r;
+          for (r = [], e = 0; 0 <= t ? e < t : e > t; e = 0 <= t ? ++e : --e) r[e] = String.fromCharCode(this.readByte());
+          return r.join("");
+        }, t.prototype.writeString = function (t) {
+          var e, r, n;
+          for (n = [], e = 0, r = t.length; 0 <= r ? e < r : e > r; e = 0 <= r ? ++e : --e) n.push(this.writeByte(t.charCodeAt(e)));
+          return n;
+        }, t.prototype.readShort = function () {
+          return this.readInt16();
+        }, t.prototype.writeShort = function (t) {
+          return this.writeInt16(t);
+        }, t.prototype.readLongLong = function () {
+          var t, e, r, n, i, a, o, s;
+          return t = this.readByte(), e = this.readByte(), r = this.readByte(), n = this.readByte(), i = this.readByte(), a = this.readByte(), o = this.readByte(), s = this.readByte(), 128 & t ? -1 * (72057594037927940 * (255 ^ t) + 281474976710656 * (255 ^ e) + 1099511627776 * (255 ^ r) + 4294967296 * (255 ^ n) + 16777216 * (255 ^ i) + 65536 * (255 ^ a) + 256 * (255 ^ o) + (255 ^ s) + 1) : 72057594037927940 * t + 281474976710656 * e + 1099511627776 * r + 4294967296 * n + 16777216 * i + 65536 * a + 256 * o + s;
+        }, t.prototype.writeLongLong = function (t) {
+          var e, r;
+          return e = Math.floor(t / 4294967296), r = 4294967295 & t, this.writeByte(e >> 24 & 255), this.writeByte(e >> 16 & 255), this.writeByte(e >> 8 & 255), this.writeByte(255 & e), this.writeByte(r >> 24 & 255), this.writeByte(r >> 16 & 255), this.writeByte(r >> 8 & 255), this.writeByte(255 & r);
+        }, t.prototype.readInt = function () {
+          return this.readInt32();
+        }, t.prototype.writeInt = function (t) {
+          return this.writeInt32(t);
+        }, t.prototype.read = function (t) {
+          var e, r;
+          for (e = [], r = 0; 0 <= t ? r < t : r > t; r = 0 <= t ? ++r : --r) e.push(this.readByte());
+          return e;
+        }, t.prototype.write = function (t) {
+          var e, r, n, i;
+          for (i = [], r = 0, n = t.length; r < n; r++) e = t[r], i.push(this.writeByte(e));
+          return i;
+        }, t;
+      }(),
+      Ge = function () {
+        var t;
+        function e(t) {
+          var e, r, n;
+          for (this.scalarType = t.readInt(), this.tableCount = t.readShort(), this.searchRange = t.readShort(), this.entrySelector = t.readShort(), this.rangeShift = t.readShort(), this.tables = {}, r = 0, n = this.tableCount; 0 <= n ? r < n : r > n; r = 0 <= n ? ++r : --r) e = {
+            tag: t.readString(4),
+            checksum: t.readInt(),
+            offset: t.readInt(),
+            length: t.readInt()
+          }, this.tables[e.tag] = e;
+        }
+        return e.prototype.encode = function (e) {
+          var r, n, i, a, o, s, c, u, l, h, f, d, p;
+          for (p in f = Object.keys(e).length, s = Math.log(2), l = 16 * Math.floor(Math.log(f) / s), a = Math.floor(l / s), u = 16 * f - l, (n = new Ve()).writeInt(this.scalarType), n.writeShort(f), n.writeShort(l), n.writeShort(a), n.writeShort(u), i = 16 * f, c = n.pos + i, o = null, d = [], e) for (h = e[p], n.writeString(p), n.writeInt(t(h)), n.writeInt(c), n.writeInt(h.length), d = d.concat(h), "head" === p && (o = c), c += h.length; c % 4;) d.push(0), c++;
+          return n.write(d), r = 2981146554 - t(n.data), n.pos = o + 8, n.writeUInt32(r), n.data;
+        }, t = function t(_t5) {
+          var e, r, n, i;
+          for (_t5 = ar.call(_t5); _t5.length % 4;) _t5.push(0);
+          for (n = new Ve(_t5), r = 0, e = 0, i = _t5.length; e < i; e = e += 4) r += n.readUInt32();
+          return 4294967295 & r;
+        }, e;
+      }(),
+      Ye = {}.hasOwnProperty,
+      Je = function Je(t, e) {
+        for (var r in e) Ye.call(e, r) && (t[r] = e[r]);
+        function n() {
+          this.constructor = t;
+        }
+        return n.prototype = e.prototype, t.prototype = new n(), t.__super__ = e.prototype, t;
+      },
+      Xe = function (t) {
+        function e() {
+          return e.__super__.constructor.apply(this, arguments);
+        }
+        return Je(e, t), e.prototype.tag = "head", e.prototype.parse = function (t) {
+          return t.pos = this.offset, this.version = t.readInt(), this.revision = t.readInt(), this.checkSumAdjustment = t.readInt(), this.magicNumber = t.readInt(), this.flags = t.readShort(), this.unitsPerEm = t.readShort(), this.created = t.readLongLong(), this.modified = t.readLongLong(), this.xMin = t.readShort(), this.yMin = t.readShort(), this.xMax = t.readShort(), this.yMax = t.readShort(), this.macStyle = t.readShort(), this.lowestRecPPEM = t.readShort(), this.fontDirectionHint = t.readShort(), this.indexToLocFormat = t.readShort(), this.glyphDataFormat = t.readShort();
+        }, e.prototype.encode = function (t) {
+          var e;
+          return (e = new Ve()).writeInt(this.version), e.writeInt(this.revision), e.writeInt(this.checkSumAdjustment), e.writeInt(this.magicNumber), e.writeShort(this.flags), e.writeShort(this.unitsPerEm), e.writeLongLong(this.created), e.writeLongLong(this.modified), e.writeShort(this.xMin), e.writeShort(this.yMin), e.writeShort(this.xMax), e.writeShort(this.yMax), e.writeShort(this.macStyle), e.writeShort(this.lowestRecPPEM), e.writeShort(this.fontDirectionHint), e.writeShort(t), e.writeShort(this.glyphDataFormat), e.data;
+        }, e;
+      }(We = function () {
+        function t(t) {
+          var e;
+          this.file = t, e = this.file.directory.tables[this.tag], this.exists = !!e, e && (this.offset = e.offset, this.length = e.length, this.parse(this.file.contents));
+        }
+        return t.prototype.parse = function () {}, t.prototype.encode = function () {}, t.prototype.raw = function () {
+          return this.exists ? (this.file.contents.pos = this.offset, this.file.contents.read(this.length)) : null;
+        }, t;
+      }()),
+      Ke = function () {
+        function t(t, e) {
+          var r, n, i, a, o, s, c, u, l, h, f, d, p, g, m, v, b;
+          switch (this.platformID = t.readUInt16(), this.encodingID = t.readShort(), this.offset = e + t.readInt(), l = t.pos, t.pos = this.offset, this.format = t.readUInt16(), this.length = t.readUInt16(), this.language = t.readUInt16(), this.isUnicode = 3 === this.platformID && 1 === this.encodingID && 4 === this.format || 0 === this.platformID && 4 === this.format, this.codeMap = {}, this.format) {
+            case 0:
+              for (s = 0; s < 256; ++s) this.codeMap[s] = t.readByte();
+              break;
+            case 4:
+              for (f = t.readUInt16(), h = f / 2, t.pos += 6, i = function () {
+                var e, r;
+                for (r = [], s = e = 0; 0 <= h ? e < h : e > h; s = 0 <= h ? ++e : --e) r.push(t.readUInt16());
+                return r;
+              }(), t.pos += 2, p = function () {
+                var e, r;
+                for (r = [], s = e = 0; 0 <= h ? e < h : e > h; s = 0 <= h ? ++e : --e) r.push(t.readUInt16());
+                return r;
+              }(), c = function () {
+                var e, r;
+                for (r = [], s = e = 0; 0 <= h ? e < h : e > h; s = 0 <= h ? ++e : --e) r.push(t.readUInt16());
+                return r;
+              }(), u = function () {
+                var e, r;
+                for (r = [], s = e = 0; 0 <= h ? e < h : e > h; s = 0 <= h ? ++e : --e) r.push(t.readUInt16());
+                return r;
+              }(), n = (this.length - t.pos + this.offset) / 2, o = function () {
+                var e, r;
+                for (r = [], s = e = 0; 0 <= n ? e < n : e > n; s = 0 <= n ? ++e : --e) r.push(t.readUInt16());
+                return r;
+              }(), s = m = 0, b = i.length; m < b; s = ++m) for (g = i[s], r = v = d = p[s]; d <= g ? v <= g : v >= g; r = d <= g ? ++v : --v) 0 === u[s] ? a = r + c[s] : 0 !== (a = o[u[s] / 2 + (r - d) - (h - s)] || 0) && (a += c[s]), this.codeMap[r] = 65535 & a;
+          }
+          t.pos = l;
+        }
+        return t.encode = function (t, e) {
+          var r, n, i, a, o, s, c, u, l, h, f, d, p, g, m, v, b, y, w, N, L, A, x, S, _, P, k, F, I, C, j, O, B, M, E, q, D, R, T, U, z, H, W, V, G, Y;
+          switch (F = new Ve(), a = Object.keys(t).sort(function (t, e) {
+            return t - e;
+          }), e) {
+            case "macroman":
+              for (p = 0, g = function () {
+                var t = [];
+                for (d = 0; d < 256; ++d) t.push(0);
+                return t;
+              }(), v = {
+                0: 0
+              }, i = {}, I = 0, B = a.length; I < B; I++) null == v[W = t[n = a[I]]] && (v[W] = ++p), i[n] = {
+                old: t[n],
+                new: v[t[n]]
+              }, g[n] = v[t[n]];
+              return F.writeUInt16(1), F.writeUInt16(0), F.writeUInt32(12), F.writeUInt16(0), F.writeUInt16(262), F.writeUInt16(0), F.write(g), {
+                charMap: i,
+                subtable: F.data,
+                maxGlyphID: p + 1
+              };
+            case "unicode":
+              for (P = [], l = [], b = 0, v = {}, r = {}, m = c = null, C = 0, M = a.length; C < M; C++) null == v[w = t[n = a[C]]] && (v[w] = ++b), r[n] = {
+                old: w,
+                new: v[w]
+              }, o = v[w] - n, null != m && o === c || (m && l.push(m), P.push(n), c = o), m = n;
+              for (m && l.push(m), l.push(65535), P.push(65535), S = 2 * (x = P.length), A = 2 * Math.pow(Math.log(x) / Math.LN2, 2), h = Math.log(A / 2) / Math.LN2, L = 2 * x - A, s = [], N = [], f = [], d = j = 0, E = P.length; j < E; d = ++j) {
+                if (_ = P[d], u = l[d], 65535 === _) {
+                  s.push(0), N.push(0);
+                  break;
+                }
+                if (_ - (k = r[_].new) >= 32768) for (s.push(0), N.push(2 * (f.length + x - d)), n = O = _; _ <= u ? O <= u : O >= u; n = _ <= u ? ++O : --O) f.push(r[n].new);else s.push(k - _), N.push(0);
+              }
+              for (F.writeUInt16(3), F.writeUInt16(1), F.writeUInt32(12), F.writeUInt16(4), F.writeUInt16(16 + 8 * x + 2 * f.length), F.writeUInt16(0), F.writeUInt16(S), F.writeUInt16(A), F.writeUInt16(h), F.writeUInt16(L), z = 0, q = l.length; z < q; z++) n = l[z], F.writeUInt16(n);
+              for (F.writeUInt16(0), H = 0, D = P.length; H < D; H++) n = P[H], F.writeUInt16(n);
+              for (V = 0, R = s.length; V < R; V++) o = s[V], F.writeUInt16(o);
+              for (G = 0, T = N.length; G < T; G++) y = N[G], F.writeUInt16(y);
+              for (Y = 0, U = f.length; Y < U; Y++) p = f[Y], F.writeUInt16(p);
+              return {
+                charMap: r,
+                subtable: F.data,
+                maxGlyphID: b + 1
+              };
+          }
+        }, t;
+      }(),
+      Ze = function (t) {
+        function e() {
+          return e.__super__.constructor.apply(this, arguments);
+        }
+        return Je(e, t), e.prototype.tag = "cmap", e.prototype.parse = function (t) {
+          var e, r, n;
+          for (t.pos = this.offset, this.version = t.readUInt16(), n = t.readUInt16(), this.tables = [], this.unicode = null, r = 0; 0 <= n ? r < n : r > n; r = 0 <= n ? ++r : --r) e = new Ke(t, this.offset), this.tables.push(e), e.isUnicode && null == this.unicode && (this.unicode = e);
+          return !0;
+        }, e.encode = function (t, e) {
+          var r, n;
+          return null == e && (e = "macroman"), r = Ke.encode(t, e), (n = new Ve()).writeUInt16(0), n.writeUInt16(1), r.table = n.data.concat(r.subtable), r;
+        }, e;
+      }(We),
+      $e = function (t) {
+        function e() {
+          return e.__super__.constructor.apply(this, arguments);
+        }
+        return Je(e, t), e.prototype.tag = "hhea", e.prototype.parse = function (t) {
+          return t.pos = this.offset, this.version = t.readInt(), this.ascender = t.readShort(), this.decender = t.readShort(), this.lineGap = t.readShort(), this.advanceWidthMax = t.readShort(), this.minLeftSideBearing = t.readShort(), this.minRightSideBearing = t.readShort(), this.xMaxExtent = t.readShort(), this.caretSlopeRise = t.readShort(), this.caretSlopeRun = t.readShort(), this.caretOffset = t.readShort(), t.pos += 8, this.metricDataFormat = t.readShort(), this.numberOfMetrics = t.readUInt16();
+        }, e;
+      }(We),
+      Qe = function (t) {
+        function e() {
+          return e.__super__.constructor.apply(this, arguments);
+        }
+        return Je(e, t), e.prototype.tag = "OS/2", e.prototype.parse = function (t) {
+          if (t.pos = this.offset, this.version = t.readUInt16(), this.averageCharWidth = t.readShort(), this.weightClass = t.readUInt16(), this.widthClass = t.readUInt16(), this.type = t.readShort(), this.ySubscriptXSize = t.readShort(), this.ySubscriptYSize = t.readShort(), this.ySubscriptXOffset = t.readShort(), this.ySubscriptYOffset = t.readShort(), this.ySuperscriptXSize = t.readShort(), this.ySuperscriptYSize = t.readShort(), this.ySuperscriptXOffset = t.readShort(), this.ySuperscriptYOffset = t.readShort(), this.yStrikeoutSize = t.readShort(), this.yStrikeoutPosition = t.readShort(), this.familyClass = t.readShort(), this.panose = function () {
+            var e, r;
+            for (r = [], e = 0; e < 10; ++e) r.push(t.readByte());
+            return r;
+          }(), this.charRange = function () {
+            var e, r;
+            for (r = [], e = 0; e < 4; ++e) r.push(t.readInt());
+            return r;
+          }(), this.vendorID = t.readString(4), this.selection = t.readShort(), this.firstCharIndex = t.readShort(), this.lastCharIndex = t.readShort(), this.version > 0 && (this.ascent = t.readShort(), this.descent = t.readShort(), this.lineGap = t.readShort(), this.winAscent = t.readShort(), this.winDescent = t.readShort(), this.codePageRange = function () {
+            var e, r;
+            for (r = [], e = 0; e < 2; e = ++e) r.push(t.readInt());
+            return r;
+          }(), this.version > 1)) return this.xHeight = t.readShort(), this.capHeight = t.readShort(), this.defaultChar = t.readShort(), this.breakChar = t.readShort(), this.maxContext = t.readShort();
+        }, e;
+      }(We),
+      tr = function (t) {
+        function e() {
+          return e.__super__.constructor.apply(this, arguments);
+        }
+        return Je(e, t), e.prototype.tag = "post", e.prototype.parse = function (t) {
+          var e, r, n;
+          switch (t.pos = this.offset, this.format = t.readInt(), this.italicAngle = t.readInt(), this.underlinePosition = t.readShort(), this.underlineThickness = t.readShort(), this.isFixedPitch = t.readInt(), this.minMemType42 = t.readInt(), this.maxMemType42 = t.readInt(), this.minMemType1 = t.readInt(), this.maxMemType1 = t.readInt(), this.format) {
+            case 65536:
+              break;
+            case 131072:
+              var i;
+              for (r = t.readUInt16(), this.glyphNameIndex = [], i = 0; 0 <= r ? i < r : i > r; i = 0 <= r ? ++i : --i) this.glyphNameIndex.push(t.readUInt16());
+              for (this.names = [], n = []; t.pos < this.offset + this.length;) e = t.readByte(), n.push(this.names.push(t.readString(e)));
+              return n;
+            case 151552:
+              return r = t.readUInt16(), this.offsets = t.read(r);
+            case 196608:
+              break;
+            case 262144:
+              return this.map = function () {
+                var e, r, n;
+                for (n = [], i = e = 0, r = this.file.maxp.numGlyphs; 0 <= r ? e < r : e > r; i = 0 <= r ? ++e : --e) n.push(t.readUInt32());
+                return n;
+              }.call(this);
+          }
+        }, e;
+      }(We),
+      er = function er(t, e) {
+        this.raw = t, this.length = t.length, this.platformID = e.platformID, this.encodingID = e.encodingID, this.languageID = e.languageID;
+      },
+      rr = function (t) {
+        function e() {
+          return e.__super__.constructor.apply(this, arguments);
+        }
+        return Je(e, t), e.prototype.tag = "name", e.prototype.parse = function (t) {
+          var e, r, n, i, a, o, s, c, u, l, h;
+          for (t.pos = this.offset, t.readShort(), e = t.readShort(), o = t.readShort(), r = [], i = 0; 0 <= e ? i < e : i > e; i = 0 <= e ? ++i : --i) r.push({
+            platformID: t.readShort(),
+            encodingID: t.readShort(),
+            languageID: t.readShort(),
+            nameID: t.readShort(),
+            length: t.readShort(),
+            offset: this.offset + o + t.readShort()
+          });
+          for (s = {}, i = u = 0, l = r.length; u < l; i = ++u) n = r[i], t.pos = n.offset, c = t.readString(n.length), a = new er(c, n), null == s[h = n.nameID] && (s[h] = []), s[n.nameID].push(a);
+          this.strings = s, this.copyright = s[0], this.fontFamily = s[1], this.fontSubfamily = s[2], this.uniqueSubfamily = s[3], this.fontName = s[4], this.version = s[5];
+          try {
+            this.postscriptName = s[6][0].raw.replace(/[\x00-\x19\x80-\xff]/g, "");
+          } catch (t) {
+            this.postscriptName = s[4][0].raw.replace(/[\x00-\x19\x80-\xff]/g, "");
+          }
+          return this.trademark = s[7], this.manufacturer = s[8], this.designer = s[9], this.description = s[10], this.vendorUrl = s[11], this.designerUrl = s[12], this.license = s[13], this.licenseUrl = s[14], this.preferredFamily = s[15], this.preferredSubfamily = s[17], this.compatibleFull = s[18], this.sampleText = s[19];
+        }, e;
+      }(We),
+      nr = function (t) {
+        function e() {
+          return e.__super__.constructor.apply(this, arguments);
+        }
+        return Je(e, t), e.prototype.tag = "maxp", e.prototype.parse = function (t) {
+          return t.pos = this.offset, this.version = t.readInt(), this.numGlyphs = t.readUInt16(), this.maxPoints = t.readUInt16(), this.maxContours = t.readUInt16(), this.maxCompositePoints = t.readUInt16(), this.maxComponentContours = t.readUInt16(), this.maxZones = t.readUInt16(), this.maxTwilightPoints = t.readUInt16(), this.maxStorage = t.readUInt16(), this.maxFunctionDefs = t.readUInt16(), this.maxInstructionDefs = t.readUInt16(), this.maxStackElements = t.readUInt16(), this.maxSizeOfInstructions = t.readUInt16(), this.maxComponentElements = t.readUInt16(), this.maxComponentDepth = t.readUInt16();
+        }, e;
+      }(We),
+      ir = function (t) {
+        function e() {
+          return e.__super__.constructor.apply(this, arguments);
+        }
+        return Je(e, t), e.prototype.tag = "hmtx", e.prototype.parse = function (t) {
+          var e, r, n, i, a, o, s;
+          for (t.pos = this.offset, this.metrics = [], e = 0, o = this.file.hhea.numberOfMetrics; 0 <= o ? e < o : e > o; e = 0 <= o ? ++e : --e) this.metrics.push({
+            advance: t.readUInt16(),
+            lsb: t.readInt16()
+          });
+          for (n = this.file.maxp.numGlyphs - this.file.hhea.numberOfMetrics, this.leftSideBearings = function () {
+            var r, i;
+            for (i = [], e = r = 0; 0 <= n ? r < n : r > n; e = 0 <= n ? ++r : --r) i.push(t.readInt16());
+            return i;
+          }(), this.widths = function () {
+            var t, e, r, n;
+            for (n = [], t = 0, e = (r = this.metrics).length; t < e; t++) i = r[t], n.push(i.advance);
+            return n;
+          }.call(this), r = this.widths[this.widths.length - 1], s = [], e = a = 0; 0 <= n ? a < n : a > n; e = 0 <= n ? ++a : --a) s.push(this.widths.push(r));
+          return s;
+        }, e.prototype.forGlyph = function (t) {
+          return t in this.metrics ? this.metrics[t] : {
+            advance: this.metrics[this.metrics.length - 1].advance,
+            lsb: this.leftSideBearings[t - this.metrics.length]
+          };
+        }, e;
+      }(We),
+      ar = [].slice,
+      or = function (t) {
+        function e() {
+          return e.__super__.constructor.apply(this, arguments);
+        }
+        return Je(e, t), e.prototype.tag = "glyf", e.prototype.parse = function () {
+          return this.cache = {};
+        }, e.prototype.glyphFor = function (t) {
+          var e, r, n, i, a, o, s, c, u, l;
+          return t in this.cache ? this.cache[t] : (i = this.file.loca, e = this.file.contents, r = i.indexOf(t), 0 === (n = i.lengthOf(t)) ? this.cache[t] = null : (e.pos = this.offset + r, a = (o = new Ve(e.read(n))).readShort(), c = o.readShort(), l = o.readShort(), s = o.readShort(), u = o.readShort(), this.cache[t] = -1 === a ? new cr(o, c, l, s, u) : new sr(o, a, c, l, s, u), this.cache[t]));
+        }, e.prototype.encode = function (t, e, r) {
+          var n, i, a, o, s;
+          for (a = [], i = [], o = 0, s = e.length; o < s; o++) n = t[e[o]], i.push(a.length), n && (a = a.concat(n.encode(r)));
+          return i.push(a.length), {
+            table: a,
+            offsets: i
+          };
+        }, e;
+      }(We),
+      sr = function () {
+        function t(t, e, r, n, i, a) {
+          this.raw = t, this.numberOfContours = e, this.xMin = r, this.yMin = n, this.xMax = i, this.yMax = a, this.compound = !1;
+        }
+        return t.prototype.encode = function () {
+          return this.raw.data;
+        }, t;
+      }(),
+      cr = function () {
+        function t(t, e, r, n, i) {
+          var a, o;
+          for (this.raw = t, this.xMin = e, this.yMin = r, this.xMax = n, this.yMax = i, this.compound = !0, this.glyphIDs = [], this.glyphOffsets = [], a = this.raw; o = a.readShort(), this.glyphOffsets.push(a.pos), this.glyphIDs.push(a.readUInt16()), 32 & o;) a.pos += 1 & o ? 4 : 2, 128 & o ? a.pos += 8 : 64 & o ? a.pos += 4 : 8 & o && (a.pos += 2);
+        }
+        return t.prototype.encode = function () {
+          var t, e, r;
+          for (e = new Ve(ar.call(this.raw.data)), t = 0, r = this.glyphIDs.length; t < r; ++t) e.pos = this.glyphOffsets[t];
+          return e.data;
+        }, t;
+      }(),
+      ur = function (t) {
+        function e() {
+          return e.__super__.constructor.apply(this, arguments);
+        }
+        return Je(e, t), e.prototype.tag = "loca", e.prototype.parse = function (t) {
+          var e, r;
+          return t.pos = this.offset, e = this.file.head.indexToLocFormat, this.offsets = 0 === e ? function () {
+            var e, n;
+            for (n = [], r = 0, e = this.length; r < e; r += 2) n.push(2 * t.readUInt16());
+            return n;
+          }.call(this) : function () {
+            var e, n;
+            for (n = [], r = 0, e = this.length; r < e; r += 4) n.push(t.readUInt32());
+            return n;
+          }.call(this);
+        }, e.prototype.indexOf = function (t) {
+          return this.offsets[t];
+        }, e.prototype.lengthOf = function (t) {
+          return this.offsets[t + 1] - this.offsets[t];
+        }, e.prototype.encode = function (t, e) {
+          for (var r = new Uint32Array(this.offsets.length), n = 0, i = 0, a = 0; a < r.length; ++a) if (r[a] = n, i < e.length && e[i] == a) {
+            ++i, r[a] = n;
+            var o = this.offsets[a],
+              s = this.offsets[a + 1] - o;
+            s > 0 && (n += s);
+          }
+          for (var c = new Array(4 * r.length), u = 0; u < r.length; ++u) c[4 * u + 3] = 255 & r[u], c[4 * u + 2] = (65280 & r[u]) >> 8, c[4 * u + 1] = (16711680 & r[u]) >> 16, c[4 * u] = (4278190080 & r[u]) >> 24;
+          return c;
+        }, e;
+      }(We),
+      lr = function () {
+        function t(t) {
+          this.font = t, this.subset = {}, this.unicodes = {}, this.next = 33;
+        }
+        return t.prototype.generateCmap = function () {
+          var t, e, r, n, i;
+          for (e in n = this.font.cmap.tables[0].codeMap, t = {}, i = this.subset) r = i[e], t[e] = n[r];
+          return t;
+        }, t.prototype.glyphsFor = function (t) {
+          var e, r, n, i, a, o, s;
+          for (n = {}, a = 0, o = t.length; a < o; a++) n[i = t[a]] = this.font.glyf.glyphFor(i);
+          for (i in e = [], n) (null != (r = n[i]) ? r.compound : void 0) && e.push.apply(e, r.glyphIDs);
+          if (e.length > 0) for (i in s = this.glyphsFor(e)) r = s[i], n[i] = r;
+          return n;
+        }, t.prototype.encode = function (t, e) {
+          var r, n, i, a, o, s, c, u, l, h, f, d, p, g, m;
+          for (n in r = Ze.encode(this.generateCmap(), "unicode"), a = this.glyphsFor(t), f = {
+            0: 0
+          }, m = r.charMap) f[(s = m[n]).old] = s.new;
+          for (d in h = r.maxGlyphID, a) d in f || (f[d] = h++);
+          return u = function (t) {
+            var e, r;
+            for (e in r = {}, t) r[t[e]] = e;
+            return r;
+          }(f), l = Object.keys(u).sort(function (t, e) {
+            return t - e;
+          }), p = function () {
+            var t, e, r;
+            for (r = [], t = 0, e = l.length; t < e; t++) o = l[t], r.push(u[o]);
+            return r;
+          }(), i = this.font.glyf.encode(a, p, f), c = this.font.loca.encode(i.offsets, p), g = {
+            cmap: this.font.cmap.raw(),
+            glyf: i.table,
+            loca: c,
+            hmtx: this.font.hmtx.raw(),
+            hhea: this.font.hhea.raw(),
+            maxp: this.font.maxp.raw(),
+            post: this.font.post.raw(),
+            name: this.font.name.raw(),
+            head: this.font.head.encode(e)
+          }, this.font.os2.exists && (g["OS/2"] = this.font.os2.raw()), this.font.directory.encode(g);
+        }, t;
+      }();
+    M.API.PDFObject = function () {
+      var t;
+      function e() {}
+      return t = function t(_t6, e) {
+        return (Array(e + 1).join("0") + _t6).slice(-e);
+      }, e.convert = function (r) {
+        var n, i, a, o;
+        if (Array.isArray(r)) return "[" + function () {
+          var t, i, a;
+          for (a = [], t = 0, i = r.length; t < i; t++) n = r[t], a.push(e.convert(n));
+          return a;
+        }().join(" ") + "]";
+        if ("string" == typeof r) return "/" + r;
+        if (null != r ? r.isString : void 0) return "(" + r + ")";
+        if (r instanceof Date) return "(D:" + t(r.getUTCFullYear(), 4) + t(r.getUTCMonth(), 2) + t(r.getUTCDate(), 2) + t(r.getUTCHours(), 2) + t(r.getUTCMinutes(), 2) + t(r.getUTCSeconds(), 2) + "Z)";
+        if ("[object Object]" === {}.toString.call(r)) {
+          for (i in a = ["<<"], r) o = r[i], a.push("/" + i + " " + e.convert(o));
+          return a.push(">>"), a.join("\n");
+        }
+        return "" + r;
+      }, e;
+    }(), t.AcroForm = xt, t.AcroFormAppearance = Lt, t.AcroFormButton = gt, t.AcroFormCheckBox = yt, t.AcroFormChoiceField = ht, t.AcroFormComboBox = dt, t.AcroFormEditBox = pt, t.AcroFormListBox = ft, t.AcroFormPasswordField = Nt, t.AcroFormPushButton = mt, t.AcroFormRadioButton = vt, t.AcroFormTextField = wt, t.GState = C, t.ShadingPattern = O, t.TilingPattern = B, t.default = M, t.jsPDF = M, Object.defineProperty(t, "__esModule", {
+      value: !0
+    });
+  });
+
+  var jspdf_umd_min = /*#__PURE__*/Object.freeze({
+    __proto__: null
+  });
+
+  exports.createChipGroup = createChipGroup;
+  exports.validateVitals = validateVitals;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+  return exports;
+
+})({});

--- a/rollup.legacy.config.js
+++ b/rollup.legacy.config.js
@@ -1,0 +1,26 @@
+const { babel } = require('@rollup/plugin-babel');
+
+module.exports = {
+  input: 'public/js/app.js',
+  output: {
+    file: 'public/js/app.legacy.js',
+    format: 'iife',
+    name: 'TraumaTeamApp',
+    sourcemap: false,
+    inlineDynamicImports: true
+  },
+  plugins: [
+    babel({
+      babelHelpers: 'bundled',
+      presets: [
+        ['@babel/preset-env', {
+          targets: { ie: '11' },
+          modules: false,
+          bugfixes: true
+        }]
+      ],
+      extensions: ['.js'],
+      exclude: 'node_modules/**'
+    })
+  ]
+};


### PR DESCRIPTION
## Summary
- add a Rollup configuration to bundle the browser app to an ES5-friendly IIFE
- commit the generated legacy bundle and load it via a `nomodule` fallback script tag

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c831a6a64c8320a08ced16d08e2153