### PR TITLE
Refactor backup helper for DB loading

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -21,6 +21,16 @@ const LOG_REQUESTS = process.env.NODE_ENV !== 'test';
 
 const EMPTY_DB = { sessions: [], data: {}, users: [] };
 
+async function backupAndNotify(){
+  const backup = `${DB_FILE}.bak`;
+  try {
+    await fs.promises.rename(DB_FILE, backup);
+    logger.error(`Backed up unreadable DB to ${backup}`);
+  } catch (err) {
+    logger.error('Failed to back up DB file', err);
+  }
+}
+
 function findSessionOr404 (req, res) {
   const id = req.params.id;
   const session = db.sessions.find(s => s.id === id);
@@ -32,15 +42,6 @@ function findSessionOr404 (req, res) {
 }
 
 async function loadDB(){
-  async function backupAndNotify(){
-    const backup = `${DB_FILE}.bak`;
-    try {
-      await fs.promises.rename(DB_FILE, backup);
-      logger.error(`Backed up unreadable DB to ${backup}`);
-    } catch (err) {
-      logger.error('Failed to back up DB file', err);
-    }
-  }
   try {
     const data = await fs.promises.readFile(DB_FILE, 'utf8');
     let parsed;


### PR DESCRIPTION
## Summary
- hoist the `backupAndNotify` helper above `loadDB` for reuse
- keep `loadDB` using the shared helper when handling DB read issues

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c844f660f48320a24a9c58cf07b990