### PR TITLE
Refactor timing utilities into shared module

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1,4 +1,5 @@
 import { $, $$ } from './utils.js';
+import { debounce, clampNumberInputs } from './utilTiming.js';
 import { initTabs } from './tabs.js';
 import { initChips, setChipActive, isChipActive, addChipIndicators } from './chips.js';
 import { initAutoActivate } from './autoActivate.js';
@@ -81,40 +82,9 @@ function expandOutput(){
   ta.style.height = ta.scrollHeight + 'px';
 }
 
-function debounce(fn, delay){
-  let t;
-  return (...args)=>{
-    clearTimeout(t);
-    t=setTimeout(()=>fn(...args),delay);
-  };
-}
 const saveAllDebounced = debounce(saveAll, 300);
 initGcs();
 /* ===== Other UI ===== */
-
-function clampNumberInputs(){
-  const clamp=el=>{
-    if(el.value==='') return;
-    const min=el.getAttribute('min');
-    const max=el.getAttribute('max');
-    const step=parseFloat(el.getAttribute('step')) || 1;
-    let val=parseFloat(el.value);
-    if(isNaN(val)) return;
-    if(min!==null && val<parseFloat(min)) val=parseFloat(min);
-    if(max!==null && val>parseFloat(max)) val=parseFloat(max);
-    val=Math.round(val/step)*step;
-    const decimals=(step.toString().split('.')[1]||'').length;
-    el.value=val.toFixed(decimals);
-  };
-  $$('input[type="number"]').forEach(el=>{
-    const min=el.getAttribute('min');
-    const max=el.getAttribute('max');
-    if(min!==null || max!==null){
-      ['input','change'].forEach(evt=>el.addEventListener(evt,()=>clamp(el)));
-      clamp(el);
-    }
-  });
-}
 
 
 /* ===== Init modules ===== */

--- a/docs/js/utilTiming.js
+++ b/docs/js/utilTiming.js
@@ -1,0 +1,44 @@
+import { $$ } from './utils.js';
+
+/**
+ * Returns a debounced wrapper that waits for a pause before invoking `fn`.
+ * @param {Function} fn - Target function to call after the delay.
+ * @param {number} delay - Delay in milliseconds before firing `fn`.
+ * @returns {Function} Debounced handler.
+ */
+export function debounce(fn, delay = 0){
+  let timeoutId;
+  return (...args)=>{
+    clearTimeout(timeoutId);
+    timeoutId=setTimeout(()=>fn(...args), delay);
+  };
+}
+
+/**
+ * Clamp numeric input values according to their min/max/step attributes.
+ * Call again if dynamic inputs are added to the DOM.
+ */
+export function clampNumberInputs(){
+  const clamp = el => {
+    if(el.value==='') return;
+    const min=el.getAttribute('min');
+    const max=el.getAttribute('max');
+    const step=parseFloat(el.getAttribute('step')) || 1;
+    let val=parseFloat(el.value);
+    if(Number.isNaN(val)) return;
+    if(min!==null && val<parseFloat(min)) val=parseFloat(min);
+    if(max!==null && val>parseFloat(max)) val=parseFloat(max);
+    val=Math.round(val/step)*step;
+    const decimals=(step.toString().split('.')[1]||'').length;
+    el.value=val.toFixed(decimals);
+  };
+
+  $$('input[type="number"]').forEach(el=>{
+    const min=el.getAttribute('min');
+    const max=el.getAttribute('max');
+    if(min!==null || max!==null){
+      ['input','change'].forEach(evt=>el.addEventListener(evt,()=>clamp(el)));
+      clamp(el);
+    }
+  });
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,4 +1,5 @@
 import { $, $$ } from './utils.js';
+import { debounce, clampNumberInputs } from './utilTiming.js';
 import { initTabs } from './tabs.js';
 import { initChips, setChipActive, isChipActive, addChipIndicators } from './chips.js';
 import { initAutoActivate } from './autoActivate.js';
@@ -83,40 +84,9 @@ function expandOutput(){
   ta.style.height = ta.scrollHeight + 'px';
 }
 
-function debounce(fn, delay){
-  let t;
-  return (...args)=>{
-    clearTimeout(t);
-    t=setTimeout(()=>fn(...args),delay);
-  };
-}
 const saveAllDebounced = debounce(saveAll, 300);
 initGcs();
 /* ===== Other UI ===== */
-
-function clampNumberInputs(){
-  const clamp=el=>{
-    if(el.value==='') return;
-    const min=el.getAttribute('min');
-    const max=el.getAttribute('max');
-    const step=parseFloat(el.getAttribute('step')) || 1;
-    let val=parseFloat(el.value);
-    if(isNaN(val)) return;
-    if(min!==null && val<parseFloat(min)) val=parseFloat(min);
-    if(max!==null && val>parseFloat(max)) val=parseFloat(max);
-    val=Math.round(val/step)*step;
-    const decimals=(step.toString().split('.')[1]||'').length;
-    el.value=val.toFixed(decimals);
-  };
-  $$('input[type="number"]').forEach(el=>{
-    const min=el.getAttribute('min');
-    const max=el.getAttribute('max');
-    if(min!==null || max!==null){
-      ['input','change'].forEach(evt=>el.addEventListener(evt,()=>clamp(el)));
-      clamp(el);
-    }
-  });
-}
 
 
 /* ===== Init modules ===== */

--- a/public/js/utilTiming.js
+++ b/public/js/utilTiming.js
@@ -1,0 +1,44 @@
+import { $$ } from './utils.js';
+
+/**
+ * Returns a debounced wrapper that waits for a pause before invoking `fn`.
+ * @param {Function} fn - Target function to call after the delay.
+ * @param {number} delay - Delay in milliseconds before firing `fn`.
+ * @returns {Function} Debounced handler.
+ */
+export function debounce(fn, delay = 0){
+  let timeoutId;
+  return (...args)=>{
+    clearTimeout(timeoutId);
+    timeoutId=setTimeout(()=>fn(...args), delay);
+  };
+}
+
+/**
+ * Clamp numeric input values according to their min/max/step attributes.
+ * Call again if dynamic inputs are added to the DOM.
+ */
+export function clampNumberInputs(){
+  const clamp = el => {
+    if(el.value==='') return;
+    const min=el.getAttribute('min');
+    const max=el.getAttribute('max');
+    const step=parseFloat(el.getAttribute('step')) || 1;
+    let val=parseFloat(el.value);
+    if(Number.isNaN(val)) return;
+    if(min!==null && val<parseFloat(min)) val=parseFloat(min);
+    if(max!==null && val>parseFloat(max)) val=parseFloat(max);
+    val=Math.round(val/step)*step;
+    const decimals=(step.toString().split('.')[1]||'').length;
+    el.value=val.toFixed(decimals);
+  };
+
+  $$('input[type="number"]').forEach(el=>{
+    const min=el.getAttribute('min');
+    const max=el.getAttribute('max');
+    if(min!==null || max!==null){
+      ['input','change'].forEach(evt=>el.addEventListener(evt,()=>clamp(el)));
+      clamp(el);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- move the debounce and clampNumberInputs helpers into a reusable utilTiming module
- update the public and docs app entrypoints to import the shared utilities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9963fe42883209706c9b837242d74