### PR TITLE
Handle missing screen CTM for BodyMap coordinate conversion

### DIFF
--- a/public/js/__tests__/bodyMap.test.js
+++ b/public/js/__tests__/bodyMap.test.js
@@ -89,5 +89,21 @@ describe('BodyMap minimal', () => {
     bm.eraseBrush(10,10,5);
     expect(totalEl.textContent).toBe(`${bm.burnArea().toFixed(1)}%`);
   });
+
+  test('svgPoint returns null when screen CTM is unavailable', () => {
+    setupDom();
+    const bm = new BodyMap();
+    bm.init(() => {});
+    bm.svg.createSVGPoint = jest.fn(() => ({
+      x: 0,
+      y: 0,
+      matrixTransform: jest.fn(() => ({ x: 0, y: 0 }))
+    }));
+    bm.svg.getScreenCTM = jest.fn(() => null);
+    bm.svg.getBoundingClientRect = jest.fn(() => null);
+    const call = () => bm.svgPoint({ clientX: 12, clientY: 34 });
+    expect(call).not.toThrow();
+    expect(call()).toBeNull();
+  });
 });
 


### PR DESCRIPTION
## Summary
- guard body map click handling when the SVG screen CTM is unavailable
- reuse a cached CTM for coordinate transforms and provide a bounding-rect fallback
- add a regression test covering missing CTM handling

## Testing
- npm run test:client -- bodyMap.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cceac7151083208698fee3d3bd0236