### PR TITLE
Clean up unused client exports and update socket reconnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ debugging:
 - `reconnect` – logs successful reconnection and notifies the user.
 
 After refreshing authentication tokens, call `setAuthToken()` followed
-by `reconnectSocket()` to manually re-establish the connection.
+by `connectSocket({ force: true })` to manually re-establish the
+connection if needed.
 
 ## Offline Support
 

--- a/docs/js/BodyMapTools.js
+++ b/docs/js/BodyMapTools.js
@@ -4,5 +4,3 @@ export const TOOLS = {
   BURN: { char: 'B', symbol: '' },
   BURN_ERASE: { char: 'E', symbol: '' }
 };
-
-export default TOOLS;

--- a/docs/js/sessionApi.js
+++ b/docs/js/sessionApi.js
@@ -58,9 +58,15 @@ export async function saveSessions(list){
   }
 }
 
-export function connectSocket({ onSessions, onSessionData, onUsers }={}){
+export function connectSocket(options={}){
+  const { onSessions, onSessionData, onUsers, force = false } = options;
   const token = getAuthToken();
-  if(typeof io === 'undefined' || socket || !token) return;
+  if(typeof io === 'undefined' || !token) return;
+  if(socket){
+    if(!force) return;
+    socket.disconnect();
+    socket = null;
+  }
   socket = io(socketEndpoint || undefined,{ auth:{ token:'Bearer '+token } });
   socket.on('connect', resetDelay);
   socket.on('connect_error', err => {
@@ -81,13 +87,5 @@ export function connectSocket({ onSessions, onSessionData, onUsers }={}){
   if(onSessions) socket.on('sessions', onSessions);
   if(onSessionData) socket.on('sessionData', onSessionData);
   if(onUsers) socket.on('users', onUsers);
-}
-
-export function reconnectSocket(callbacks){
-  if(socket){
-    socket.disconnect();
-    socket = null;
-  }
-  connectSocket(callbacks);
 }
 

--- a/public/js/BodyMapTools.js
+++ b/public/js/BodyMapTools.js
@@ -4,5 +4,3 @@ export const TOOLS = {
   BURN: { char: 'B', symbol: '' },
   BURN_ERASE: { char: 'E', symbol: '' }
 };
-
-export default TOOLS;

--- a/public/js/sessionApi.js
+++ b/public/js/sessionApi.js
@@ -58,9 +58,15 @@ export async function saveSessions(list){
   }
 }
 
-export function connectSocket({ onSessions, onSessionData, onUsers }={}){
+export function connectSocket(options={}){
+  const { onSessions, onSessionData, onUsers, force = false } = options;
   const token = getAuthToken();
-  if(typeof io === 'undefined' || socket || !token) return;
+  if(typeof io === 'undefined' || !token) return;
+  if(socket){
+    if(!force) return;
+    socket.disconnect();
+    socket = null;
+  }
   socket = io(socketEndpoint || undefined,{ auth:{ token:'Bearer '+token } });
   socket.on('connect', resetDelay);
   socket.on('connect_error', err => {
@@ -81,13 +87,5 @@ export function connectSocket({ onSessions, onSessionData, onUsers }={}){
   if(onSessions) socket.on('sessions', onSessions);
   if(onSessionData) socket.on('sessionData', onSessionData);
   if(onUsers) socket.on('users', onUsers);
-}
-
-export function reconnectSocket(callbacks){
-  if(socket){
-    socket.disconnect();
-    socket = null;
-  }
-  connectSocket(callbacks);
 }
 


### PR DESCRIPTION
## Summary
- remove the unused default export from BodyMapTools
- drop the unused reconnectSocket helper and allow connectSocket to force a reconnect
- document the new manual reconnect workflow in the README and update the prebuilt assets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e41d9f8498832090fcc20229c8bf6d